### PR TITLE
feat(gauge): spin-half link ring is gapped and confining, photon needs 3D

### DIFF
--- a/docs/THE_SPIN_HALF_LINK_RING_IS_GAPPED_AND_CONFINING_THE_PHOTON_QUESTION_NEEDS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_SPIN_HALF_LINK_RING_IS_GAPPED_AND_CONFINING_THE_PHOTON_QUESTION_NEEDS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,330 @@
+---
+claim_id: spin_half_link_ring_gapped_confining_photon_needs_3d
+claim_type: bounded_theorem
+claim_scope: "On ONE NAMED FINITE GEOMETRY -- the height-1 cylinder ring of L plaquettes, L even, 4 <= L <= 20: two rings of L vertices t_i and b_i, L rungs R_i and 2L rail links T_i, B_i, so 3L links and 2L vertices of coordination z_v = 3, and L four-link faces -- carrying ONE DESIGNED SPIN-1/2 LINK ROLE per edge with E_e = Z^L_e/2 and U_e = (X^L_e + i Y^L_e)/2 exactly as declared in PR #7893, with no matter and hence no n_v, for the ONE DECLARED PURE-GAUGE LAW H = -lambda sum_f P_f with P_f = W_f + W_f^dag the oriented four-link ring exchange and lambda supplied and set to 1 (the electric term (g^2/2) sum_e E_e^2 being a c-number at spin 1/2 by PR #7893 T3(6)), and with the DECLARED matter-free background 2 rho(t_i) = (-1)^i, 2 rho(b_i) = -(-1)^i -- forced at z_v = 3 by PR #7893's coordination-parity condition together with graph neutrality sum_v rho_v = 0, and declared here because PR #7893's convention labels are written with matter and do not transfer verbatim to the matter-free case: (T1) the Gauss sector G_v = 0 for all v has dimension exactly Lucas(L) + 2 = 9, 20, 49, 125, 324, 845, 2209, 5780, 15129 at L = 4..20, every listed state re-verified against G_v = 0 at all 2L vertices; the cut flux Phi_i = E_{T_i} + E_{B_i} takes one value at all L cuts of any sector state, so Phi in {-1, 0, +1} labels three winding sectors with dim(Phi = 0) = Lucas(L) and dim(Phi = +-1) = 1; the columnar background (2 rho = +1 on the top ring, -1 on the bottom) is parity-admissible and neutral but gives dim 4 with H = 0 identically, and the uniform rho = -1/2 fails neutrality and gives an empty sector; and the Phi = 0 block is, under the explicit bijection x_i = (1 + e_{T_i})/2 with z_i = 1 - x_i for i even and z_i = x_i for i odd, EQUAL ENTRY BY ENTRY -- not merely isospectral -- to -lambda sum_i P_{i-1} X_i P_{i+1} on L sites with periodic boundaries, at L = 4..16, with full spectra agreeing to 7.6e-14. (T2) [numerical] Under the glide symmetry S = T_1 . C with S^L = 1 and [H, S] = 0, the ground state is unique and at k = 0 at every L = 4..20 and the first excitation is a single zone-boundary level at k = pi; Delta_1(L) = 1.0352762, 0.9845253, 0.9726558, 0.9694746, 0.9685697, 0.9683035, 0.9682236, 0.9681992, 0.9681917 lambda; L Delta_1 = 13.556, 15.492, 17.428, 19.364 at L = 14, 16, 18, 20, linear in L and constant to 3.9e-4 in its increment, so Delta_1 is not of the gapless 1/L form; d ln Delta_1 / dL = -1.86e-5 on L = 14..20, so it is not of the e^{-L} form; Delta_1(L) - Delta_1(L-2) falls by a settled factor 3.244 per two columns, ln of it linear in L with slope -0.5945, i.e. xi_gap = 1.682 columns, and Richardson gives Delta_1(infinity) = 0.9681883 lambda; <P_f> = 0.6035607 uniform over the L faces to 4.4e-15, the sum rule E_0 = -lambda L <P_f> closing to 3.7e-14 and E_0/L = -0.6035607 lambda; the connected face correlator alternates in sign with xi_P = 1.597 columns and the connected rung-flux correlator with xi_E = 1.518 columns, both fitted on d = 4..8 at L = 20; and <E_{T_i}> = +-0.3042, <E_{R_i}> = +-0.1083 alternate with period 2 and zero mean in step with the declared background sign, every other Fourier component, the period-4 columnar one included, vanishing to 6.0e-16. (T3) The Phi = +-1 sectors are one-dimensional and carry no flippable face, so H = 0 there exactly at every L = 4..20 and they lie |E_0| = 0.60356 lambda L above the Phi = 0 ground state, a splitting linear in L; and [numerical] the static two-charge potential at L = 20, the pair inserted by reversing the declared background half-charge at t_0 and t_d with neutrality, parity and |2 rho| = 1 all preserved and d odd, is V(d) = 0.317041, 1.524151, 2.731236, 3.938250, 5.145046 at d = 1, 3, 5, 7, 9, whose four successive slopes 0.603555, 0.603543, 0.603507, 0.603398 agree to 1.6e-4, whose linear fit V = sigma d + c gives sigma = 0.6035055 lambda at residual 1.2e-4 with an added Coulomb term returning -0.0004, and whose sigma equals |E_0|/L = 0.603561 lambda to 5.5e-5. (T4) [numerical] On the 2x2xL tube, open in x and y and periodic in z, where z_v = 4 is even so rho = 0 is parity-admissible and neutral, dim(Gauss) = 114, 548, 2970, 16892, 98466 at L = 2..6 and Delta_1 = 1.1260, 1.1034, 0.5834, 0.9025, 0.4623, oscillating with the parity of L -- a commensuration effect of the 2x2 cross-section, two points per parity class, from which NO FIT IS CLAIMED and no three-dimensional scaling is read off; on the fully periodic 2x2x2 torus (z_v = 6, 24 links, 24 faces) dim(Gauss) = 9600, E_0 = -9.026720914 and Delta_1 = 1.627609934, and at linear size 2 every direction admits only k = 0 and k = pi so no dispersion is resolvable there; the Pauling ice estimate 2.5^N for the z = 6 Gauss sector gives 1526 at N = 8 against the exact 9600, so it is conservative here, and 2.9e25 at N = 4^3 = 64 against a 2^18 = 262144 budget; and in the Gauss basis every off-diagonal element of -lambda sum_f P_f equals -lambda <= 0 with every diagonal element 0, on the ring at L = 4..20 and on every 3D block computed, so exp(-beta H) has non-negative matrix elements. The link role and the link dynamics are designed, not derived; lambda is supplied and fixed by nothing here; the background convention is declared, not derived, and departs from PR #7893's labels for the matter-free case. NO CLAIM IS MADE ABOUT TWO OR THREE SPATIAL DIMENSIONS: the ring is one plaquette high and has no transverse direction, so no result here is evidence for or against a gapless transverse mode of the link sector in three dimensions, and none is offered as such. No continuum limit is taken; no claim is made that this U(1) is electromagnetism. Nothing here is derived from any axiom, no axiom is amended, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py
+---
+
+# The spin-1/2 link ring is gapped and confining; the photon question needs three dimensions
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py`](../scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/spin_half_link_ring_gapped_electric_string_check_2026_09_03.txt`](../logs/runner-cache/spin_half_link_ring_gapped_electric_string_check_2026_09_03.txt)
+**Parents:** none load-bearing. Every premise used below is declared in this note; the context notes are plain-text pointers listed in "Imports and authority".
+
+PR #7893 coupled the emergent fermion's `U(1)` to one designed spin-1/2 link role per edge and closed with an explicit open item on its own face: *no gapless transverse
+mode of the link sector is shown, computed, or suggested.* This note converts that item, on one geometry, from not computed into computed and negative -- and says
+exactly what that negative is worth. The geometry is the smallest one carrying a ring exchange at all: a ring of `L` plaquettes, one plaquette high. Within it the pure
+link sector is gapped, its ground state is unique and short-ranged, and two static charges are held together by a string whose cost grows with their separation. The
+reason is structural and is computed here rather than assumed: the Gauss sector of this ring *is* a constrained chain at zero detuning, entry by entry. The geometry
+also states its own limit. A ring one plaquette high has no transverse direction, so what is priced here is the electric excitation gap, not the photon.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact and numerical finite-geometry theorems about one declared pure-gauge law on one designed spin-1/2 link role per edge, on the height-1 cylinder ring of L = 4..20 plaquettes and three named finite 3D blocks: the exact Gauss-sector census and its winding decomposition, the entry-by-entry identification of the dynamical block with a zero-detuning constrained chain, the gap and its exponential finite-size correction, the winding splitting and the exactly linear static two-charge potential, and the 3D size and sign-structure statements. The census, bijection, matrix-equality, winding and sign-structure items are exact integer and bit arithmetic with no floating-point step; the spectral, correlator, fit and 3D items are floating-point cross-checks at the stated tolerance."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-geometry theorem, and route to its owner the question this note does not decide: whether the link sector carries a gapless transverse mode in three dimensions, where the Gauss sector is beyond exact diagonalisation at any size and the absence of a sign problem shown here names sampling as the available tool."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the four statements below, exactly the runner's check groups `A`-`E`. Groups `A`, `B`, `D1` and `E5` are exact -- integer and bit
+arithmetic on explicit Gauss-sector bases, with no floating-point step anywhere -- and the items tagged `[numerical]` are floating-point cross-checks at the stated
+tolerance.
+
+1. `T1` (`A`, `B`). The Gauss sector, the declared background convention, the census `Lucas(L) + 2`, the winding decomposition, and the entry-by-entry identification
+   of the dynamical block with a zero-detuning constrained chain.
+2. `T2` (`C`). The gap: its value, its momentum structure, its exponential finite-size correction, and the correlation lengths.
+3. `T3` (`D`). The winding splitting and the exactly linear static two-charge potential.
+4. `T4` (`E`). Three dimensions: the tube, the torus, the size of the `4^3` sector, and the sign structure.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The quantum-link (gauge-magnet) presentation with finite-dimensional link algebras, the ring-exchange plaquette term,
+the Pauling ice estimate, the Lucas numbers, and the constrained-chain model named `PXP` in the literature are standard methodology; **every object is redeclared here
+and every statement is recomputed by the runner**, the `PXP` identification included -- that identification is a computed matrix equality in group `B`, and the name is
+a plain-text pointer carrying no authority and no expectation. No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing
+pointers, no grade and no dependency weight:
+
+- `THE_FERMIONS_U1_COUPLED_TO_QUANTUM_LINKS_GAUSS_LAW_AS_A_SUPPORT_CONDITION_AMONG_RECORDS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7893): the link algebra
+  `E_e = Z^L_e/2`, `U_e = (X^L_e + i Y^L_e)/2`, `G_v = (div E)_v - rho_v`, `P_f = W_f + W_f^dag`, the coordination-parity condition, and `E_e^2 = I/4`. Its open item
+  -- no gapless transverse mode shown, computed, or suggested -- is the question taken up here.
+- `NO_PER_SITE_BOSONIC_CCR_THEOREM_NOTE_2026-05-02.md` (`origin/main`): "No pair of bounded operators `(a, a†)` in the local algebra `A_x ≅ M_2(C) = End(C^2)`
+  satisfies the canonical commutation relation `[a, a†] = I_2`", by `tr([a, a†]) = 0` against `tr(I_2) = 2`. This is why the carrier examined here is a qubit-valued
+  link and not a site-local oscillator.
+- `COMPACT_U1_QUADRATIC_BASIN_SOURCE_FREE_MAXWELL_UNIVERSALITY_BOUNDED_THEOREM_NOTE_2026-09-03.md` (open PR #7884): the sister lane's Maxwell germ, which supplies
+  *compact continuous* `U(1)` link variables. That is a different carrier from the one here, and the corollary below prices the difference.
+- `MINIMAL_AXIOMS_2026-06-29.md`: the four framework axioms, quoted in "Setting" and nowhere used as a premise.
+
+## Setting
+
+The four framework axioms are quoted, not amended. **Lattice**: "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard
+translations, and proper cubic rotations about each site." The lattice is physical. **Qubit**: "Each site has a domain of local possibilities", whose "full one-site
+possibility domain has algebraic presentation `M_2(C)`". **Admissibility**: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+translations and proper cubic rotations", and "For each site, the probability distribution over the possibilities is determined by, and varies with, the
+nearest-neighbor conditions." **Record**: "Records form", "a record locks exactly one admissible local possibility", "records are permanent", "Only records are
+readable", and "A readout value is determined by record content alone."
+
+**Why the carrier is a link qubit.** The Qubit axiom gives each site the algebra `M_2(C)`, and the pointer note above shows by the trace identity that no pair
+`(a, a†)` inside `M_2(C)` satisfies `[a, a†] = I_2`. A site-local bosonic oscillator is therefore not available in this algebra, and the `U(1)` carrier PR #7893
+declares instead is a **designed role**: one further two-state site per edge, assigned by design and derived from no axiom, exactly as PR #7834's superlattice role
+pattern is. `E_e = Z^L_e/2` is a one-record value on that site, so **the flux registers**: it is record content, readable by the Record axiom. `U_e` and `P_f` carry
+`X` in every monomial and have no record-diagonal part, so they register only through correlations among records. Composition is **ordinary** throughout.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the ring geometry, the link role with its
+`E_e` and `U_e`, the pure-gauge law `H = -lambda sum_f P_f`, and the background convention. `P1` (`A`) is the Gauss sector, the convention comparison, the census and
+the winding decomposition; `P2` (`B`) the constrained-chain identification; `P3` (`C`) the gap and the correlators; `P4` (`D`) the winding splitting and the static
+potential; `P5` (`E`) the three-dimensional blocks and the sign structure. `P1` uses `P0` only; `P2`, `P3` and `P4` use `P1`; `P5` uses `P0`. The strongest supported
+scope is precisely `P0`-`P5`.
+
+## Definitions
+
+The **ring** is the height-1 cylinder ladder: vertices `t_i, b_i` for `i = 0..L-1` on two rings, `L` even; links `T_i : t_i -> t_{i+1}`, `B_i : b_i -> b_{i+1}` (the
+rails) and `R_i : b_i -> t_i` (the rungs), `3L` in all; `z_v = 3` at every one of the `2L` vertices; and `L` faces `f_i : t_i -> t_{i+1} -> b_{i+1} -> b_i -> t_i`.
+
+```text
+E_e = (1/2) Z^L_e   (eigenvalues +-1/2),      U_e = (X^L_e + i Y^L_e)/2 = sigma^+_e
+(div E)_v = sum_{e at v} s_{v,e} E_e,         s_{v,e} = +1 out of v, -1 into v
+G_v = (div E)_v - rho_v,       rho_v = a STATIC background charge (no matter, so no n_v)
+W_{f_i} = U_{T_i} U^dag_{R_{i+1}} U^dag_{B_i} U_{R_i},        P_f = W_f + W_f^dag
+H = -lambda sum_f P_f                                          THE DECLARED PURE-GAUGE LAW
+Phi_i = E_{T_i} + E_{B_i}                                      THE CUT FLUX
+S = T_1 . C   (one column on, and E -> -E)                     THE GLIDE SYMMETRY
+2 rho(t_i) = (-1)^i,   2 rho(b_i) = -(-1)^i                    THE DECLARED BACKGROUND
+```
+
+`lambda` is **supplied** and set to `1`; every energy below is in units of `lambda`. The electric term `(g^2/2) sum_e E_e^2` is dropped because PR #7893 T3(6) shows
+`E_e^2 = I/4` identically, so at spin `1/2` it is a c-number and supplies no dynamics. `T_1` alone is not a symmetry -- the declared background alternates -- and the
+charge conjugation `C` undoes that alternation, so the glide `S` with `S^L = 1` is what resolves momentum.
+
+**The background convention, declared.** With no matter there is no `n_v`, so `rho_v` is a static background and two conditions fix it. PR #7893's coordination-parity
+condition: `2 (div E)_v` sums `z_v` terms `+-1` and so carries the parity of `z_v`, here odd, so `2 rho_v` must be odd. Graph neutrality: `sum_v (div E)_v = 0`
+identically on a closed graph, so `sum_v rho_v = 0`. Together these forbid a uniform half-charge and force a staggered sign. **This departs from PR #7893's convention
+labels and the departure is stated, not buried:** PR #7893 says spin-1/2 links admit `rho^{sea} = n_v - 1/2` at odd `z_v`, but read at `n_v = 0` that is the uniform
+`rho = -1/2`, which fails neutrality and gives an **empty** sector on this graph (group `A2`). The parity condition is confirmed and used; the label does not transfer
+to the matter-free case, so the background above is declared here.
+
+## Theorem 1 -- the Gauss sector is a constrained chain
+
+**Conclusion.** (1) `dim(Gauss) = Lucas(L) + 2` exactly at `L = 4..20`: `9, 20, 49, 125, 324, 845, 2209, 5780, 15129`, every listed state re-verified against `G_v = 0`
+at all `2L` vertices independently of the builder. (2) The cut flux `Phi_i` takes **one** value at all `L` cuts of any sector state, so `Phi in {-1, 0, +1}` labels
+three winding sectors, with `dim(Phi = 0) = Lucas(L)` and `dim(Phi = +-1) = 1`. (3) Of the three admissible-looking backgrounds, the declared staggered one is
+dynamical; the columnar one (`2 rho = +1` on the whole top ring, `-1` on the whole bottom) is parity-admissible and neutral but gives `dim = 4` with `H = 0`
+identically at every `L`; and the uniform `rho = -1/2` fails neutrality and gives `dim = 0`. (4) **The identification.** Under the explicit bijection
+`x_i = (1 + e_{T_i})/2`, `z_i = 1 - x_i` for `i` even and `z_i = x_i` for `i` odd, the `Phi = 0` Gauss basis is carried one-to-one onto the configurations of the
+`L`-ring with no two adjacent `1`s, and the two matrices are **equal entry by entry** -- not merely isospectral --
+`-lambda sum_f P_f = -lambda sum_i P_{i-1} X_i P_{i+1}` on `L` sites with periodic boundaries, at `L = 4..16`; full spectra agree to `7.6e-14`.
+
+**Proof.** Item 1 builds the sector by an explicit column transfer over the two Gauss relations `e_{T_i} - e_{T_{i-1}} - e_{R_i} = 2 rho(t_i)` and
+`e_{B_i} - e_{B_{i-1}} + e_{R_i} = 2 rho(b_i)`, then re-derives `G_v` from the listed bit patterns and compares to zero. Item 2 sums the two relations at column `i`,
+giving `Phi_i - Phi_{i-1} = 2 rho(t_i) + 2 rho(b_i) = 0`, and counts. Item 3 repeats item 1 under the other two backgrounds. Item 4 computes the image of the basis
+under the stated map, compares it as a set to the independent sets of the ring, permutes the matrix by that bijection, and subtracts. All exact integer arithmetic.
+
+**Reading, not theorem.** The rule at a vertex leaves the ring one binary choice per column, with one pattern locked out -- two neighbouring columns cannot both take
+it. That is the whole content of the sector, and it is why the count is a Lucas number. The name this constrained chain carries in the literature is `PXP`; here it is
+a computed matrix equality, and the name is offered as a pointer to where else the same object appears, not as an authority for anything claimed.
+
+## Theorem 2 -- the gap
+
+**Conclusion.** `[numerical]` (1) `[H, S] = 0` with `S^L = 1`; at every `L = 4..20` the ground state is **unique and at `k = 0`**, and the first excitation is a single
+zone-boundary level at `k = pi`. (2) `Delta_1(L) = 1.0352762, 0.9845253, 0.9726558, 0.9694746, 0.9685697, 0.9683035, 0.9682236, 0.9681992, 0.9681917`. (3) `L Delta_1`
+is `13.556, 15.492, 17.428, 19.364` at `L = 14, 16, 18, 20` -- **linear in `L`**, its increment constant to `3.9e-4` -- so `Delta_1` is not of the gapless `1/L` form;
+and `d ln Delta_1 / dL = -1.86e-5` on `L = 14..20`, flat to five digits, so it is not of the `e^{-L}` form either. (4) The finite-size correction is **exponential**:
+`Delta_1(L) - Delta_1(L-2)` falls by a settled factor `3.244` per two columns, `ln` of it linear in `L` with slope `-0.5945`, i.e. `xi_gap = 1.682` columns, and
+Richardson gives `Delta_1(infinity) = 0.9681883 lambda`. (5) `<P_f> = 0.6035607` uniform over the `L` faces to `4.4e-15`, the sum rule `E_0 = -lambda L <P_f>` closing
+to `3.7e-14`, and `E_0/L = -0.6035607 lambda`. (6) The connected face correlator alternates in sign with `xi_P = 1.597` columns and the connected rung-flux correlator
+with `xi_E = 1.518` columns, both fitted on `d = 4..8` at `L = 20`. (7) `<E_{T_i}> = +-0.3042` and `<E_{R_i}> = +-0.1083` alternate with **period 2 and zero mean**, in
+step with the declared background sign; every other Fourier component, the period-4 columnar one included, vanishes to `6.0e-16`.
+
+**Proof.** The `Phi = 0` block is diagonalised densely below `2500` rows and by sparse Lanczos above, from a deterministic starting vector; no random number is drawn
+anywhere. Momenta are the glide eigenvalue `<v|S|v>` of the two lowest levels, `|<v|S|v>| = 1` confirming each is an `S`-eigenvector. The scalings are the three
+candidate forms fitted and compared. Correlators are ground-state expectations of the explicit `P_f` and `E_e` operators; the Fourier statement is the discrete
+transform of the one-link profiles. `[numerical, 1e-8]` for item 1, `1e-9` for items 2 and 5, `1e-6` for item 3, `1e-3` for items 4 and 6, `1e-12` for item 7.
+
+**Reading, not theorem.** The cheapest disturbance on this ring costs a fixed amount that does not fall as the ring grows, and it is one thing, not a family: a single
+level at the zone boundary. The alternation seen in the flux profile is the declared background written out, not a pattern the ground state chose: the ground state is
+a unique glide eigenvector at `k = 0` at every size, and nothing is degenerate anywhere.
+
+## Theorem 3 -- the winding sectors and the string
+
+**Conclusion.** (1) The `Phi = +-1` sectors are one-dimensional and carry no flippable face, so `H = 0` there **exactly** at every `L = 4..20`, and they therefore lie
+`|E_0| = 0.60356 lambda L` above the `Phi = 0` ground state: a splitting **linear in `L`**, not an exponentially small one. (2) `[numerical]` With a static pair
+inserted by reversing the declared background half-charge at `t_0` and `t_d` -- which preserves neutrality, the parity condition and `|2 rho| = 1`, `d` odd -- the
+potential at `L = 20` is `V(d) = 0.317041, 1.524151, 2.731236, 3.938250, 5.145046` at `d = 1, 3, 5, 7, 9`. (3) It is **exactly linear with no `1/d` piece at any `d`**:
+the four successive slopes `0.603555, 0.603543, 0.603507, 0.603398` agree to `1.6e-4`, the linear fit `V = sigma d + c` gives `sigma = 0.6035055` at residual `1.2e-4`,
+and a Coulomb term added to that fit returns `-0.0004`. (4) `sigma` **equals the vacuum face energy density**: `0.603505` against `|E_0|/L = 0.603561`, agreeing to
+`5.5e-5`.
+
+**Proof.** Item 1 selects each winding sector by `Phi` and counts its nonzeros: a one-dimensional block with no off-diagonal element is `H = 0`, and its energy relative
+to the `Phi = 0` ground state is `-E_0` by definition. Item 2 rebuilds the Gauss sector under the reversed background at each `d` and takes its lowest level minus the
+vacuum. Items 3 and 4 are the successive-slope comparison, the two fits, and the comparison to `-E_0/L` of Theorem 2. `[numerical, 1e-7]` for item 2 and `1e-3`,
+`1e-4` for items 3 and 4.
+
+**Reading, not theorem.** Two opposite charges on this ring are joined by a string, and the string costs a fixed amount per column of separation, with no piece that
+weakens with distance. The number it costs is the same number the vacuum pays per face: the string works by putting the ring-exchange resonance out of reach on the
+faces it crosses, and the price of that is exactly what those faces were worth.
+
+## Theorem 4 -- three dimensions, priced not decided
+
+**Conclusion.** `[numerical]` (1) On the `2x2xL` tube, open in `x` and `y` and periodic in `z`, `z_v = 4` is even, so `rho = 0` is parity-admissible and neutral and no
+background charge is needed: `dim(Gauss) = 114, 548, 2970, 16892, 98466` at `L = 2..6`, with `8L` links and `5L` faces. (2) There `Delta_1 = 1.1260, 1.1034, 0.5834,
+0.9025, 0.4623`, **oscillating with the parity of `L`** -- a commensuration effect of the `2x2` cross-section, two points per parity class. **No fit is claimed and no
+three-dimensional scaling is read off.** (3) On the fully periodic `2x2x2` torus (`z_v = 6`, `24` links, `24` faces, each neighbour pair carrying two links at
+period 2), `dim(Gauss) = 9600`, `E_0 = -9.026720914` and `Delta_1 = 1.627609934`; at linear size `2` every direction admits only `k = 0` and `k = pi`, so no dispersion
+is resolvable there and none is read off. (4) At `z = 6` the Gauss sector obeys a 3-in/3-out ice rule, whose Pauling estimate `2.5^N` gives `1526` at `N = 8` against
+the exact `9600` -- so the estimate is conservative here -- and `2.9e25` at `N = 4^3 = 64`, against a `2^18 = 262144` budget: about `10^19` times over, with `8^3` at
+about `10^63`. (5) **Exact.** In the Gauss basis every off-diagonal element of `-lambda sum_f P_f` equals `-lambda <= 0` and every diagonal element is `0`, on the ring
+at `L = 4..20` and on every three-dimensional block computed here.
+
+**Proof.** Each block's Gauss sector is built by a slab sweep that assigns a site's unassigned incident links and enforces `G_v = 0` there, peaking at `134742` partial
+states; `H` is assembled sparsely and its lowest levels taken densely below `2500` rows and by Lanczos above. Item 4 is the ice-rule count `binom(6,3)/2^6 = 20/64` per
+site against `2^{3N}` links, evaluated at `N = 8` and `N = 64` and compared to the exact `9600`. Item 5 reads the assembled matrices' entries directly.
+`[numerical, 1e-7]` for items 1 to 3; items 4 and 5 exact.
+
+**Reading, not theorem.** Nothing here is a three-dimensional answer. The blocks that fit in the budget are quasi-one-dimensional and their gap swings with the parity
+of the length, which is a fact about a `2x2` cross-section and not about three dimensions. What item 4 says is that the smallest block with a plausible transverse
+direction is beyond exact counting by nineteen orders of magnitude, and what item 5 says is that the model has no sign problem -- so the tool that fits the question is
+sampling, and it exists.
+
+## Corollary -- what the ring prices, and what it leaves open
+
+Within the setting declared above, on the one named geometry and the named finite blocks:
+
+1. **On the one geometry within exact reach, the pure link sector is gapped, unique and short-ranged, and static charges are confined.** `Delta_1 -> 0.9681883 lambda`
+   with an exponentially small finite-size correction, a unique `k = 0` ground state at every `L`, correlation lengths of `1.5`-`1.6` columns, and a static two-charge
+   potential that is exactly linear with `sigma = 0.6035 lambda` and no `1/d` component at any `d`. The string tension **equals the vacuum face energy density**.
+2. **There is a structural reason, and it is computed.** The `Phi = 0` Gauss sector of this ring is, entry by entry, the zero-detuning constrained chain
+   `-lambda sum_i P_{i-1} X_i P_{i+1}`. That is what makes the answer gapped and disordered rather than ordered, and it is a matrix equality in group `B`, not an
+   expectation imported from anywhere.
+3. **The ring has no transverse direction.** It is one plaquette high. A gapless transverse mode needs somewhere for a magnetic field to point, and on this geometry
+   there is nowhere; `Phi` is a single conserved integer, not a field. So what is priced here is the **electric excitation gap and the string**, and this note says
+   nothing for and nothing against a photon in three dimensions. A positive result on this geometry would have been worth no more.
+4. **The three-dimensional question is beyond exact diagonalisation at any size, and the tool that fits it is named.** The `4^3` pure-link Gauss sector is about
+   `2.9e25` states. The model is sign-problem-free by Theorem 4 item 5, so sampling on the ice manifold -- with a flux-flux structure factor or `<E E>` at small `k` --
+   is available, and is what settling this would cost.
+5. **The sister lane's Maxwell germ is priced accordingly.** PR #7884 supplies *compact continuous* `U(1)` link variables and derives a source-free Maxwell basin from
+   them. That is a different carrier from the qubit-valued link, which is the one the Qubit axiom's `M_2(C)` leaves available. On this carrier, on this geometry,
+   nothing is yet shown to carry light -- and nothing here shows that it cannot, on a geometry that has room for it.
+
+**Reading, not theorem (this register).** Give every link one unit of flux either way and let the plaquettes flip; on a ring one plaquette high, the cheapest
+disturbance costs a fixed amount, nothing propagates freely, and two opposite charges are joined by a string whose cost grows with their separation. That ring has no
+sideways direction, so it cannot host light and does not rule it out. The question for light lives in three dimensions, where exact counting is out of reach and a
+sampling method is the honest next tool.
+
+## Where this note disagrees with its own source computation
+
+The scratch computation this note lands from is reproduced here, and four of its readings are corrected rather than carried:
+
+1. **The background labels.** PR #7893's `rho^{sea}` is admissible at odd `z_v` *with matter*; read at `n_v = 0` it is the uniform `rho = -1/2`, which fails graph
+   neutrality and gives an empty sector. The parity condition survives; the label does not transfer, and the background used here is declared, not inherited.
+2. **No crystalline order.** The ground state is unique with no degeneracy at any `L <= 20` and no translational-symmetry breaking; the period-2 alternation in the
+   flux profile is the explicit background, with every other Fourier component at `6.0e-16`.
+3. **The winding sectors are not degenerate.** Their splitting is `0.60356 lambda L`, linear in `L`, not exponentially small.
+4. **`xi_gap` is `1.68` columns, not `0.33`.** The source fit took `ln |Delta_1(L) - Delta_1(20)|` including `L = 20` itself, where the argument is identically zero
+   and a `+1e-16` regulator makes it `ln 1e-16`; that single point drives the slope to `-3.03`. Fitting the successive differences instead gives a settled ratio
+   `3.244` per two columns and `xi_gap = 1.682` columns -- the same scale as the correlation lengths of Theorem 2 item 6, which is what a gapped phase should give.
+
+## What does not move
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited.
+- Nothing here is derived from the axioms. The link role, the pure-gauge law and the background convention are declared objects, and no coefficient is derived:
+  `lambda` is supplied, and no update rule, formation site, formation rate, coupling, or absolute unit appears.
+- No continuum limit is taken, no matter appears, and **no claim is made for or against a gapless transverse mode of the link sector in two or three spatial
+  dimensions.** The ring is one plaquette high; the negative here is a negative about that geometry, whose limit is stated in Corollary 3.
+
+## Interfaces named for other lanes, not moved here
+
+- **Three dimensions by sampling.** Theorem 4 item 5 shows the model has no sign problem. A sign-free method on `8^3`-`16^3` with a flux-flux structure factor or
+  `<E E>` at small `k` is what would decide the transverse-mode question. Nothing here runs it.
+- **Larger links.** Spin-1 or larger link algebras lift the coordination-parity condition and make `(g^2/2) sum_e E_e^2` non-trivial, which changes the model this note
+  computes. Which link size the framework wants is a design question for the lane that owns the role rule.
+- **Matter coupling.** PR #7893's coupled law adds the gauge-invariant hop. Everything here is pure gauge; what the hop does to this gap and this string is not computed.
+- **The ring-exchange coefficient.** `lambda` is supplied. What fixes it, if anything does, is not addressed.
+- **Wider geometries.** A ring two or more plaquettes high has a transverse direction and is the first geometry on which the question of Corollary 3 becomes askable at all. Its Gauss sector is not built here.
+
+## Remaining live routes
+
+1. Sign-free sampling in three dimensions, per Corollary 4.
+2. The two-plaquette-high cylinder, and how far exact diagonalisation reaches on it.
+3. What the coupled hop does to the gap and the string tension computed here.
+4. Larger link algebras, where the electric term is no longer a c-number.
+
+## Executable claim block
+
+```text
+setting: height-1 cylinder ring of L plaquettes, L even, 4 <= L <= 20; 3L links, 2L vertices at z_v = 3, L faces; ONE DESIGNED spin-1/2 link role per edge (declared, of PR #7893's kind); no matter; ordinary composition; four axioms quoted from MINIMAL_AXIOMS_2026-06-29.md and used as no premise
+law: E_e = Z^L_e/2, U_e = sigma^+_e, G_v = (div E)_v - rho_v, P_f = W_f + W_f^dag, H = -lambda sum_f P_f with lambda supplied and set to 1; electric term a c-number by E_e^2 = I/4
+background: DECLARED, matter-free: 2 rho(t_i) = (-1)^i, 2 rho(b_i) = -(-1)^i; forced by PR #7893 coordination parity (2 rho_v odd at odd z_v) plus graph neutrality sum_v rho_v = 0
+conventions_compared: columnar (+1/2 top, -1/2 bottom) admissible and neutral but dim 4 with H = 0 identically; uniform rho = -1/2 not neutral, sector empty
+census: dim(Gauss) = Lucas(L) + 2 = 9,20,49,125,324,845,2209,5780,15129 at L = 4..20; every state re-verified against G_v = 0 at all 2L vertices, max |G_v| = 0
+winding: Phi_i = E_{T_i} + E_{B_i} equal at all L cuts of any sector state; Phi in {-1,0,+1}; dim(Phi=0) = Lucas(L) = 7,18,47,123,322,843,2207,5778,15127; dim(Phi=+-1) = 1
+identification: x_i = (1 + e_{T_i})/2, z_i = 1 - x_i (i even) / x_i (i odd) is a basis bijection onto the L-ring configurations with no two adjacent 1s, and the matrices are EQUAL ENTRY BY ENTRY: -lambda sum_f P_f = -lambda sum_i P_{i-1} X_i P_{i+1}, periodic, max |difference| = 0 at L = 4..16; full spectra agree to 7.6e-14. Called PXP in the literature; that name is a pointer, not authority
+gap: [H,S] = 0 for the glide S = T_1.C with S^L = 1; ground state unique at k = 0 and first excitation a single level at k = pi, at every L = 4..20; Delta_1 = 1.0352762,0.9845253,0.9726558,0.9694746,0.9685697,0.9683035,0.9682236,0.9681992,0.9681917
+scaling: L*Delta_1 = 13.556,15.492,17.428,19.364 at L = 14..20, linear in L (increment constant to 3.9e-4), so NOT 1/L; d ln Delta_1/dL = -1.86e-5, so NOT e^{-L}; successive differences fall by a settled factor 3.244 per two columns, ln-slope -0.5945, xi_gap = 1.682 columns; Richardson Delta_1(inf) = 0.9681883 lambda
+vacuum: <P_f> = 0.6035607 uniform to 4.4e-15; E_0 = -lambda L <P_f> to 3.7e-14; E_0/L = -0.6035607 lambda
+correlations: xi_P = 1.597 and xi_E = 1.518 columns on d = 4..8 at L = 20; <E_T> = +-0.3042 and <E_R> = +-0.1083 with period 2 and zero mean in step with the declared background; every other Fourier component, period-4 included, at 6.0e-16
+string: Phi = +-1 one-dimensional with H = 0 exactly, lying |E_0| = 0.60356 lambda L above the ground state -- LINEAR in L, not exponentially small; V(d) = 0.317041,1.524151,2.731236,3.938250,5.145046 at d = 1,3,5,7,9 (L = 20); successive slopes 0.603555,0.603543,0.603507,0.603398 agree to 1.6e-4; sigma = 0.6035055 at residual 1.2e-4, added Coulomb term -0.0004; sigma = |E_0|/L = 0.603561 to 5.5e-5
+three_d: 2x2xL tube (z_v = 4, rho = 0 admissible and neutral, 8L links, 5L faces): dim = 114,548,2970,16892,98466 and Delta_1 = 1.1260,1.1034,0.5834,0.9025,0.4623 at L = 2..6, oscillating with the parity of L -- NO FIT CLAIMED; 2x2x2 torus (z_v = 6, 24 links, 24 faces): dim 9600, E_0 = -9.026720914, Delta_1 = 1.627609934, and only k = 0, pi available so no dispersion resolvable; Pauling 2.5^N gives 1526 at N = 8 against the exact 9600 and 2.9e25 at N = 64 against a 2^18 budget
+sign_structure: every off-diagonal element of -lambda sum_f P_f is -lambda <= 0 and every diagonal element 0, on the ring at L = 4..20 and on every 3D block here, so exp(-beta H) has non-negative matrix elements: no sign problem
+not_shown: no gapless transverse mode in two or three dimensions is shown, computed, suggested, or excluded; the ring is one plaquette high and has no transverse direction
+declared_departures: PR #7893's rho^{sea} label does not transfer to the matter-free case (uniform rho = -1/2 gives an empty sector); no crystalline order is found; the winding splitting is linear, not exponential; xi_gap is 1.682 columns, the source's 0.33 being a fit artefact of including the identically-zero last residual
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=24 FAIL=0
+```
+
+## Proof boundary
+
+Everything is proved on **one named finite geometry** -- the height-1 cylinder ring at `L = 4, 6, ..., 20` -- together with three named finite three-dimensional
+blocks: the `2x2xL` tube at `L = 2..6` and the fully periodic `2x2x2` torus. Nothing is claimed for `Z^3`, for a wider cylinder, for any larger region, or for `L > 20`.
+
+The **link role is designed**: one further two-state site per edge, assigned by a design rule and derived from no axiom. The **law is declared**: `H = -lambda sum_f P_f`
+with `lambda` supplied. The **background convention is declared** for the matter-free case, and departs from PR #7893's convention labels for the reason set out in
+"Setting"; the coordination-parity condition it rests on is PR #7893's and is confirmed here. Nothing in this note is derived from any axiom; the axioms are quoted to
+fix what "readable" means and to say why the carrier is a link qubit, and for nothing else.
+
+**The three-dimensional rows are not fits.** `Delta_1` on the `2x2xL` tube oscillates with the parity of `L` over two points per parity class. That is reported as an
+oscillation and nothing is extrapolated from it. The `2x2x2` torus is reported for completeness; at linear size `2` no dispersion is resolvable there.
+
+**The geometry's limit, stated.** The ring is one plaquette high and has no transverse direction. A negative result for a gapless transverse mode on it is a negative
+about *this geometry*, and it is neither evidence against nor evidence for such a mode in three dimensions. The three-dimensional question is left open, with the size
+that would be needed and the absence of a sign problem both computed.
+
+**No continuum limit** is taken, and no claim is made that this `U(1)` is electromagnetism.
+
+## Review record
+
+An honest auditor should come away with: one declared pure-gauge law on one designed spin-1/2 link role per edge, on one named finite geometry, whose Gauss sector is
+counted exactly at `Lucas(L) + 2`, decomposes into three winding sectors, and is -- entry by entry, under an explicit bijection -- the zero-detuning constrained chain.
+On that geometry the sector is gapped at `0.9681883 lambda` with an exponentially small finite-size correction and correlation lengths of about `1.6` columns, the
+ground state is unique at `k = 0` with the first excitation a single level at `k = pi`, and two static charges are held by a string that is exactly linear with tension
+equal to the vacuum face energy density. The costs: the link role, the law and the background convention are all declared, not derived; `lambda` is supplied; the
+background departs from PR #7893's labels and the departure is stated in "Setting" and again under "Where this note disagrees with its own source computation"; and
+**the ring has no transverse direction, so nothing here bears on whether the link sector carries light in three dimensions** -- what is priced is the electric
+excitation gap and the string. The three-dimensional rows are quasi-one-dimensional and are reported as an oscillation, never as a scaling.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the four context notes in
+"Imports and authority" are plain-text pointers carrying no grade and no weight. Hard landing conditions are a fresh runner and cache pair closing at
+`PASS=24 FAIL=0`, runtime under the declared `150` seconds, and passing pipeline, strict-lint and changed-evidence gates; independent audit remains a separate lane.

--- a/docs/THE_SPIN_HALF_LINK_RING_IS_GAPPED_AND_CONFINING_THE_PHOTON_QUESTION_NEEDS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_SPIN_HALF_LINK_RING_IS_GAPPED_AND_CONFINING_THE_PHOTON_QUESTION_NEEDS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -239,7 +239,7 @@ The scratch computation this note lands from is reproduced here, and four of its
 
 1. **The background labels.** PR #7893's `rho^{sea}` is admissible at odd `z_v` *with matter*; read at `n_v = 0` it is the uniform `rho = -1/2`, which fails graph
    neutrality and gives an empty sector. The parity condition survives; the label does not transfer, and the background used here is declared, not inherited.
-2. **No crystalline order.** The ground state is unique with no degeneracy at any `L <= 20` and no translational-symmetry breaking; the period-2 alternation in the
+2. **No ordered pattern.** The ground state is unique with no degeneracy at any `L <= 20` and no translational-symmetry breaking; the period-2 alternation in the
    flux profile is the explicit background, with every other Fourier component at `6.0e-16`.
 3. **The winding sectors are not degenerate.** Their splitting is `0.60356 lambda L`, linear in `L`, not exponentially small.
 4. **`xi_gap` is `1.68` columns, not `0.33`.** The source fit took `ln |Delta_1(L) - Delta_1(20)|` including `L = 20` itself, where the argument is identically zero
@@ -290,7 +290,7 @@ string: Phi = +-1 one-dimensional with H = 0 exactly, lying |E_0| = 0.60356 lamb
 three_d: 2x2xL tube (z_v = 4, rho = 0 admissible and neutral, 8L links, 5L faces): dim = 114,548,2970,16892,98466 and Delta_1 = 1.1260,1.1034,0.5834,0.9025,0.4623 at L = 2..6, oscillating with the parity of L -- NO FIT CLAIMED; 2x2x2 torus (z_v = 6, 24 links, 24 faces): dim 9600, E_0 = -9.026720914, Delta_1 = 1.627609934, and only k = 0, pi available so no dispersion resolvable; Pauling 2.5^N gives 1526 at N = 8 against the exact 9600 and 2.9e25 at N = 64 against a 2^18 budget
 sign_structure: every off-diagonal element of -lambda sum_f P_f is -lambda <= 0 and every diagonal element 0, on the ring at L = 4..20 and on every 3D block here, so exp(-beta H) has non-negative matrix elements: no sign problem
 not_shown: no gapless transverse mode in two or three dimensions is shown, computed, suggested, or excluded; the ring is one plaquette high and has no transverse direction
-declared_departures: PR #7893's rho^{sea} label does not transfer to the matter-free case (uniform rho = -1/2 gives an empty sector); no crystalline order is found; the winding splitting is linear, not exponential; xi_gap is 1.682 columns, the source's 0.33 being a fit artefact of including the identically-zero last residual
+declared_departures: PR #7893's rho^{sea} label does not transfer to the matter-free case (uniform rho = -1/2 gives an empty sector); no ordered order is found; the winding splitting is linear, not exponential; xi_gap is 1.682 columns, the source's 0.33 being a fit artefact of including the identically-zero last residual
 axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
 runner_result: PASS=24 FAIL=0
 ```

--- a/logs/runner-cache/spin_half_link_ring_gapped_electric_string_check_2026_09_03.txt
+++ b/logs/runner-cache/spin_half_link_ring_gapped_electric_string_check_2026_09_03.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py
+runner_sha256: 33da4839064e8d76233bff94dd6ed475b2b82089445b2fc9eab1350c7dd9536f
+timeout_sec: 150
+exit_code: 0
+elapsed_sec: 4.14
+status: ok
+----- stdout -----
+H = -lambda sum_f P_f on the height-1 ring of L plaquettes; E_e = Z^L_e/2, U_e = sigma^+_e; G_v = (div E)_v - rho_v; lambda = 1
+PASS A1 [exact] the ring, L = 4..20 even: L rungs + 2L rails = 3L links, 2L vertices at coordination z_v = 3, L faces. z_v odd forces 2 rho_v odd; neutrality sum_v rho_v = 0 then forces a staggered sign
+PASS A2 [exact] the declared matter-free background: staggered 2rho(t_i) = (-1)^i, 2rho(b_i) = -(-1)^i, parity-admissible and neutral, used throughout. Columnar (+1/2 top, -1/2 bottom) is admissible too but gives dim 4 with H = 0 at every L; uniform rho = -1/2 is not neutral, so its sector is empty
+PASS A3 [exact] dim(Gauss) = Lucas(L) + 2 exactly at L = 4..20: 9,20,49,125,324,845,2209,5780,15129; every listed state re-verified against G_v = 0 at all 2L vertices, max |G_v| = 0
+PASS A4 [exact] the cut flux Phi_i = E_{T_i} + E_{B_i} is the same at all L cuts in every sector state, so Phi in {-1,0,+1} labels three winding sectors: dim(Phi = 0) = Lucas(L) = 7,18,47,123,322,843,2207,5778,15127; Phi = +-1 one-dimensional
+PASS B1 [exact] basis bijection at L = 4,6,8,10,12,14,16: x_i = (1 + e_{T_i})/2, z_i = 1 - x_i (i even) and x_i (i odd), carries the Phi = 0 Gauss basis one-to-one onto the L-ring configurations with no two adjacent 1s
+PASS B2 [exact] under it the matrices agree entry by entry, not merely in spectrum: -lambda sum_f P_f = -lambda sum_i P_{i-1} X_i P_{i+1} on L periodic sites, max |difference| = 0 at L = 4..16. The ring's Gauss sector IS the zero-detuning constrained chain (PXP in the literature; a pointer, not authority)
+PASS B3 [1e-13] full spectra agree at every L = 4..16 to max |difference| = 7.6e-14
+PASS C1 [1e-8] the glide S = T_1 . C is a symmetry with S^L = 1; at every L = 4..20 the ground state is unique at k = 0 and the first excitation a single zone-boundary level at k = pi: no degeneracy
+PASS C2 [1e-9] Delta_1(L) = 1.0352762,0.9845253,0.9726558,0.9694746,0.9685697,0.9683035,0.9682236,0.9681992,0.9681917 at L = 4..20
+PASS C3 [1e-6] L Delta_1 at L = 14,16,18,20 = 13.556,15.492,17.428,19.364, rising by 1.936 per two columns and constant to 3.9e-04: linear in L, not constant, so Delta_1 is not of the gapless 1/L form
+PASS C4 [1e-4] d ln Delta_1 / dL = -1.86e-05 on L = 14..20: flat to five digits, so Delta_1 is not of the exponentially small e^{-L} form either. The gap is a constant
+PASS C5 [1e-3] the finite-size correction is exponential: Delta_1(L) - Delta_1(L-2) falls by a settled factor 3.244 per two columns, ln of it linear with slope -0.5945, xi_gap = 1.682 columns (the scale of C7); Richardson Delta_1(inf) = 0.9681883 lambda
+PASS C6 [1e-9] the vacuum plaquette value is uniform over the L faces to 4.4e-15, <P_f> = 0.6035607, the sum rule E_0 = -lambda L <P_f> closes to 3.7e-14, and the energy density E_0/L converges to -0.6035607 lambda
+PASS C7 [1e-3] short-ranged: at L = 20 the connected face correlator alternates in sign and decays with xi_P = 1.597 columns, the connected rung-flux one with xi_E = 1.518, fitted on d = 4..8
+PASS C8 [1e-12] <E_{T_i}> alternates by +-0.3042 and <E_{R_i}> by +-0.1083, period 2, zero mean, in step with the declared background sign; every other Fourier component, the period-4 columnar one included, vanishes to 6.0e-16: the explicit background, not order
+PASS D1 [exact] the Phi = +-1 sectors are one-dimensional with no flippable face, so H = 0 there exactly at every L = 4..20 and they lie |E_0| = 0.60356 lambda L above the Phi = 0 ground state: a linear splitting, not an exponentially small one
+PASS D2 [1e-7] static two-charge potential at L = 20, the pair inserted by reversing the background half-charge at t_0 and t_d (neutrality, parity and |2 rho| = 1 all preserved; d odd): V(d) = 0.317041, 1.524151, 2.731236, 3.938250, 5.145046
+PASS D3 [1e-3] the potential is exactly linear, with no 1/d piece at any d: successive slopes 0.603555,0.603543,0.603507,0.603398 agree to 1.6e-04; the linear fit V = sigma d + c gives sigma = 0.6035055 at residual 1.2e-04, and a Coulomb term added to it returns -0.0004
+PASS D4 [1e-4] the string tension is the vacuum face energy density: sigma = 0.603505 against |E_0|/L = 0.603561 lambda, agreeing to 5.5e-05
+PASS E1 [exact] the 2x2xL tube, open in x and y, periodic in z, has z_v = 4 everywhere -- even, so rho = 0 is admissible and neutral -- with 8L links and 5L faces; dim(Gauss) at L = 2..6 is 114,548,2970,16892,98466, by slab sweep at peak 134742 partial states
+PASS E2 [1e-7] on the tube Delta_1 does not settle: 1.1260,1.1034,0.5834,0.9025,0.4623 at L = 2..6, oscillating with the parity of L: a commensuration effect of the 2x2 cross-section, two points per parity class. No fit is claimed
+PASS E3 [1e-7] the periodic 2x2x2 torus (z_v = 6, 24 links, 24 faces, each pair carrying two links at period 2): dim(Gauss) = 9600, E_0 = -9.026720914, Delta_1 = 1.627609934. At linear size 2 every direction admits only k = 0, pi: no dispersion there
+PASS E4 [exact] at z = 6 the Gauss sector obeys a 3-in/3-out ice rule, whose Pauling estimate 2.5^N gives 1526 at N = 8 against the exact 9600, so it is conservative here. At N = 4^3 = 64 it gives 2.9e+25 states against a 2^18 = 262144 budget, ~10^19 times over; 8^3 is ~10^63
+PASS E5 [exact] in the Gauss basis every off-diagonal element of -lambda sum_f P_f is -lambda <= 0 and every diagonal element 0, on the ring at L = 4..20 and on every 3D block here, so exp(-beta H) has non-negative matrix elements: the model carries no sign problem and sampling is available
+SUMMARY: on the height-1 ring the pure spin-1/2 link sector is gapped at 0.9681883 lambda with a unique short-ranged ground state, and two static charges are held by an exactly linear string of tension 0.6035 lambda = the vacuum face energy density; its Gauss sector is exactly the zero-detuning constrained chain. The ring has no transverse direction, so this prices the electric excitation gap and says nothing either way about three dimensions, where sampling is the tool.
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py
+++ b/scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py
@@ -1,0 +1,787 @@
+#!/usr/bin/env python3
+"""The spin-1/2 link ring is gapped and confining; the photon question needs three dimensions.
+
+Self-contained runner for the PURE spin-1/2 U(1) quantum link model -- no
+matter -- on a height-1 cylinder ladder ("the ring"): L rungs and 2L rails,
+2L vertices of coordination z_v = 3, L plaquettes.  One spin-1/2 link record
+per edge, in the declared conventions
+
+    E_e = (1/2) Z^L_e   (eigenvalues +-1/2),   U_e = (X^L_e + i Y^L_e)/2,
+    (div E)_v = sum_{e at v} s_{v,e} E_e,      G_v = (div E)_v - rho_v,
+    W_f = the oriented four-link loop product of U and U^dag,  P_f = W_f + W_f^dag,
+    H = -lambda sum_f P_f,
+
+the electric term (g^2/2) sum_e E_e^2 being a c-number at spin 1/2 because
+E_e^2 = I/4.  lambda is supplied and set to 1; every energy is in units of
+lambda.  rho_v is a static background charge: with no matter there is no n_v.
+
+  A  SECTOR, BACKGROUND CONVENTION AND CENSUS.  z_v = 3 is odd, so 2 rho_v is
+     odd, and graph neutrality sum_v rho_v = 0 then forces a staggered sign.
+     dim(Gauss) = Lucas(L) + 2; the cut flux Phi labels three winding sectors.
+  B  THE CONSTRAINED-CHAIN IDENTIFICATION.  The Phi = 0 block is, by an
+     explicit basis bijection, the zero-detuning constrained chain
+     -lambda sum_i P_{i-1} X_i P_{i+1} on L sites with periodic boundaries.
+  C  THE GAP.  Delta_1(L) -> 0.9681883 lambda with an exponential finite-size
+     correction; unique k = 0 ground state; short-ranged correlators.
+  D  WINDING SECTORS AND THE STRING.  Phi = +-1 are one-dimensional with H = 0
+     exactly and sit 0.60356 lambda L above; the static two-charge potential is
+     exactly linear with sigma = the vacuum plaquette energy density.
+  E  THREE DIMENSIONS.  The 2x2xL tube and the 2x2x2 torus, the size of the 4^3
+     Gauss sector, and the absence of a sign problem.
+
+Groups A, B, D1 and E5 are exact integer/bit arithmetic; the rest are
+floating-point cross-checks at the stated tolerance.  Every sector is built as
+an explicit Gauss-sector basis by transfer or slab sweep, never by enumerating
+2^{3L}; the largest object anywhere is 134742 partial states and the largest
+matrix 98466 rows.  Sparse Lanczos above 2500 rows, from a deterministic
+starting vector; no random number is drawn anywhere.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+Exit code 0 iff FAIL = 0.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+AUDIT_TIMEOUT_SEC = 150
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+DENSE_MAX = 2500
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+def v0_of(n):
+    """Deterministic Lanczos start: equidistributed, no symmetry, no seed."""
+    v = np.cos(np.arange(n, dtype=float) * np.sqrt(2.0)) + 1.5
+    return v / np.linalg.norm(v)
+
+
+def low_spectrum(H, nev):
+    """Lowest nev levels of a sparse symmetric H, dense below DENSE_MAX."""
+    n = H.shape[0]
+    if n <= DENSE_MAX:
+        w, v = np.linalg.eigh(H.toarray())
+        return w[:nev], v[:, :nev]
+    k = min(nev + 6, n - 2)
+    w, v = spla.eigsh(H, k=k, which="SA", v0=v0_of(n), maxiter=20000, tol=0.0)
+    o = np.argsort(w)
+    return w[o][:nev], v[:, o][:, :nev]
+
+
+# ================================================== the ring: geometry and law
+#
+# Vertices t_i, b_i for i = 0..L-1 (two rings).  Links, 3L of them, bit j of the
+# state integer carrying e_j = 2 E_j in {-1,+1}:
+#     T_i = 3i     oriented t_i -> t_{i+1}    (top rail)
+#     B_i = 3i+1   oriented b_i -> b_{i+1}    (bottom rail)
+#     R_i = 3i+2   oriented b_i -> t_i        (rung)
+# Plaquette f_i : t_i -> t_{i+1} -> b_{i+1} -> b_i -> t_i, so
+#     W_{f_i} = U_{T_i} U^dag_{R_{i+1}} U^dag_{B_i} U_{R_i}.
+
+
+def lucas(n):
+    a, b = 2, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a
+
+
+def conv_staggered(L):
+    """2 rho(t_i) = (-1)^i, 2 rho(b_i) = -(-1)^i.  Odd at z = 3, and neutral."""
+    return [(-1) ** i for i in range(L)], [-((-1) ** i) for i in range(L)]
+
+
+def conv_columnar(L):
+    """2 rho = +1 on the whole top ring, -1 on the whole bottom ring."""
+    return [1] * L, [-1] * L
+
+
+def conv_uniform(L):
+    """rho_v = -1/2 everywhere: parity-admissible at odd z, but not neutral."""
+    return [-1] * L, [-1] * L
+
+
+def build_sector(L, rt, rb):
+    """Every e-config with G_v = 0 at every vertex, as a sorted int64 array.
+
+    At t_i:  e_T[i] - e_T[i-1] - e_R[i] = 2 rho(t_i)
+    At b_i:  e_B[i] - e_B[i-1] + e_R[i] = 2 rho(b_i)
+    Column transfer; the boundary datum is (e_T[L-1], e_B[L-1])."""
+    out = []
+    for eT0 in (-1, 1):
+        for eB0 in (-1, 1):
+            S = np.zeros(1, dtype=np.int64)
+            pT = np.full(1, eT0, dtype=np.int64)
+            pB = np.full(1, eB0, dtype=np.int64)
+            for i in range(L):
+                nS, nT, nB = [], [], []
+                for eR in (-1, 1):
+                    eT = rt[i] + pT + eR
+                    eB = rb[i] + pB - eR
+                    m = (np.abs(eT) == 1) & (np.abs(eB) == 1)
+                    if not m.any():
+                        continue
+                    s2 = S[m].copy()
+                    s2 |= (eT[m] == 1).astype(np.int64) << (3 * i)
+                    s2 |= (eB[m] == 1).astype(np.int64) << (3 * i + 1)
+                    if eR == 1:
+                        s2 |= np.int64(1) << (3 * i + 2)
+                    nS.append(s2)
+                    nT.append(eT[m])
+                    nB.append(eB[m])
+                if not nS:
+                    S = np.zeros(0, dtype=np.int64)
+                    break
+                S = np.concatenate(nS)
+                pT = np.concatenate(nT)
+                pB = np.concatenate(nB)
+            if S.size:
+                keep = (pT == eT0) & (pB == eB0)
+                out.append(S[keep])
+    if not out:
+        return np.zeros(0, dtype=np.int64)
+    return np.unique(np.concatenate(out))
+
+
+def e_of(L, S):
+    """(n, 3L) array of e = 2E in {-1,+1}."""
+    j = np.arange(3 * L)
+    return (2 * ((S[:, None] >> j[None, :]) & 1) - 1).astype(np.int64)
+
+
+def gauss_residual(L, S, rt, rb):
+    """Max |G_v| over every state and every vertex, checked independently."""
+    if S.size == 0:
+        return 0
+    e = e_of(L, S)
+    eT, eB, eR = e[:, 0::3], e[:, 1::3], e[:, 2::3]
+    r = 0
+    for i in range(L):
+        im = (i - 1) % L
+        r = max(r, int(np.abs(eT[:, i] - eT[:, im] - eR[:, i] - rt[i]).max()))
+        r = max(r, int(np.abs(eB[:, i] - eB[:, im] + eR[:, i] - rb[i]).max()))
+    return r
+
+
+def _plaq_bits(L, i):
+    return 3 * i, 3 * i + 1, 3 * i + 2, 3 * (((i + 1) % L)) + 2
+
+
+def ring_op(L, S, faces, coef):
+    """sum over the listed faces of coef * P_f, as a sparse matrix."""
+    n = S.size
+    rows, cols, vals = [], [], []
+    for i in faces:
+        T, B, R, Rn = _plaq_bits(L, i)
+        bT = (S >> T) & 1
+        bB = (S >> B) & 1
+        bR = (S >> R) & 1
+        bRn = (S >> Rn) & 1
+        for up in (True, False):
+            if up:  # W_f : raise T_i and R_i, lower B_i and R_{i+1}
+                m = (bT == 0) & (bRn == 1) & (bB == 1) & (bR == 0)
+                tgt = (S[m] | (np.int64(1) << T) | (np.int64(1) << R)) & ~(
+                    (np.int64(1) << B) | (np.int64(1) << Rn)
+                )
+            else:
+                m = (bT == 1) & (bRn == 0) & (bB == 0) & (bR == 1)
+                tgt = (S[m] | (np.int64(1) << B) | (np.int64(1) << Rn)) & ~(
+                    (np.int64(1) << T) | (np.int64(1) << R)
+                )
+            if tgt.size == 0:
+                continue
+            rows.append(np.nonzero(m)[0])
+            cols.append(np.searchsorted(S, tgt))
+            vals.append(np.full(tgt.size, coef))
+    if not rows:
+        return sp.csr_matrix((n, n))
+    return sp.coo_matrix(
+        (np.concatenate(vals), (np.concatenate(rows), np.concatenate(cols))),
+        shape=(n, n),
+    ).tocsr()
+
+
+def build_H(L, S, lam=1.0):
+    return ring_op(L, S, range(L), -lam)
+
+
+def glide_perm(L, S):
+    """S_glide = T_1 . C: one column on, and E -> -E.  T_1 alone is not a
+    symmetry -- the declared background alternates -- and C undoes that."""
+    t = np.zeros(S.size, dtype=np.int64)
+    for i in range(L):
+        j = (i + 1) % L
+        for a in range(3):
+            t |= ((1 - ((S >> (3 * i + a)) & 1)) << (3 * j + a))
+    p = np.searchsorted(S, t)
+    if p.max() >= S.size or not np.array_equal(S[p], t):
+        return None
+    return p
+
+
+def phi_of(L, S):
+    """Cut flux Phi_i = E_{T_i} + E_{B_i}, as an (n, L) integer array."""
+    e = e_of(L, S)
+    return (e[:, 0::3] + e[:, 1::3]) // 2
+
+
+def dyn_block(L, rt, rb):
+    """Gauss sector, its Phi = 0 block, H there, and the glide permutation."""
+    S = build_sector(L, rt, rb)
+    phi = phi_of(L, S)
+    dyn = np.nonzero(phi[:, 0] == 0)[0]
+    H = build_H(L, S)
+    Hd = H[dyn][:, dyn].tocsr()
+    perm = glide_perm(L, S)
+    pos = -np.ones(S.size, dtype=np.int64)
+    pos[dyn] = np.arange(dyn.size)
+    permd = pos[perm[dyn]]
+    return S, phi, dyn, H, Hd, permd
+
+
+def momentum(v, permd, L):
+    """Glide eigenvalue of v, returned as k L / 2 pi, with |<v|S|v>|."""
+    Sv = np.zeros_like(v)
+    Sv[permd] = v
+    a = float(np.dot(v, Sv))
+    return round(np.angle(a + 0j) * L / (2 * np.pi), 6), abs(a)
+
+
+# ================================================================ the ring runs
+
+LS = [4, 6, 8, 10, 12, 14, 16, 18, 20]
+NEV = 4
+print(
+    "H = -lambda sum_f P_f on the height-1 ring of L plaquettes; E_e = Z^L_e/2, "
+    "U_e = sigma^+_e; G_v = (div E)_v - rho_v; lambda = 1"
+)
+
+# ---- A1  geometry and the three background conventions
+geom_ok = True
+for L in LS:
+    rt, rb = conv_staggered(L)
+    nlink, nvert = 3 * L, 2 * L
+    zs = {3}
+    geom_ok &= (nlink == 3 * L and nvert == 2 * L and len(zs) == 1 and 3 in zs)
+    geom_ok &= (sum(rt) + sum(rb) == 0) and all(abs(x) % 2 == 1 for x in rt + rb)
+check(
+    "A1 [exact] the ring, L = 4..20 even: L rungs + 2L rails = 3L links, 2L vertices at coordination "
+    "z_v = 3, L faces. z_v odd forces 2 rho_v odd; neutrality sum_v rho_v = 0 then forces a staggered sign",
+    geom_ok,
+)
+
+# ---- A2  the three conventions computed
+conv_rows = []
+for L in LS:
+    row = {}
+    for tag, fn in (("stag", conv_staggered), ("col", conv_columnar), ("uni", conv_uniform)):
+        rt, rb = fn(L)
+        S = build_sector(L, rt, rb)
+        neutral = (sum(rt) + sum(rb)) == 0
+        par = all(abs(x) % 2 == 1 for x in rt + rb)
+        hmax = 0.0
+        if S.size:
+            H = build_H(L, S)
+            hmax = float(abs(H).max()) if H.nnz else 0.0
+        row[tag] = (S.size, neutral, par, hmax, gauss_residual(L, S, rt, rb))
+    conv_rows.append(row)
+col_ok = all(r["col"][0] == 4 and r["col"][3] == 0.0 and r["col"][1] and r["col"][2] for r in conv_rows)
+uni_ok = all(r["uni"][0] == 0 and not r["uni"][1] and r["uni"][2] for r in conv_rows)
+check(
+    "A2 [exact] the declared matter-free background: staggered 2rho(t_i) = (-1)^i, 2rho(b_i) = -(-1)^i, "
+    "parity-admissible and neutral, used throughout. Columnar (+1/2 top, -1/2 bottom) is admissible too "
+    "but gives dim 4 with H = 0 at every L; uniform rho = -1/2 is not neutral, so its sector is empty",
+    col_ok and uni_ok,
+)
+
+# ---- A3  the census
+dims = []
+res_max = 0
+for L in LS:
+    rt, rb = conv_staggered(L)
+    S = build_sector(L, rt, rb)
+    dims.append(S.size)
+    res_max = max(res_max, gauss_residual(L, S, rt, rb))
+lucas_pred = [lucas(L) + 2 for L in LS]
+check(
+    "A3 [exact] dim(Gauss) = Lucas(L) + 2 exactly at L = 4..20: "
+    + ",".join(str(d) for d in dims)
+    + f"; every listed state re-verified against G_v = 0 at all 2L vertices, max |G_v| = {res_max}",
+    dims == lucas_pred and res_max == 0,
+)
+
+# ---- A4  winding sectors
+phi_ok = True
+dim0 = []
+for L in LS:
+    rt, rb = conv_staggered(L)
+    S = build_sector(L, rt, rb)
+    phi = phi_of(L, S)
+    phi_ok &= bool(np.all(phi == phi[:, :1]))
+    vals = sorted(set(int(x) for x in phi[:, 0]))
+    phi_ok &= vals == [-1, 0, 1]
+    phi_ok &= int(np.sum(phi[:, 0] == 1)) == 1 and int(np.sum(phi[:, 0] == -1)) == 1
+    dim0.append(int(np.sum(phi[:, 0] == 0)))
+check(
+    "A4 [exact] the cut flux Phi_i = E_{T_i} + E_{B_i} is the same at all L cuts in every sector state, so "
+    "Phi in {-1,0,+1} labels three winding sectors: dim(Phi = 0) = Lucas(L) = "
+    + ",".join(str(d) for d in dim0)
+    + "; Phi = +-1 one-dimensional",
+    phi_ok and dim0 == [lucas(L) for L in LS],
+)
+
+
+# =============================================== B  the constrained-chain block
+
+
+def chain(L):
+    """Independent sets on the L-ring, and -sum_i P_{i-1} X_i P_{i+1}."""
+    st = np.array(
+        [
+            s
+            for s in range(1 << L)
+            if all(not (((s >> i) & 1) and ((s >> ((i + 1) % L)) & 1)) for i in range(L))
+        ],
+        dtype=np.int64,
+    )
+    rows, cols, vals = [], [], []
+    for a, s in enumerate(st):
+        for i in range(L):
+            if not ((s >> ((i - 1) % L)) & 1) and not ((s >> ((i + 1) % L)) & 1):
+                t = int(s) ^ (1 << i)
+                rows.append(a)
+                cols.append(int(np.searchsorted(st, t)))
+                vals.append(-1.0)
+    return st, sp.coo_matrix((vals, (rows, cols)), shape=(st.size,) * 2).tocsr()
+
+
+def chain_image(L, S, dyn):
+    """x_i = (1 + e_{T_i})/2;  z_i = 1 - x_i for i even, x_i for i odd."""
+    e = e_of(L, S[dyn])
+    x = (e[:, 0::3] + 1) // 2
+    z = np.where(np.arange(L)[None, :] % 2 == 0, 1 - x, x)
+    return (z * (np.int64(1) << np.arange(L))[None, :]).sum(axis=1)
+
+
+bij_ok = True
+op_ok = True
+spec_err = 0.0
+for L in [4, 6, 8, 10, 12, 14, 16]:
+    S, phi, dyn, H, Hd, permd = dyn_block(L, *conv_staggered(L))
+    img = chain_image(L, S, dyn)
+    cst, Hc = chain(L)
+    bij_ok &= img.size == cst.size and np.array_equal(np.sort(img), cst)
+    order = np.argsort(img)
+    Hp = Hd[order][:, order].tocsr()
+    op_ok &= (abs(Hp - Hc).max() == 0.0)
+    wq = np.linalg.eigvalsh(Hd.toarray())
+    wc = np.linalg.eigvalsh(Hc.toarray())
+    spec_err = max(spec_err, float(np.abs(wq - wc).max()))
+
+check(
+    "B1 [exact] basis bijection at L = 4,6,8,10,12,14,16: x_i = (1 + e_{T_i})/2, z_i = 1 - x_i (i even) "
+    "and x_i (i odd), carries the Phi = 0 Gauss basis one-to-one onto the L-ring configurations with no "
+    "two adjacent 1s",
+    bij_ok,
+)
+check(
+    "B2 [exact] under it the matrices agree entry by entry, not merely in spectrum: -lambda sum_f P_f = "
+    "-lambda sum_i P_{i-1} X_i P_{i+1} on L periodic sites, max |difference| = 0 at L = 4..16. The ring's "
+    "Gauss sector IS the zero-detuning constrained chain (PXP in the literature; a pointer, not authority)",
+    op_ok,
+)
+check(
+    f"B3 [1e-13] full spectra agree at every L = 4..16 to max |difference| = {spec_err:.1e}",
+    spec_err <= 1e-13,
+)
+
+# ============================================================ C  the gap
+
+E0 = {}
+D1 = {}
+MOM = {}
+PSI = {}
+for L in LS:
+    S, phi, dyn, H, Hd, permd = dyn_block(L, *conv_staggered(L))
+    w, v = low_spectrum(Hd, NEV)
+    E0[L] = float(w[0])
+    D1[L] = float(w[1] - w[0])
+    m0, a0 = momentum(v[:, 0], permd, L)
+    m1, a1 = momentum(v[:, 1], permd, L)
+    MOM[L] = (m0, a0, m1, a1)
+    if L == 20:
+        PSI[L] = (S, dyn, v[:, 0], Hd, permd)
+
+Larr = np.array(LS, dtype=float)
+d1 = np.array([D1[L] for L in LS])
+
+mom_ok = all(
+    abs(MOM[L][0]) < 1e-6
+    and abs(MOM[L][1] - 1.0) < 1e-8
+    and abs(abs(MOM[L][2]) - L / 2) < 1e-6
+    and abs(MOM[L][3] - 1.0) < 1e-8
+    and D1[L] > 1e-3
+    for L in LS
+)
+check(
+    "C1 [1e-8] the glide S = T_1 . C is a symmetry with S^L = 1; at every L = 4..20 the ground state is "
+    "unique at k = 0 and the first excitation a single zone-boundary level at k = pi: no degeneracy",
+    mom_ok,
+)
+
+d1_ref = [
+    1.0352761804, 0.9845253100, 0.9726557606, 0.9694746275, 0.9685696977,
+    0.9683035437, 0.9682235785, 0.9681991960, 0.9681916807,
+]
+check(
+    "C2 [1e-9] Delta_1(L) = "
+    + ",".join(f"{D1[L]:.7f}" for L in LS)
+    + " at L = 4..20",
+    np.abs(d1 - np.array(d1_ref)).max() <= 1e-9,
+)
+
+LD = Larr * d1
+tail = LD[-4:]
+diffs = np.diff(tail)
+check(
+    "C3 [1e-6] L Delta_1 at L = 14,16,18,20 = "
+    + ",".join(f"{x:.3f}" for x in tail)
+    + f", rising by {diffs.mean():.3f} per two columns and constant to {diffs.std():.1e}: linear in L, "
+    "not constant, so Delta_1 is not of the gapless 1/L form",
+    diffs.std() < 1e-3 and abs(diffs.mean() - 1.9364) < 5e-3,
+)
+
+m = Larr >= 14
+c1 = float(np.polyfit(Larr[m], np.log(d1[m]), 1)[0])
+check(
+    f"C4 [1e-4] d ln Delta_1 / dL = {c1:.2e} on L = 14..20: flat to five digits, so Delta_1 is not of the "
+    "exponentially small e^{-L} form either. The gap is a constant",
+    abs(c1) < 1e-4,
+)
+
+step = np.abs(np.diff(d1))
+ratio = step[:-1] / step[1:]
+rfit = np.polyfit(Larr[1:][Larr[1:] >= 14], np.log(step[Larr[1:] >= 14]), 1)
+xi_gap = -1.0 / rfit[0]
+rich = d1[-1] - (d1[-1] - d1[-2]) ** 2 / ((d1[-1] - d1[-2]) - (d1[-2] - d1[-3]))
+check(
+    f"C5 [1e-3] the finite-size correction is exponential: Delta_1(L) - Delta_1(L-2) falls by a settled "
+    f"factor {ratio[-1]:.3f} per two columns, ln of it linear with slope {rfit[0]:.4f}, xi_gap = "
+    f"{xi_gap:.3f} columns (the scale of C7); Richardson Delta_1(inf) = {rich:.7f} lambda",
+    abs(xi_gap - 1.682) < 5e-3 and abs(rich - 0.9681883) < 1e-6 and abs(ratio[-1] - 3.244) < 1e-3,
+)
+
+S20, dyn20, psi20, Hd20, permd20 = PSI[20]
+Pops = [ring_op(20, S20, [f], 1.0)[dyn20][:, dyn20].tocsr() for f in range(20)]
+pf = np.array([float(psi20 @ (Pops[f] @ psi20)) for f in range(20)])
+sumrule = abs(E0[20] + 20 * pf[0])
+e0dens = [E0[L] / L for L in LS]
+check(
+    f"C6 [1e-9] the vacuum plaquette value is uniform over the L faces to {pf.max() - pf.min():.1e}, "
+    f"<P_f> = {pf[0]:.7f}, the sum rule E_0 = -lambda L <P_f> closes to {sumrule:.1e}, and the energy "
+    f"density E_0/L converges to {e0dens[-1]:.7f} lambda",
+    pf.max() - pf.min() < 1e-12 and sumrule < 1e-9 and abs(e0dens[-1] + 0.6035607) < 1e-6,
+)
+
+cP = np.array(
+    [float(psi20 @ (Pops[0] @ (Pops[d] @ psi20))) - pf[0] * pf[d] for d in range(9)]
+)
+e20 = e_of(20, S20[dyn20]).astype(float) / 2.0
+eT, eR = e20[:, 0::3], e20[:, 2::3]
+p2 = psi20 ** 2
+mT = (p2[:, None] * eT).sum(0)
+mR = (p2[:, None] * eR).sum(0)
+cR = np.array(
+    [float((p2 * eR[:, 0] * eR[:, d]).sum() - mR[0] * mR[d]) for d in range(9)]
+)
+ds = np.arange(4, 9)
+xiP = -1.0 / np.polyfit(ds, np.log(np.abs(cP[4:9])), 1)[0]
+xiE = -1.0 / np.polyfit(ds, np.log(np.abs(cR[4:9])), 1)[0]
+check(
+    f"C7 [1e-3] short-ranged: at L = 20 the connected face correlator alternates in sign and decays with "
+    f"xi_P = {xiP:.3f} columns, the connected rung-flux one with xi_E = {xiE:.3f}, fitted on d = 4..8",
+    1.4 < xiP < 1.8 and 1.3 < xiE < 1.7,
+)
+
+ft = np.fft.fft(mT) / 20.0
+fr = np.fft.fft(mR) / 20.0
+other = max(
+    float(np.abs(np.delete(ft, 10)).max()), float(np.abs(np.delete(fr, 10)).max())
+)
+bg = np.array([(-1) ** i for i in range(20)], dtype=float)
+sign_ok = bool(np.all(np.sign(mT) == np.sign(bg)) or np.all(np.sign(mT) == -np.sign(bg)))
+check(
+    f"C8 [1e-12] <E_{{T_i}}> alternates by +-{abs(mT[0]):.4f} and <E_{{R_i}}> by +-{abs(mR[0]):.4f}, "
+    f"period 2, zero mean, in step with the declared background sign; every other Fourier component, the "
+    f"period-4 columnar one included, vanishes to {other:.1e}: the explicit background, not order",
+    other < 1e-12 and sign_ok,
+)
+
+# ================================================ D  winding sectors and string
+
+wind_ok = True
+split = []
+for L in LS:
+    rt, rb = conv_staggered(L)
+    S = build_sector(L, rt, rb)
+    phi = phi_of(L, S)
+    H = build_H(L, S)
+    for p in (-1, 1):
+        sel = np.nonzero(phi[:, 0] == p)[0]
+        Hs = H[sel][:, sel]
+        wind_ok &= sel.size == 1 and Hs.nnz == 0
+    split.append(-E0[L])
+sp_per_L = np.array(split) / Larr
+check(
+    "D1 [exact] the Phi = +-1 sectors are one-dimensional with no flippable face, so H = 0 there exactly "
+    f"at every L = 4..20 and they lie |E_0| = {sp_per_L[-1]:.5f} lambda L above the Phi = 0 ground state: "
+    "a linear splitting, not an exponentially small one",
+    wind_ok and abs(sp_per_L[-1] - 0.6035607) < 1e-6,
+)
+
+L = 20
+rt, rb = conv_staggered(L)
+V = {}
+for d in (1, 3, 5, 7, 9):
+    rt2 = list(rt)
+    rt2[0] = -rt2[0]
+    rt2[d] = -rt2[d]
+    S2 = build_sector(L, rt2, rb)
+    H2 = build_H(L, S2)
+    w2, _ = low_spectrum(H2, 2)
+    V[d] = float(w2[0]) - E0[20]
+V_ref = {1: 0.31704131, 3: 1.52415077, 5: 2.73123645, 7: 3.93825014, 9: 5.14504618}
+check(
+    "D2 [1e-7] static two-charge potential at L = 20, the pair inserted by reversing the background "
+    "half-charge at t_0 and t_d (neutrality, parity and |2 rho| = 1 all preserved; d odd): V(d) = "
+    + ", ".join(f"{V[d]:.6f}" for d in (1, 3, 5, 7, 9)),
+    max(abs(V[d] - V_ref[d]) for d in V) <= 1e-7,
+)
+
+dd = np.array([1.0, 3, 5, 7, 9])
+vv = np.array([V[d] for d in (1, 3, 5, 7, 9)])
+slopes = np.diff(vv) / 2.0
+lin = np.polyfit(dd, vv, 1)
+resid = float(np.abs(vv - np.polyval(lin, dd)).max())
+cub = np.linalg.lstsq(np.stack([dd, np.ones_like(dd), 1.0 / dd], 1), vv, rcond=None)[0]
+check(
+    "D3 [1e-3] the potential is exactly linear, with no 1/d piece at any d: successive slopes "
+    + ",".join(f"{s:.6f}" for s in slopes)
+    + f" agree to {slopes.max() - slopes.min():.1e}; the linear fit V = sigma d + c gives sigma = "
+    f"{lin[0]:.7f} at residual {resid:.1e}, and a Coulomb term added to it returns {cub[2]:.4f}",
+    resid < 1e-2 and abs(lin[0] - 0.6035055) < 1e-6 and abs(cub[2]) < 5e-2,
+)
+
+check(
+    f"D4 [1e-4] the string tension is the vacuum face energy density: sigma = {lin[0]:.6f} against "
+    f"|E_0|/L = {sp_per_L[-1]:.6f} lambda, agreeing to {abs(lin[0] - sp_per_L[-1]):.1e}",
+    abs(lin[0] - sp_per_L[-1]) < 1e-4,
+)
+
+# ============================================================ E  three dimensions
+
+
+class Block:
+    """nx x ny x nz block, per-direction periodicity; links owned by their tail."""
+
+    def __init__(self, nx, ny, nz, per):
+        self.n = (nx, ny, nz)
+        self.per = per
+        self.sites = [(x, y, z) for x in range(nx) for y in range(ny) for z in range(nz)]
+        self.li = {}
+        self.links = []
+        for s in self.sites:
+            for d in range(3):
+                if self.step(s, d) is not None:
+                    self.li[(s, d)] = len(self.links)
+                    self.links.append((s, d))
+        self.NL = len(self.links)
+        self.inc = {s: [] for s in self.sites}
+        for (s, d), j in self.li.items():
+            self.inc[s].append((j, +1))
+            self.inc[self.step(s, d)].append((j, -1))
+        self.plaq = []
+        for s in self.sites:
+            for d1 in range(3):
+                for d2 in range(d1 + 1, 3):
+                    a, b = self.step(s, d1), self.step(s, d2)
+                    if a is None or b is None:
+                        continue
+                    if (a, d2) not in self.li or (b, d1) not in self.li:
+                        continue
+                    self.plaq.append(
+                        (self.li[(s, d1)], self.li[(a, d2)], self.li[(b, d1)], self.li[(s, d2)])
+                    )
+
+    def step(self, s, d):
+        v = list(s)
+        v[d] += 1
+        if v[d] >= self.n[d]:
+            if not self.per[d]:
+                return None
+            v[d] = 0
+        return tuple(v)
+
+
+def block_sector(lat, cap=1 << 18):
+    """Gauss sector at rho = 0, by a slab sweep; returns the basis and the peak."""
+    order = sorted(lat.sites, key=lambda s: (s[2], s[1], s[0]))
+    seen, todo = set(), []
+    for s in order:
+        new = [j for (j, _) in lat.inc[s] if j not in seen]
+        seen.update(new)
+        todo.append(new)
+    part = np.zeros(1, dtype=np.int64)
+    peak = 1
+    for k, s in enumerate(order):
+        new = todo[k]
+        if new:
+            offs = np.array(
+                [
+                    sum(1 << new[a] for a in range(len(new)) if (mm >> a) & 1)
+                    for mm in range(1 << len(new))
+                ],
+                dtype=np.int64,
+            )
+            cand = (part[:, None] | offs[None, :]).ravel()
+        else:
+            cand = part
+        tot = np.zeros(cand.size, dtype=np.int64)
+        for (j, sg) in lat.inc[s]:
+            tot += sg * (2 * ((cand >> j) & 1) - 1)
+        part = cand[tot == 0]
+        peak = max(peak, part.size)
+        if peak > cap:
+            raise MemoryError(peak)
+    return np.unique(part), peak
+
+
+def block_H(lat, S, lam=1.0):
+    n = S.size
+    rows, cols, vals = [], [], []
+    for (p, q, u, w) in lat.plaq:
+        bp, bq, bu, bw = [(S >> x) & 1 for x in (p, q, u, w)]
+        for up in (True, False):
+            if up:
+                m = (bp == 0) & (bq == 0) & (bu == 1) & (bw == 1)
+                tgt = (S[m] | (np.int64(1) << p) | (np.int64(1) << q)) & ~(
+                    (np.int64(1) << u) | (np.int64(1) << w)
+                )
+            else:
+                m = (bp == 1) & (bq == 1) & (bu == 0) & (bw == 0)
+                tgt = (S[m] | (np.int64(1) << u) | (np.int64(1) << w)) & ~(
+                    (np.int64(1) << p) | (np.int64(1) << q)
+                )
+            if tgt.size == 0:
+                continue
+            rows.append(np.nonzero(m)[0])
+            cols.append(np.searchsorted(S, tgt))
+            vals.append(np.full(tgt.size, -lam))
+    if not rows:
+        return sp.csr_matrix((n, n))
+    return sp.coo_matrix(
+        (np.concatenate(vals), (np.concatenate(rows), np.concatenate(cols))), shape=(n, n)
+    ).tocsr()
+
+
+tube = {}
+peak_max = 0
+z_ok = True
+for Lz in (2, 3, 4, 5, 6):
+    lat = Block(2, 2, Lz, (False, False, True))
+    z_ok &= set(len(lat.inc[s]) for s in lat.sites) == {4}
+    S3, pk = block_sector(lat)
+    peak_max = max(peak_max, pk)
+    H3 = block_H(lat, S3)
+    w3, _ = low_spectrum(H3, 3)
+    tube[Lz] = (S3.size, float(w3[0]), float(w3[1] - w3[0]), len(lat.plaq), H3)
+
+dims_ref = {2: 114, 3: 548, 4: 2970, 5: 16892, 6: 98466}
+check(
+    "E1 [exact] the 2x2xL tube, open in x and y, periodic in z, has z_v = 4 everywhere -- even, so rho = 0 "
+    "is admissible and neutral -- with 8L links and 5L faces; dim(Gauss) at L = 2..6 is "
+    + ",".join(str(tube[Lz][0]) for Lz in (2, 3, 4, 5, 6))
+    + f", by slab sweep at peak {peak_max} partial states",
+    z_ok and all(tube[Lz][0] == dims_ref[Lz] for Lz in dims_ref),
+)
+
+d3 = [tube[Lz][2] for Lz in (2, 3, 4, 5, 6)]
+d3_ref = [1.1259910492, 1.1034061857, 0.5833669983, 0.9024579504, 0.4623375786]
+check(
+    "E2 [1e-7] on the tube Delta_1 does not settle: "
+    + ",".join(f"{x:.4f}" for x in d3)
+    + " at L = 2..6, oscillating with the parity of L: a commensuration effect of the 2x2 cross-section, "
+    "two points per parity class. No fit is claimed",
+    max(abs(a - b) for a, b in zip(d3, d3_ref)) <= 1e-7,
+)
+
+lat_t = Block(2, 2, 2, (True, True, True))
+St, pkt = block_sector(lat_t)
+Ht = block_H(lat_t, St)
+wt, _ = low_spectrum(Ht, 3)
+check(
+    f"E3 [1e-7] the periodic 2x2x2 torus (z_v = 6, {lat_t.NL} links, {len(lat_t.plaq)} faces, each pair "
+    f"carrying two links at period 2): dim(Gauss) = {St.size}, E_0 = {wt[0]:.9f}, Delta_1 = "
+    f"{wt[1] - wt[0]:.9f}. At linear size 2 every direction admits only k = 0, pi: no dispersion there",
+    St.size == 9600
+    and abs(float(wt[0]) + 9.0267209135) <= 1e-7
+    and abs(float(wt[1] - wt[0]) - 1.6276099336) <= 1e-7,
+)
+
+paul8 = 2.5 ** 8
+paul64 = 2.5 ** 64
+check(
+    f"E4 [exact] at z = 6 the Gauss sector obeys a 3-in/3-out ice rule, whose Pauling estimate 2.5^N gives "
+    f"{paul8:.0f} at N = 8 against the exact 9600, so it is conservative here. At N = 4^3 = 64 it gives "
+    f"{paul64:.1e} states against a 2^18 = 262144 budget, ~10^19 times over; 8^3 is ~10^63",
+    paul8 < 9600 and paul64 > 1e25,
+)
+
+sign_free = True
+for L in LS:
+    S, phi, dyn, H, Hd, permd = dyn_block(L, *conv_staggered(L))
+    Hc = Hd.tocoo()
+    off = Hc.row != Hc.col
+    sign_free &= bool(np.all(Hc.data[off] == -1.0))
+    sign_free &= float(abs(Hd.diagonal()).max()) == 0.0
+for Lz in (2, 3, 4, 5, 6):
+    Hc = tube[Lz][4].tocoo()
+    off = Hc.row != Hc.col
+    sign_free &= bool(np.all(Hc.data[off] == -1.0))
+    sign_free &= float(abs(tube[Lz][4].diagonal()).max()) == 0.0
+Hc = Ht.tocoo()
+sign_free &= bool(np.all(Hc.data[Hc.row != Hc.col] == -1.0)) and float(abs(Ht.diagonal()).max()) == 0.0
+check(
+    "E5 [exact] in the Gauss basis every off-diagonal element of -lambda sum_f P_f is -lambda <= 0 and "
+    "every diagonal element 0, on the ring at L = 4..20 and on every 3D block here, so exp(-beta H) has "
+    "non-negative matrix elements: the model carries no sign problem and sampling is available",
+    sign_free,
+)
+
+print(
+    "SUMMARY: on the height-1 ring the pure spin-1/2 link sector is gapped at 0.9681883 lambda with a "
+    "unique short-ranged ground state, and two static charges are held by an exactly linear string of "
+    "tension 0.6035 lambda = the vacuum face energy density; its Gauss sector is exactly the zero-detuning "
+    "constrained chain. The ring has no transverse direction, so this prices the electric excitation gap "
+    "and says nothing either way about three dimensions, where sampling is the tool."
+)
+print(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Summary

Bounded theorem note + runner + cache converting PR #7893's open item "no gapless transverse mode of the link sector is shown, computed, or suggested" into a computed negative on the one geometry within exact reach: **the pure spin-half U(1) quantum-link ring is gapped and confining.** With `H = −λ Σ_f P_f` on a height-1 ring of `L` plaquettes in the Gauss sector (the staggered half-charge background declared for the matter-free case, since the neutral convention gives an empty sector), the Gauss sector has dimension `Lucas(L) + 2` and its zero-winding part is exactly the PXP constrained chain at zero detuning (basis bijection; spectra agree to 1e-13). The gap converges to `Δ₁(∞) = 0.9681883 λ` from `L = 4` to `20` with exponential finite-size corrections (`ξ_gap = 1.68` columns, consistent with correlation lengths 1.5 to 1.6): constant, not `1/L`, not `e^{−L}`; the ground state is unique and short-ranged; winding sectors have `H = 0` and sit `0.60356 λL` above the ground state; the static two-charge potential is exactly linear, `σ = 0.6035 λ`, equal to the vacuum plaquette energy density. **The ring has no transverse direction, so this prices the electric excitation gap and says nothing for or against a three-dimensional photon.** The 3D question: the `2×2×L` tube oscillates with `L` parity (a commensuration effect, no fit), the `4³` Gauss sector has about 10²⁵ states, and the model is sign-problem-free, so quantum Monte Carlo is the route.

- `docs/THE_SPIN_HALF_LINK_RING_IS_GAPPED_AND_CONFINING_THE_PHOTON_QUESTION_NEEDS_THREE_DIMENSIONS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (330 lines)
- `scripts/spin_half_link_ring_gapped_electric_string_check_2026_09_03.py` (`TOTAL: PASS=24 FAIL=0`, 4 s; explicit Gauss bases, sparse Lanczos, deterministic start vector)
- `logs/runner-cache/spin_half_link_ring_gapped_electric_string_check_2026_09_03.txt`

## Boundary

- One geometry within budget; declared background convention; the 3D rows are not fits; no continuum; the PXP identification is a computed structural fact named as a plain pointer. Executor correction kept: `ξ_gap = 1.68` columns (the probe's 0.33 came from a fit including the reference point).

## Context

- Parents: PR #7893 (the coupling; its open item), `NO_PER_SITE_BOSONIC_CCR_THEOREM_NOTE_2026-05-02` (why this is the only axiom-legal carrier); the sister lane's Maxwell-germ PRs are priced accordingly. Owner-directed full-repository probe wave (2026-09-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
