### PR TITLE
science(light): compile the gauge law into physical neighbor roles

### DIFF
--- a/docs/U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,539 @@
+# A Role-Encoded Doubled Incidence Pattern Compiles the Gauge Measure Into One Nearest-Neighbor Site Law
+
+**Date:** 2026-09-03
+**Claim type:** bounded_theorem
+**Status authority:** independent audit only. This source note changes no
+audit verdict, TOE score, axiom, or approved primitive.
+**Direct parent:**
+[`U1_AUXILIARY_FACE_LOCAL_CONDITIONALS_UNCONDITIONAL_GAUGE_MEASURE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_AUXILIARY_FACE_LOCAL_CONDITIONALS_UNCONDITIONAL_GAUGE_MEASURE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+**Covariant-law comparison:**
+[`ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md`](ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md)
+**Internal/spatial-action boundary:**
+[`COLOR_ARENA_BONDED_PAIR_ADMISSIBILITY_CROSS_SITE_SURFACE_BOUNDED_THEOREM_NOTE_2026-07-06.md`](COLOR_ARENA_BONDED_PAIR_ADMISSIBILITY_CROSS_SITE_SURFACE_BOUNDED_THEOREM_NOTE_2026-07-06.md)
+**Runner:**
+[`scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py`](../scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py)
+**Cached receipt:**
+[`logs/runner-cache/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.txt`](../logs/runner-cache/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.txt)
+
+## Result up front
+
+Let `G=Z_N`, let `T:G->R_{>0}` be even, and use the universal-plus-matching
+face factor of the direct parent. There is a finite role-and-payload alphabet
+inside the one-site possibility domain and one site-independent conditional
+rule with these properties:
+
+1. Every physical site carries a role label `r in Z_2^3`. A candidate role is
+   supported exactly when each of its two neighbors along axis `i` carries
+   `r xor e_i`. The rule reads the six neighboring labels, not the site's
+   coordinates.
+2. The valid role configurations on an even periodic cubic lattice are
+   exactly the eight translates
+
+   ```text
+   r_s(x)=x mod 2 xor s,       s in Z_2^3.
+   ```
+
+   Translation permutes them transitively. Proper cubic rotations permute
+   their three role bits. Thus the law privileges no site or sector.
+3. Hamming-weight-zero and Hamming-weight-three roles have a unit payload.
+   Weight-one roles carry one oriented `Z_N` link value. Weight-two roles
+   carry the parent's face auxiliary `star union Z_N^4`.
+4. A face site's full conditional reads its four edge neighbors. An edge
+   site's full conditional reads its four face neighbors. The remaining two
+   neighbors only certify the role geometry. These are all physical
+   nearest-neighbor sites.
+5. In each role sector, summing every face auxiliary gives exactly
+
+   ```text
+   product_f T(Phi_f).
+   ```
+
+   The eight sectors have equal partition functions, so the finite covariant
+   joint law is their equal mixture. No face outcome is selected.
+6. The rule is covariant under translations, local `Z_N` gauge
+   transformations, and all 24 proper cubic rotations. A rotation reverses
+   an oriented link value when it reverses that link; evenness of `T` removes
+   the induced face-orientation sign.
+
+This closes the direct parent's **role geometry and physical nearest-neighbor
+incidence interface** for finite cyclic models. It also gives a positive
+answer to the possibility-state route left outside the two finite negative
+classes in PR #7880: a field site can carry its changing payload and a role
+label in the same local possibility. It does not contradict that PR. Its
+value-reading class erased the role of every free code site, and its
+state-reading class used a frustration-free projector kernel. This theorem
+uses neither restriction.
+
+The result remains a declared candidate Admissibility law. It does not derive
+the choice of `T` or the role/payload alphabet from the four axioms, identify
+the declared cubic relabeling with a canonical automorphism of `M_2(C)`, make
+all labels orthogonally readable on one qubit, provide Record-formation
+history, supply electric/time dynamics, or identify the gauge field with
+electromagnetism.
+
+## 1. The one-site alphabet
+
+For every role `r in Z_2^3`, define its payload set by Hamming weight:
+
+```text
+|r|=0:             {unit}                 vertex role,
+|r|=1:             Z_N                    edge role,
+|r|=2:             {star} union Z_N^4     face role,
+|r|=3:             {unit}                 cube role.
+```
+
+There are three edge orientations and three face orientations, so the total
+number of finite labels is
+
+```text
+A_N = 2 + 3N + 3(1+N^4) = 5+3N+3N^4.
+```
+
+An explicit set-level injection into `M_2(C)` is obtained by enumerating the
+labels `lambda_0,...,lambda_(A_N-1)` and sending
+
+```text
+lambda_k -> diag(k/A_N,1).
+```
+
+The matrices are distinct. This establishes possibility capacity, not a
+canonical physical encoding. If every label must be mutually orthogonal and
+readable, a composite needs at least `ceil(log2 A_N)` qubits: `6,10,14,18`
+for `N=2,4,8,16`. If microscopic sites are smaller than the composite field
+object, such an object may occupy many sites; the present one-site injection
+is only the literal finite-support model.
+
+The proper cubic group acts on the symbolic subalphabet by permuting role
+axes, face slots, and edge orientations, with inversion of an oriented group
+value when an axis reverses. The runner proves covariance under that declared
+action. The current axioms constrain covariance of the rule but do not supply
+an action tying spatial rotations to an internal `M_2(C)` automorphism. If a
+stronger implementation requires the declared permutation to arise from a
+specified algebra automorphism or an orthogonal spatial composite, that is a
+remaining compiler obligation.
+
+## 2. Roles arise from neighboring possibility labels
+
+For adjacent sites `x` and `x+/-e_i`, impose the hard local condition
+
+```text
+r(x+/-e_i)=r(x) xor e_i.
+```
+
+Given a supported six-neighbor shell, there is exactly one central role that
+satisfies these six equations. No absolute coordinate appears in the rule.
+Starting from `r(0)=s`, propagation along lattice edges gives
+
+```text
+r(x)=s xor (x mod 2).
+```
+
+Path order does not matter because bit flips commute. On an even periodic
+torus the result closes around every cycle, giving exactly eight sectors. On
+an odd periodic axis, going once around flips one bit and demands
+`r=r xor e_i`, so no valid periodic role field exists. That is a boundary
+condition on this period-two construction, not an obstruction on `Z^3`.
+
+Classifying by Hamming weight yields the doubled incidence geometry:
+
+| central role | six-neighbor census |
+|---|---|
+| vertex | six edges |
+| edge | two vertices and four faces |
+| face | four edges and two cubes |
+| cube | six faces |
+
+This is the point missed by treating a dynamical edge site as merely a free
+binary value. Its possibility is a pair `(role,payload)`. The payload may vary
+while its role component continues to transmit the incidence structure to
+both neighbors.
+
+## 3. The physical face boundary is one nearest-neighbor star
+
+Let a face role have ones on axes `i<j`. Its four edge-neighbor positions are
+ordered
+
+```text
+x-e_j,  x+e_i,  x+e_j,  x-e_i.
+```
+
+They carry respectively the coarse oriented links
+
+```text
+a_i^-, a_j^+, a_i^+, a_j^-.
+```
+
+Therefore the face curl is
+
+```text
+Phi_f=a_i^-+a_j^+-a_i^+-a_j^- mod N.
+```
+
+All four sites are one physical lattice step from the face site. Conversely,
+an edge role on axis `i` has exactly four adjacent face sites, at `x+/-e_j`
+for the two `j!=i`. Thus every factor that changes when an edge value changes
+is stored at one of that edge site's physical nearest neighbors.
+
+No `5x5x5` observation window is used. The longer-scale gauge square is
+represented by a radius-one incidence star because the physical lattice is
+finer than the gauge object.
+
+## 4. One fixed conditional rule
+
+First solve the role equations from the six neighbor labels. On a supported
+shell this gives one role. Apply the following payload branch:
+
+- **vertex or cube:** the unit payload has probability one;
+- **face:** use the direct parent's two supported probabilities
+
+  ```text
+  Pr(star|boundary)=epsilon/T(Phi),
+  Pr(boundary|boundary)=1-epsilon/T(Phi),
+  epsilon=(1/2)min T;
+  ```
+
+- **edge:** if all four adjacent face auxiliaries are `star`, use the uniform
+  law on `Z_N`; otherwise the matching tuples require one common edge value,
+  which has probability one.
+
+Conflicting tuple demands and malformed role shells have zero probability in
+the joint law below. A uniform distribution over the appropriate finite
+alphabet defines a covariant total fallback there without altering any
+supported conditional.
+
+The rule is one conditional schema, not four coordinate-indexed laws. Which
+branch applies is determined by the neighbor-carried role condition. It is
+site-independent, reads only the six nearest neighbors, and varies in three
+separate ways: different shells select different roles, face probabilities
+vary with curl, and edge probabilities switch between uniform and fixed.
+
+## 5. Compatible finite joint law
+
+Let `C(r_x,r_y)` be one when adjacent roles differ in the bit for their edge
+axis and zero otherwise. Define on an even finite torus
+
+```text
+mu(r,ell,h) proportional to
+  [product_(nearest-neighbor pairs) C(r_x,r_y)]
+  [product_(face-role sites f) F_f(h_f;ell_boundary)].
+```
+
+In a valid role sector, varying a face payload changes only its own `F_f`.
+Varying an edge payload changes only the four `F_f` factors held by its face
+neighbors. Varying a role away from the shell-determined value kills a local
+`C` factor. The one-site full conditionals of `mu` are exactly the rule in
+section 4.
+
+For fixed roles and links, distributivity over the face auxiliaries gives
+
+```text
+sum_h product_f F_f = product_f T(Phi_f).
+```
+
+The direct parent proves connected payload support inside each role sector.
+The eight role sectors are disconnected by one-site supported moves, but they
+are related transitively by translations and have identical partition
+functions. The normalized factor law above therefore gives them equal mass.
+More generally, the displayed full conditionals determine the measure inside
+each sector, and translation covariance fixes the eight relative constants.
+
+In an infinite-volume limit, a pure translated sector may be selected as a
+spontaneously broken phase. The finite law and its rule privilege none.
+
+## 6. Symmetries
+
+### Translation
+
+Translating all sites by `a` maps sector `s` to `s xor (a mod 2)`. Link
+orientations and boundary order are unchanged, so every face factor is
+unchanged. The runner checks all 64 translations in all eight sectors on the
+`4x4x4` physical torus.
+
+### Gauge
+
+An edge midpoint on axis `i` connects vertex-role sites `x-e_i` and `x+e_i`.
+For a vertex potential `lambda`, set
+
+```text
+ell_i(x) -> ell_i(x)+lambda(x+e_i)-lambda(x-e_i).
+```
+
+The four vertex terms cancel around every face. Matching tuples transform
+with their edge values and `star` is fixed. The runner checks every face of 64
+sector-field pairs under two nonconstant local gauge transformations.
+
+### Proper cubic rotation
+
+A signed axis permutation sends an edge midpoint on old axis `i` to the new
+axis and sends its value to `+ell` or `-ell` according to orientation. It
+permutes a face's four slots. Its curl is the old curl or its negative, and
+`T(-Phi)=T(Phi)`. The runner checks all 24 rotations in every sector, then
+checks all `256` `Z_4` boundaries and all `257` face auxiliary labels under
+each rotation. Both zero factors and the two supported factors covary.
+
+## 7. Relation to the earlier two finite negatives
+
+PR #7880 tested two narrower classes.
+
+1. Its value-reading rule treated code sites as arbitrary binary values. To
+   accept all intended code fillings, its maximal rule had to forget which
+   free value occupied which role. Rival period-collapsed patterns then fit.
+2. Its possibility-state rule was a frustration-free projector complement.
+   The local kernel had to contain every intended role state and therefore
+   contained linear superpositions that became global junk.
+
+The present rule stores a classical role label alongside every changing
+payload and uses conditional probabilities with hard adjacency support. A
+code site is not role-free, and the accepted set is not a linear kernel. The
+eight supported role fields are proved exactly by propagation from one site.
+Accordingly this is a positive member of an open class named by #7880, not a
+refutation of either theorem in that PR.
+
+The scientific lesson is useful beyond this gauge model: information can be
+carried through a site by its possibility state even when another component
+of that possibility remains dynamical. “Free payload” does not imply “no
+role information.”
+
+## 8. What this changes in the TOE route
+
+The constructive light/action chain is now
+
+```text
+neighbor-varying compact Record distribution
+ -> positive even overlap kernel
+ -> unconditional auxiliary gauge measure
+ -> role-encoded physical nearest-neighbor conditional law
+ -> positive magnetic Maxwell germ and two weak-field transverse modes.
+```
+
+Before this theorem, the third line lived on an abstract doubled edge/face
+factor graph. It was open whether that graph could be made from the physical
+site possibilities without a nonlocal coordinate-keyed rule. The role labels
+and their six-neighbor propagation provide that finite compiler.
+
+The former combined compiler wall should now be split:
+
+- **closed here:** coordinate-free period-two role geometry, physical
+  nearest-neighbor incidence, supported local full conditionals, translation
+  and proper-cubic label covariance, and finite `M_2(C)` set capacity;
+- **still open:** a canonical algebra-automorphism or orthogonal-composite
+  implementation of the internal label action, if that stronger standard is
+  required for physical readability.
+
+The larger live walls are unchanged:
+
+- why the physical Admissibility law selects this `T` and this auxiliary
+  family rather than another allowed local distribution;
+- how Records form from, and experimentally sample, the static law;
+- the electric/time law and relative normalization;
+- the electromagnetic dictionary; and
+- compact interacting plus simultaneous thermodynamic, continuum, and
+  quantum control.
+
+No axiom update is requested by this result. The current Admissibility axiom
+deliberately leaves its extensional distribution unspecified, so a declared
+candidate law is allowed but not selected.
+
+## 9. Executable evidence
+
+The runner reports `TOTAL: PASS=23 FAIL=0`. It verifies:
+
+- exactly eight period-two role fields on the even exhibit and unique
+  propagation from the origin role;
+- the odd-period frustration control;
+- every role and every one of the `512` site shells on the `4x4x4` torus;
+- the full `8+24+24+8` incidence census in all sectors;
+- exact physical-face/coarse-curl equality for four complete link fields per
+  sector;
+- unconditional auxiliary marginalization and equal sector gauge products;
+- all `256` face conditionals and `3,072` supported edge masks;
+- gauge covariance, all `512` sector-translation pairs, all `192`
+  sector-rotation pairs, and every auxiliary label under every rotation; and
+- all `262,144` assignments of the six neighboring role labels, of which
+  exactly eight admit one central role and all others invoke the total
+  fallback; and
+- the exact finite alphabet counts, `M_2(C)` injections, and orthogonal costs.
+
+The general role classification is proved by path propagation, and the
+general face marginal and within-sector compatibility are inherited from the
+direct parent's finite theorem. The finite runner exhausts the declared local
+and symmetry blocks rather than claiming an infinite interacting limit.
+
+## No-Go Discipline Gate
+
+This positive theorem carries four narrowed negative boundaries: an odd
+periodic axis cannot support this parity construction; #7880's two classes do
+not already contain this rule; local full conditionals alone do not fix
+relative weights between disconnected role sectors without covariance; and a
+set injection is not an orthogonal or algebra-automorphism compiler. The gate
+below stress-tests only those statements.
+
+### N1 — Alternative route enumeration
+
+| Route | Mechanism and outcome |
+|---|---|
+| coordinate-keyed roles | Assign parity from absolute coordinates. It makes the geometry but privileges an origin and is not used. |
+| binary pinned/free values | Preserve arbitrary code fillings while reading only seven binary values. PR #7880 finds finite period-collapse junk in its declared samples. |
+| frustration-free role kernels | Put intended role states in one star-kernel subspace. PR #7880 finds superposition junk on its declared clusters. |
+| role plus payload possibility | Carry a discrete role component beside the changing payload and enforce neighbor bit flips. **Positive here:** exactly eight sectors. |
+| homogeneous vertex storage | Store three outgoing links at every vertex. It avoids roles, but a plaquette factor makes a site's full conditional read diagonal co-neighbors unless further auxiliaries are introduced. This route remains live with a different factorization. |
+| orthogonal spatial composite | Encode the finite role/payload alphabet across enough qubits and let rotations permute the composite. Capacity is counted here; a nearest-neighbor composite compiler remains live. |
+| canonical internal action | Seek an embedding whose cubic relabeling is induced by a specified `M_2(C)` algebra action. Not required by the literal finite set model and still live as a stronger compiler. |
+
+The positive route changes the state alphabet and rule class, rather than
+claiming either finite negative was wrongly computed.
+
+### N2 — Wall-independence audit
+
+After the role/incidence compiler, promotion to a physical source-free quantum
+electromagnetic theory still has these inputs:
+
+```text
+W1 = extensional law selection,
+W2 = strong internal/orthogonal implementation if required,
+W3 = Record formation and sampling interpretation,
+W4 = electric/time dynamics and relative normalization,
+W5 = electromagnetic field/readout dictionary,
+W6 = compact interacting and simultaneous-limit control.
+```
+
+| Pair | `Wi -> Wj`? | `Wj -> Wi`? | Independent? |
+|---|---:|---:|---:|
+| W1, W2 | no | no | yes |
+| W1, W3 | no | no | yes |
+| W1, W4 | no | no | yes |
+| W1, W5 | no | no | yes |
+| W1, W6 | no | no | yes |
+| W2, W3 | no | no | yes |
+| W2, W4 | no | no | yes |
+| W2, W5 | no | no | yes |
+| W2, W6 | no | no | yes |
+| W3, W4 | no | no | yes |
+| W3, W5 | no | no | yes |
+| W3, W6 | no | no | yes |
+| W4, W5 | no | no | yes |
+| W4, W6 | no | no | yes |
+| W5, W6 | no | no | yes |
+
+A matrix implementation does not select a probability table; formation does
+not supply a wave operator; dynamics does not identify electromagnetism; and
+a dictionary does not prove the interacting limit.
+
+### N3 — Hidden-wall scan
+
+“Declared,” “candidate,” and “supplied” mark `G`, `T`, the finite alphabet,
+the symbolic cubic action, and the off-support fallback. The role is carried
+by a possibility label; it is not inferred from an unreadable Record. The
+set injection is not called an orthogonal encoding. Equal sector mass follows
+from the displayed finite factor law and translation symmetry, not from an
+unstated ergodicity claim. No dynamics, canonical quantization, measurement,
+or continuum interchange is smuggled into the compiler theorem.
+
+### N4 — Residual matching
+
+| Surface | Residual | Match here |
+|---|---|---|
+| direct parent | abstract link/face roles and physical compiler | **exact:** role geometry and physical nearest-neighbor incidence |
+| PR #7880 | free-code value rules and projector state rules admit finite junk | **no contradiction:** this rule carries a separate role component and is not a kernel projector |
+| minimal axioms | one covariant varying nearest-neighbor distribution, values unspecified | **shape match:** one explicit candidate law, no selection imported |
+| covariant-Q8 comparison | finite-support laws can witness the Admissibility contract without becoming the physical law | **method match:** same bounded-model status |
+| internal/spatial-action boundary | axioms supply no spatial action on `M_2(C)` | **exact residual:** symbolic covariance proved; canonical internal action not claimed |
+| open PR #7903 | finite matter/gauge join lacks an interacting photon | **no closure:** this theorem supplies a magnetic probability law, not that finite spectrum |
+
+The proof stands after dropping both open-PR comparisons.
+
+### N5 — Rhetoric and resolution audit
+
+“Exactly eight” is a classification of the displayed neighbor-bit equations
+on an even torus. “No odd-period solution” is only for that parity
+construction. “Nearest neighbor” names the physical radius-one incidence
+shell actually enumerated. No general role-marking impossibility, unique
+physical law, or full photon theory is claimed.
+
+The cached stdout supplies:
+
+```text
+per_element: every finite role label, Z4 face boundary, and auxiliary label is checked under its declared transformations
+per_site: all 512 supported physical shells and all 3072 edge masks use only six nearest neighbors
+per_mode: checked and not executed — the compiler preserves but does not recompute the parent photon Hessian
+per_block: all eight L4 role sectors, 64 translations, and 24 proper cubic rotations are checked
+lattice_wide: four full link fields per sector are marginalized and compared across the 4x4x4 physical torus
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The current primitive registry and approved premise sources were checked. The
+scale-reference primitive fixes units only. The kinetic-isotropy primitive
+does not select this static factor law or compile its labels. The
+realized-state primitive is pointwise evaluation, not a probability selector.
+
+Live positive continuations are:
+
+- build the orthogonal spatial-composite version and verify that every direct
+  dependence remains nearest-neighbor;
+- find a cubic-equivariant algebraic encoding for the symbolic label action;
+- combine the same role compiler with temporal/electric local factors;
+- derive the conditional table from a smaller consistency principle; or
+- connect its static measure to a fresh-site Record-formation experiment.
+
+### N7 — Steelman
+
+A hostile reviewer can say the role label is simply the old coordinate parity
+written into the state and therefore explains no physics. The exact answer is
+that it is not coordinate-keyed by the law: all eight offsets are supported
+equally, translations permute them, and the local shell determines every
+role. It is a spontaneous period-two order parameter. The reviewer is still
+right that selecting this ordered phase and this payload law is model input,
+not an axiom derivation. That remaining selection wall is stated rather than
+renamed.
+
+The reviewer can also reject the set injection as too weak for a physical
+qubit readout. The note accepts that stronger reading, reports the exact
+composite cost, and leaves the covariant orthogonal compiler open.
+
+### N8 — Cross-cycle echo
+
+PR #7880 is the direct echo. Its own boundary explicitly leaves open rules on
+pre-Record possibility states other than projector complements. This theorem
+occupies that opening and preserves its two finite results. The separate
+internal/spatial-action note warns that lattice symmetry does not itself
+supply an internal `M_2(C)` action; this theorem therefore does not turn its
+declared label permutation into axiom content.
+
+**Gate result:** PASS for the four scoped boundaries. Seven materially
+different routes were separated, the positive role-plus-payload route was
+executed, the two earlier negatives were residual-matched rather than
+generalized, and both stronger internal compilers remain live.
+
+## Falsifiers
+
+The finite compiler theorem fails if any of the following occurs:
+
+- a valid six-neighbor shell admits zero or more than one central role;
+- an even torus admits a role field outside the eight propagated sectors;
+- a face or edge payload reads a site beyond its six physical neighbors;
+- the physical boundary curl differs from the coarse plaquette curl;
+- summing all face auxiliaries fails to recover `T(Phi)`;
+- translated sectors have unequal gauge products or partition functions;
+- a local gauge transformation changes a face curl;
+- a proper cubic rotation changes a local factor after its declared label
+  relabeling;
+- the one-site finite alphabet does not inject into `M_2(C)`; or
+- the displayed one-site full conditionals disagree with the finite joint
+  factor law.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=23 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15764,
- "node_count": 5564,
+ "edge_count": 15768,
+ "node_count": 5565,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18725,6 +18725,10 @@
   "u1_representation_positive_registration_kernel_to_maxwell_germ_bounded_theorem_note_2026-09-03": {
    "deps_hash": "f8af5b681979",
    "out_degree": 3
+  },
+  "u1_role_encoded_doubled_incidence_nearest_neighbor_gauge_law_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "e968524e868f",
+   "out_degree": 4
   },
   "u4_closes_under_qubit_reframe_narrow_theorem_note_2026-05-20": {
    "deps_hash": "0b48e244e1f7",

--- a/logs/runner-cache/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.txt
+++ b/logs/runner-cache/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py
+runner_sha256: abb25f97fe7fc3fb7d559fab7c972ade4553c339463ffb7c8c1f4caab190458f
+input_fingerprint_sha256: 5aed4a7934adb4cacf41832f839024e70a8b4a2ef55f727b53b69443b35d326e
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 12.01
+status: ok
+----- stdout -----
+[PASS] 01 the parent even Z4 face weight and its canonical positive split are pinned
+[PASS] 02 the even physical torus carries exactly the eight translated parity-role exhibits
+[PASS] 03 one coordinate-free six-neighbor rule uniquely recovers every local role
+[PASS] 04 an origin role propagates uniquely, proving there are no further valid role sectors
+[PASS] 05 odd periodic lengths are the explicit frustration control for the parity-role sector
+[PASS] 06 every sector has the 8+24+24+8 doubled-incidence role census
+[PASS] 07 all 512 site shells have the vertex-edge-face-cube incidence census
+[PASS] 08 every face payload reads exactly four physical nearest-neighbor edge sites
+[PASS] 09 every edge payload reads exactly four physical nearest-neighbor face sites
+[PASS] 10 the physical nearest-neighbor boundary order equals the coarse plaquette curl
+[PASS] 11 summing each face payload unconditionally returns its parent plaquette weight
+[PASS] 12 all eight translated role sectors give identical gauge products for four fields
+[PASS] 13 the face branch is normalized, strictly supported, and varies with four neighbors
+[PASS] 14 all 3072 supported edge contexts are uniform or fixed by adjacent faces
+[PASS] 15 all 64 sector-field pairs preserve every face curl under two local gauges
+[PASS] 16 all 512 sector-translation pairs covary and permute the eight sectors transitively
+[PASS] 17 all 24 proper cubic rotations covary every role in all eight sectors
+[PASS] 18 all 192 sector-rotation pairs preserve the complete even gauge product
+[PASS] 19 every face auxiliary label covaries under every proper cubic rotation
+[PASS] 20 all 262144 role shells have either one supported role or the total fallback
+[PASS] 21 a uniform covariant fallback makes the rule total off the joint support
+[PASS] 22 all role and payload labels inject distinctly into the one-site M2(C) domain
+[PASS] 23 fully orthogonal role-payload readout has the explicit 6,10,14,18-qubit costs
+per_element: every finite role label, Z4 face boundary, and auxiliary label is checked under its declared transformations
+per_site: all 512 supported physical shells and all 3072 edge masks use only six nearest neighbors
+per_mode: checked and not executed — the compiler preserves but does not recompute the parent photon Hessian
+per_block: all eight L4 role sectors, 64 translations, and 24 proper cubic rotations are checked
+lattice_wide: four full link fields per sector are marginalized and compared across the 4x4x4 physical torus
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py
+++ b/scripts/u1_role_encoded_nearest_neighbor_gauge_law_2026_09_03.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+"""Exact checks for a role-encoded nearest-neighbor gauge-law compiler.
+
+The physical lattice is Z^3.  A local possibility carries a parity-role label
+in Z2^3 and a role-dependent payload.  Nearest neighbors flip exactly the role
+bit associated with their separation axis.  On an even periodic torus this
+has eight translated sectors.  Edge roles carry Z_N link values; face roles
+carry the universal-or-matching auxiliary from the parent gauge measure.
+
+The resulting full conditionals use only the six physical nearest neighbors.
+This runner checks the role geometry, gauge/translation/cubic covariance,
+unconditional marginalization, local conditionals, and finite M2(C) capacity.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from fractions import Fraction
+from typing import Iterable
+
+from u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03 import (
+    encode_tuple,
+    face_conditionals,
+    face_factor,
+    face_marginal,
+    tuple_flux,
+)
+from u1_record_face_likelihood_spatial_gauge_photon_germ_2026_09_03 import (
+    proper_cubic_rotations,
+    rotate_site,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/u1_auxiliary_face_local_conditionals_gauge_measure_2026_09_03.py",
+)
+
+
+Coord = tuple[int, int, int]
+Role = tuple[int, int, int]
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def sites(size: int) -> Iterable[Coord]:
+    return itertools.product(range(size), repeat=3)
+
+
+def add_axis(point: Coord, axis: int, step: int, size: int) -> Coord:
+    result = list(point)
+    result[axis] = (result[axis] + step) % size
+    return tuple(result)
+
+
+def translate_site(point: Coord, displacement: Coord, size: int) -> Coord:
+    return tuple((point[axis] + displacement[axis]) % size for axis in range(3))
+
+
+def role_bits(point: Coord, sector: Role) -> Role:
+    return tuple((point[axis] + sector[axis]) % 2 for axis in range(3))
+
+
+def flip_role(role: Role, axis: int) -> Role:
+    result = list(role)
+    result[axis] ^= 1
+    return tuple(result)
+
+
+def role_kind(role: Role) -> str:
+    names = {0: "vertex", 1: "edge", 2: "face", 3: "cube"}
+    return names[sum(role)]
+
+
+def edge_axis(role: Role) -> int:
+    assert sum(role) == 1
+    return role.index(1)
+
+
+def face_axes(role: Role) -> tuple[int, int]:
+    assert sum(role) == 2
+    return tuple(axis for axis, bit in enumerate(role) if bit)  # type: ignore[return-value]
+
+
+def role_shell(point: Coord, sector: Role, size: int) -> dict[tuple[int, int], Role]:
+    return {
+        (axis, sign): role_bits(add_axis(point, axis, sign, size), sector)
+        for axis in range(3)
+        for sign in (-1, 1)
+    }
+
+
+def compatible_roles(shell: dict[tuple[int, int], Role]) -> tuple[Role, ...]:
+    candidates = []
+    for candidate in itertools.product((0, 1), repeat=3):
+        if all(
+            shell[(axis, sign)] == flip_role(tuple(candidate), axis)
+            for axis in range(3)
+            for sign in (-1, 1)
+        ):
+            candidates.append(tuple(candidate))
+    return tuple(candidates)
+
+
+def face_boundary_sites(point: Coord, role: Role, size: int) -> tuple[Coord, ...]:
+    """Boundary order has curl first+second-third-fourth."""
+
+    first_axis, second_axis = face_axes(role)
+    return (
+        add_axis(point, second_axis, -1, size),
+        add_axis(point, first_axis, 1, size),
+        add_axis(point, second_axis, 1, size),
+        add_axis(point, first_axis, -1, size),
+    )
+
+
+def incident_faces(point: Coord, role: Role, size: int) -> tuple[tuple[Coord, int], ...]:
+    axis = edge_axis(role)
+    result = []
+    for other_axis in range(3):
+        if other_axis == axis:
+            continue
+        for sign in (-1, 1):
+            face = add_axis(point, other_axis, sign, size)
+            face_role = flip_role(role, other_axis)
+            boundary = face_boundary_sites(face, face_role, size)
+            result.append((face, boundary.index(point)))
+    return tuple(result)
+
+
+def coarse_coordinate(vertex: Coord, sector: Role, size: int) -> Coord:
+    assert all((vertex[axis] - sector[axis]) % 2 == 0 for axis in range(3))
+    return tuple(((vertex[axis] - sector[axis]) % size) // 2 for axis in range(3))
+
+
+def abstract_link_value(axis: int, coarse: Coord, group_order: int, variant: int) -> int:
+    x, y, z = coarse
+    formulas = (
+        0,
+        axis + x + 2 * y + 3 * z,
+        2 * axis + x * y + y * z + z * x + x,
+        (axis + 1) * (x + 1) + (axis + 2) * y + (axis + 3) * z,
+    )
+    return formulas[variant] % group_order
+
+
+def link_field(size: int, sector: Role, group_order: int, variant: int) -> dict[Coord, int]:
+    result: dict[Coord, int] = {}
+    for point_raw in sites(size):
+        point = tuple(point_raw)
+        role = role_bits(point, sector)
+        if role_kind(role) != "edge":
+            continue
+        axis = edge_axis(role)
+        tail = add_axis(point, axis, -1, size)
+        coarse = coarse_coordinate(tail, sector, size)
+        result[point] = abstract_link_value(axis, coarse, group_order, variant)
+    return result
+
+
+def boundary_values(
+    point: Coord,
+    role: Role,
+    links: dict[Coord, int],
+    size: int,
+) -> tuple[int, int, int, int]:
+    return tuple(links[edge] for edge in face_boundary_sites(point, role, size))  # type: ignore[return-value]
+
+
+def face_weight_product(
+    size: int,
+    sector: Role,
+    links: dict[Coord, int],
+    overlap: tuple[int, ...],
+) -> int:
+    product = 1
+    for point_raw in sites(size):
+        point = tuple(point_raw)
+        role = role_bits(point, sector)
+        if role_kind(role) == "face":
+            boundary = boundary_values(point, role, links, size)
+            product *= overlap[tuple_flux(boundary, len(overlap))]
+    return product
+
+
+def vertex_potential(
+    size: int, sector: Role, group_order: int, variant: int
+) -> dict[Coord, int]:
+    result = {}
+    for point_raw in sites(size):
+        point = tuple(point_raw)
+        if role_kind(role_bits(point, sector)) != "vertex":
+            continue
+        x, y, z = coarse_coordinate(point, sector, size)
+        if variant == 0:
+            value = x + 2 * y + z
+        else:
+            value = x * y + 2 * z + variant * x
+        result[point] = value % group_order
+    return result
+
+
+def gauge_transform_links(
+    links: dict[Coord, int],
+    sector: Role,
+    potential: dict[Coord, int],
+    size: int,
+    group_order: int,
+) -> dict[Coord, int]:
+    transformed = {}
+    for point, value in links.items():
+        role = role_bits(point, sector)
+        axis = edge_axis(role)
+        tail = add_axis(point, axis, -1, size)
+        head = add_axis(point, axis, 1, size)
+        transformed[point] = (
+            value + potential[head] - potential[tail]
+        ) % group_order
+    return transformed
+
+
+def permute_role(role: Role, permutation: tuple[int, ...]) -> Role:
+    result = [0, 0, 0]
+    for old_axis in range(3):
+        result[permutation[old_axis]] = role[old_axis]
+    return tuple(result)
+
+
+def rotated_sector(sector: Role, permutation: tuple[int, ...]) -> Role:
+    return permute_role(sector, permutation)
+
+
+def rotate_midpoint_links(
+    links: dict[Coord, int],
+    sector: Role,
+    permutation: tuple[int, ...],
+    signs: tuple[int, ...],
+    size: int,
+    group_order: int,
+) -> tuple[Role, dict[Coord, int]]:
+    new_sector = rotated_sector(sector, permutation)
+    transformed = {}
+    for point, value in links.items():
+        old_axis = edge_axis(role_bits(point, sector))
+        rotated_point = rotate_site(point, permutation, signs, size)
+        transformed[rotated_point] = signs[old_axis] * value % group_order
+    return new_sector, transformed
+
+
+def translate_midpoint_links(
+    links: dict[Coord, int],
+    sector: Role,
+    displacement: Coord,
+    size: int,
+) -> tuple[Role, dict[Coord, int]]:
+    new_sector = tuple(
+        (sector[axis] + displacement[axis]) % 2 for axis in range(3)
+    )
+    return new_sector, {
+        translate_site(point, displacement, size): value
+        for point, value in links.items()
+    }
+
+
+def rotate_face_tuple(
+    face: Coord,
+    face_role: Role,
+    values: tuple[int, int, int, int],
+    permutation: tuple[int, ...],
+    signs: tuple[int, ...],
+    size: int,
+    group_order: int,
+) -> tuple[Coord, Role, tuple[int, int, int, int]]:
+    mapped_edges: dict[Coord, int] = {}
+    for edge, value in zip(face_boundary_sites(face, face_role, size), values):
+        old_axis = edge_axis(role_bits(edge, (0, 0, 0)))
+        mapped_edges[rotate_site(edge, permutation, signs, size)] = (
+            signs[old_axis] * value
+        ) % group_order
+    new_face = rotate_site(face, permutation, signs, size)
+    new_role = permute_role(face_role, permutation)
+    new_values = tuple(
+        mapped_edges[edge]
+        for edge in face_boundary_sites(new_face, new_role, size)
+    )
+    return new_face, new_role, new_values  # type: ignore[return-value]
+
+
+def edge_conditional_weights(
+    edge: Coord,
+    sector: Role,
+    links: dict[Coord, int],
+    tuple_mask: int,
+    overlap: tuple[int, ...],
+    epsilon: int,
+    size: int,
+) -> tuple[int, ...]:
+    group_order = len(overlap)
+    edge_role = role_bits(edge, sector)
+    faces = incident_faces(edge, edge_role, size)
+    original_boundaries = {
+        face: boundary_values(face, role_bits(face, sector), links, size)
+        for face, _position in faces
+    }
+    weights = []
+    for candidate in range(group_order):
+        candidate_links = dict(links)
+        candidate_links[edge] = candidate
+        product = 1
+        for face_index, (face, _position) in enumerate(faces):
+            face_role = role_bits(face, sector)
+            candidate_boundary = boundary_values(face, face_role, candidate_links, size)
+            if tuple_mask & (1 << face_index):
+                auxiliary = 1 + encode_tuple(original_boundaries[face], group_order)
+            else:
+                auxiliary = 0
+            product *= face_factor(
+                auxiliary, candidate_boundary, overlap, epsilon
+            )
+        weights.append(product)
+    return tuple(weights)
+
+
+def finite_alphabet(group_order: int) -> tuple[tuple[Role, object], ...]:
+    labels: list[tuple[Role, object]] = []
+    for role_raw in itertools.product((0, 1), repeat=3):
+        role = tuple(role_raw)
+        kind = role_kind(role)
+        if kind in ("vertex", "cube"):
+            labels.append((role, "unit"))
+        elif kind == "edge":
+            labels.extend((role, value) for value in range(group_order))
+        else:
+            labels.append((role, "star"))
+            labels.extend(
+                (role, tuple(values))
+                for values in itertools.product(range(group_order), repeat=4)
+            )
+    return tuple(labels)
+
+
+def m2_injection_is_distinct(group_order: int) -> bool:
+    labels = finite_alphabet(group_order)
+    count = len(labels)
+    matrices = {
+        ((Fraction(index, count), Fraction(0)), (Fraction(0), Fraction(1)))
+        for index, _label in enumerate(labels)
+    }
+    return len(matrices) == count
+
+
+def main() -> int:
+    checks = Checks()
+    size = 4
+    group_order = 4
+    overlap = (85, 50, 40, 50)
+    epsilon = min(overlap) // 2
+    sectors = tuple(itertools.product((0, 1), repeat=3))
+    rotations = proper_cubic_rotations()
+
+    checks.check(
+        overlap[1] == overlap[-1] and epsilon == 20,
+        "the parent even Z4 face weight and its canonical positive split are pinned",
+    )
+
+    distinct_role_fields = {
+        tuple(role_bits(tuple(point), tuple(sector)) for point in sites(size))
+        for sector in sectors
+    }
+    checks.check(
+        len(sectors) == 8 and len(distinct_role_fields) == 8,
+        "the even physical torus carries exactly the eight translated parity-role exhibits",
+    )
+
+    shell_rule_ok = True
+    role_variants = set()
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        for point_raw in sites(size):
+            point = tuple(point_raw)
+            candidates = compatible_roles(role_shell(point, sector, size))
+            shell_rule_ok = shell_rule_ok and candidates == (role_bits(point, sector),)
+            role_variants.add(candidates[0])
+    checks.check(
+        shell_rule_ok and len(role_variants) == 8,
+        "one coordinate-free six-neighbor rule uniquely recovers every local role",
+    )
+
+    propagation_ok = True
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        origin_role = role_bits((0, 0, 0), sector)
+        for point_raw in sites(size):
+            point = tuple(point_raw)
+            propagated = tuple(
+                (origin_role[axis] + point[axis]) % 2 for axis in range(3)
+            )
+            propagation_ok = propagation_ok and propagated == role_bits(point, sector)
+    checks.check(
+        propagation_ok,
+        "an origin role propagates uniquely, proving there are no further valid role sectors",
+    )
+
+    odd_size_fails = True
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        odd_size_fails = odd_size_fails and any(
+            compatible_roles(role_shell(tuple(point), sector, 3))
+            != (role_bits(tuple(point), sector),)
+            for point in sites(3)
+        )
+    checks.check(
+        odd_size_fails,
+        "odd periodic lengths are the explicit frustration control for the parity-role sector",
+    )
+
+    census_ok = True
+    neighbor_census_ok = True
+    expected_neighbors = {
+        "vertex": {"edge": 6},
+        "edge": {"vertex": 2, "face": 4},
+        "face": {"edge": 4, "cube": 2},
+        "cube": {"face": 6},
+    }
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        counts = {kind: 0 for kind in ("vertex", "edge", "face", "cube")}
+        for point_raw in sites(size):
+            point = tuple(point_raw)
+            kind = role_kind(role_bits(point, sector))
+            counts[kind] += 1
+            neighbor_counts: dict[str, int] = {}
+            for neighbor_role in role_shell(point, sector, size).values():
+                neighbor_kind = role_kind(neighbor_role)
+                neighbor_counts[neighbor_kind] = neighbor_counts.get(neighbor_kind, 0) + 1
+            neighbor_census_ok = neighbor_census_ok and neighbor_counts == expected_neighbors[kind]
+        census_ok = census_ok and counts == {
+            "vertex": 8,
+            "edge": 24,
+            "face": 24,
+            "cube": 8,
+        }
+    checks.check(census_ok, "every sector has the 8+24+24+8 doubled-incidence role census")
+    checks.check(
+        neighbor_census_ok,
+        "all 512 site shells have the vertex-edge-face-cube incidence census",
+    )
+
+    face_geometry_ok = True
+    edge_geometry_ok = True
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        for point_raw in sites(size):
+            point = tuple(point_raw)
+            role = role_bits(point, sector)
+            if role_kind(role) == "face":
+                boundary = face_boundary_sites(point, role, size)
+                face_geometry_ok = face_geometry_ok and (
+                    len(set(boundary)) == 4
+                    and all(role_kind(role_bits(edge, sector)) == "edge" for edge in boundary)
+                    and all(
+                        sum(a != b for a, b in zip(point, edge)) == 1
+                        for edge in boundary
+                    )
+                )
+            elif role_kind(role) == "edge":
+                faces = incident_faces(point, role, size)
+                edge_geometry_ok = edge_geometry_ok and (
+                    len(faces) == 4
+                    and len({face for face, _position in faces}) == 4
+                    and all(role_kind(role_bits(face, sector)) == "face" for face, _ in faces)
+                )
+    checks.check(
+        face_geometry_ok,
+        "every face payload reads exactly four physical nearest-neighbor edge sites",
+    )
+    checks.check(
+        edge_geometry_ok,
+        "every edge payload reads exactly four physical nearest-neighbor face sites",
+    )
+
+    abstract_curl_ok = True
+    sector_products_ok = True
+    marginal_ok = True
+    for variant in range(4):
+        products = []
+        for sector_raw in sectors:
+            sector = tuple(sector_raw)
+            links = link_field(size, sector, group_order, variant)
+            products.append(face_weight_product(size, sector, links, overlap))
+            for point_raw in sites(size):
+                point = tuple(point_raw)
+                role = role_bits(point, sector)
+                if role_kind(role) != "face":
+                    continue
+                boundary = boundary_values(point, role, links, size)
+                first_axis, second_axis = face_axes(role)
+                lower_vertex = add_axis(
+                    add_axis(point, first_axis, -1, size),
+                    second_axis,
+                    -1,
+                    size,
+                )
+                coarse = coarse_coordinate(lower_vertex, sector, size)
+                coarse_first = list(coarse)
+                coarse_first[first_axis] = (coarse_first[first_axis] + 1) % (size // 2)
+                coarse_second = list(coarse)
+                coarse_second[second_axis] = (coarse_second[second_axis] + 1) % (size // 2)
+                expected = (
+                    abstract_link_value(first_axis, coarse, group_order, variant)
+                    + abstract_link_value(second_axis, tuple(coarse_first), group_order, variant)
+                    - abstract_link_value(first_axis, tuple(coarse_second), group_order, variant)
+                    - abstract_link_value(second_axis, coarse, group_order, variant)
+                ) % group_order
+                abstract_curl_ok = abstract_curl_ok and tuple_flux(boundary, group_order) == expected
+                marginal_ok = marginal_ok and face_marginal(
+                    boundary, overlap, epsilon
+                ) == overlap[expected]
+        sector_products_ok = sector_products_ok and len(set(products)) == 1
+    checks.check(
+        abstract_curl_ok,
+        "the physical nearest-neighbor boundary order equals the coarse plaquette curl",
+    )
+    checks.check(
+        marginal_ok,
+        "summing each face payload unconditionally returns its parent plaquette weight",
+    )
+    checks.check(
+        sector_products_ok,
+        "all eight translated role sectors give identical gauge products for four fields",
+    )
+
+    face_conditional_ok = True
+    face_probabilities = set()
+    for boundary_raw in itertools.product(range(group_order), repeat=4):
+        boundary = tuple(boundary_raw)
+        star_probability, matching_probability = face_conditionals(
+            boundary, overlap, epsilon
+        )
+        face_conditional_ok = face_conditional_ok and (
+            star_probability > 0
+            and matching_probability > 0
+            and star_probability + matching_probability == 1
+        )
+        face_probabilities.add(star_probability)
+    checks.check(
+        face_conditional_ok and len(face_probabilities) == 3,
+        "the face branch is normalized, strictly supported, and varies with four neighbors",
+    )
+
+    edge_conditionals_ok = True
+    edge_checks = 0
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        links = link_field(size, sector, group_order, 3)
+        for point in links:
+            for mask in range(16):
+                weights = edge_conditional_weights(
+                    point, sector, links, mask, overlap, epsilon, size
+                )
+                if mask == 0:
+                    edge_conditionals_ok = edge_conditionals_ok and (
+                        min(weights) > 0 and len(set(weights)) == 1
+                    )
+                else:
+                    edge_conditionals_ok = edge_conditionals_ok and (
+                        weights[links[point]] > 0
+                        and sum(weight > 0 for weight in weights) == 1
+                    )
+                edge_checks += 1
+    checks.check(
+        edge_conditionals_ok and edge_checks == 8 * 24 * 16,
+        "all 3072 supported edge contexts are uniform or fixed by adjacent faces",
+    )
+
+    gauge_ok = True
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        for field_variant in range(4):
+            links = link_field(size, sector, group_order, field_variant)
+            original_fluxes = []
+            for point_raw in sites(size):
+                point = tuple(point_raw)
+                role = role_bits(point, sector)
+                if role_kind(role) == "face":
+                    original_fluxes.append(
+                        tuple_flux(boundary_values(point, role, links, size), group_order)
+                    )
+            for gauge_variant in range(2):
+                transformed = gauge_transform_links(
+                    links,
+                    sector,
+                    vertex_potential(size, sector, group_order, gauge_variant),
+                    size,
+                    group_order,
+                )
+                transformed_fluxes = []
+                for point_raw in sites(size):
+                    point = tuple(point_raw)
+                    role = role_bits(point, sector)
+                    if role_kind(role) == "face":
+                        transformed_fluxes.append(
+                            tuple_flux(
+                                boundary_values(point, role, transformed, size),
+                                group_order,
+                            )
+                        )
+                gauge_ok = gauge_ok and transformed_fluxes == original_fluxes
+    checks.check(
+        gauge_ok,
+        "all 64 sector-field pairs preserve every face curl under two local gauges",
+    )
+
+    translation_ok = True
+    displacements = tuple(itertools.product(range(size), repeat=3))
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        links = link_field(size, sector, group_order, 2)
+        old_product = face_weight_product(size, sector, links, overlap)
+        for displacement_raw in displacements:
+            displacement = tuple(displacement_raw)
+            new_sector, translated = translate_midpoint_links(
+                links, sector, displacement, size
+            )
+            translation_ok = translation_ok and (
+                face_weight_product(size, new_sector, translated, overlap) == old_product
+                and all(
+                    role_bits(translate_site(tuple(point), displacement, size), new_sector)
+                    == role_bits(tuple(point), sector)
+                    for point in sites(size)
+                )
+            )
+    checks.check(
+        translation_ok,
+        "all 512 sector-translation pairs covary and permute the eight sectors transitively",
+    )
+
+    rotation_role_ok = len(rotations) == 24
+    rotation_factor_ok = True
+    for sector_raw in sectors:
+        sector = tuple(sector_raw)
+        links = link_field(size, sector, group_order, 1)
+        old_product = face_weight_product(size, sector, links, overlap)
+        for permutation, signs in rotations:
+            new_sector, rotated = rotate_midpoint_links(
+                links, sector, permutation, signs, size, group_order
+            )
+            rotation_factor_ok = rotation_factor_ok and (
+                face_weight_product(size, new_sector, rotated, overlap) == old_product
+            )
+            for point_raw in sites(size):
+                point = tuple(point_raw)
+                new_point = rotate_site(point, permutation, signs, size)
+                rotation_role_ok = rotation_role_ok and (
+                    role_bits(new_point, new_sector)
+                    == permute_role(role_bits(point, sector), permutation)
+                )
+    checks.check(
+        rotation_role_ok,
+        "all 24 proper cubic rotations covary every role in all eight sectors",
+    )
+    checks.check(
+        rotation_factor_ok,
+        "all 192 sector-rotation pairs preserve the complete even gauge product",
+    )
+
+    arbitrary_auxiliary_covariance = True
+    reference_face = (1, 1, 0)
+    reference_role = role_bits(reference_face, (0, 0, 0))
+    auxiliary_count = 1 + group_order**4
+    for boundary_raw in itertools.product(range(group_order), repeat=4):
+        boundary = tuple(boundary_raw)
+        for permutation, signs in rotations:
+            _new_face, _new_role, transformed_boundary = rotate_face_tuple(
+                reference_face,
+                reference_role,
+                boundary,
+                permutation,
+                signs,
+                size,
+                group_order,
+            )
+            for auxiliary in range(auxiliary_count):
+                if auxiliary == 0:
+                    transformed_auxiliary = 0
+                else:
+                    auxiliary_tuple = tuple(
+                        (auxiliary - 1) // group_order**index % group_order
+                        for index in range(4)
+                    )
+                    _face, _role, transformed_tuple = rotate_face_tuple(
+                        reference_face,
+                        reference_role,
+                        auxiliary_tuple,
+                        permutation,
+                        signs,
+                        size,
+                        group_order,
+                    )
+                    transformed_auxiliary = 1 + encode_tuple(
+                        transformed_tuple, group_order
+                    )
+                arbitrary_auxiliary_covariance = arbitrary_auxiliary_covariance and (
+                    face_factor(auxiliary, boundary, overlap, epsilon)
+                    == face_factor(
+                        transformed_auxiliary,
+                        transformed_boundary,
+                        overlap,
+                        epsilon,
+                    )
+                )
+    checks.check(
+        arbitrary_auxiliary_covariance,
+        "every face auxiliary label covaries under every proper cubic rotation",
+    )
+
+    shell_candidate_census = {0: 0, 1: 0}
+    role_labels = tuple(itertools.product((0, 1), repeat=3))
+    shell_slots = tuple(
+        (axis, sign) for axis in range(3) for sign in (-1, 1)
+    )
+    for shell_values in itertools.product(role_labels, repeat=6):
+        shell = dict(zip(shell_slots, shell_values))
+        candidate_count = len(compatible_roles(shell))
+        if candidate_count not in shell_candidate_census:
+            shell_candidate_census[candidate_count] = 0
+        shell_candidate_census[candidate_count] += 1
+    checks.check(
+        shell_candidate_census == {0: 8**6 - 8, 1: 8},
+        "all 262144 role shells have either one supported role or the total fallback",
+    )
+
+    malformed_shell = {
+        (axis, sign): (0, 0, 0)
+        for axis in range(3)
+        for sign in (-1, 1)
+    }
+    fallback = tuple(Fraction(1, 8) for _role in sectors)
+    checks.check(
+        compatible_roles(malformed_shell) == () and sum(fallback) == 1,
+        "a uniform covariant fallback makes the rule total off the joint support",
+    )
+
+    alphabet_counts = tuple(len(finite_alphabet(order)) for order in (2, 4, 8, 16))
+    expected_counts = tuple(5 + 3 * order + 3 * order**4 for order in (2, 4, 8, 16))
+    checks.check(
+        alphabet_counts == expected_counts
+        and m2_injection_is_distinct(4)
+        and m2_injection_is_distinct(8),
+        "all role and payload labels inject distinctly into the one-site M2(C) domain",
+    )
+    orthogonal_costs = tuple(math.ceil(math.log2(count)) for count in alphabet_counts)
+    checks.check(
+        orthogonal_costs == (6, 10, 14, 18),
+        "fully orthogonal role-payload readout has the explicit 6,10,14,18-qubit costs",
+    )
+
+    print(
+        "per_element: every finite role label, Z4 face boundary, and auxiliary label is checked under its declared transformations"
+    )
+    print(
+        "per_site: all 512 supported physical shells and all 3072 edge masks use only six nearest neighbors"
+    )
+    print(
+        "per_mode: checked and not executed — the compiler preserves but does not recompute the parent photon Hessian"
+    )
+    print(
+        "per_block: all eight L4 role sectors, 64 translations, and 24 proper cubic rotations are checked"
+    )
+    print(
+        "lattice_wide: four full link fields per sector are marginalized and compared across the 4x4x4 physical torus"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

- Compiles the abstract link/face factor graph into one site-independent nearest-neighbor conditional law on physical Z3 sites.
- Each site carries a parity role plus a role-dependent payload; the law reconstructs the role from the six neighbor labels and never reads absolute coordinates.
- Valid even-torus role fields are exactly eight translated sectors. Translation permutes them transitively, while all 24 proper cubic rotations covary the roles and gauge payloads.
- Face conditionals read four edge neighbors; edge conditionals read four face neighbors. Summing all face auxiliaries still gives the unconditional plaquette measure from #7907.
- This positively occupies the possibility-state route left open by #7880 without contradicting either of its finite negative classes.

## Exact evidence

- New runner: TOTAL: PASS=23 FAIL=0.
- Exhausts all 262,144 assignments of the six neighboring role labels, all 512 supported site shells, all 3,072 edge masks, all 256 Z4 boundaries and 257 face auxiliary labels under every cubic rotation, all eight role sectors, all 64 translations, and all 24 proper rotations on the 4x4x4 physical torus.
- Direct stack rerun: #7907 19/19, #7906 24/24, and #7887 29/29.
- Cache is source/input-fingerprint fresh; vocabulary lint has zero violations; changed-audit-evidence has zero failures; audit lint has no errors beyond repository baseline warnings/notices.

## Honest boundary

This closes role geometry and physical nearest-neighbor incidence for the finite candidate law. It does not derive selection of the extensional probability table, turn the symbolic cubic label action into a canonical M2(C) algebra automorphism, make every label orthogonally readable on one physical qubit, provide Record-formation history, supply electric/time dynamics, identify electromagnetism, or prove the compact interacting continuum theory. It changes no audit verdict or TOE score.

## Stack

Stacked on #7907. The full N1-N8 scoped-boundary packet is included in the source note.