### PR TITLE
science(light): conserved sources join Coulomb and photon sectors

### DIFF
--- a/docs/U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,528 @@
+# Conserved Vertex Charge and Edge Current Join Coulomb to the Local Photon Tick
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct dynamics parent:**
+[`U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Minimal-radius decision boundary:**
+[`U1_RADIUS_ONE_ONSITE_UNITARY_MINIMAL_MAXWELL_TICK_BOUNDED_NO_GO_NOTE_2026-09-03.md`](U1_RADIUS_ONE_ONSITE_UNITARY_MINIMAL_MAXWELL_TICK_BOUNDED_NO_GO_NOTE_2026-09-03.md)
+
+**Physical role compiler:**
+[`U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Kinetic normalization boundary:**
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+
+**Runner:**
+[`scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py`](../scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/u1_conserved_source_coulomb_photon_bridge_2026_09_03.txt`](../logs/runner-cache/u1_conserved_source_coulomb_photon_bridge_2026_09_03.txt)
+
+## Result up front
+
+The source-free parent carried two local transverse photon branches, but did
+not show how charge and current join that field. There is a direct positive
+extension on the same vertex-edge-face-cube incidence complex.
+
+Put charge `rho` on vertex roles, current `J` on edge roles, electric field
+`E` on edge roles, and magnetic field `B` on face roles. Let `d0` be the
+vertex-to-edge incidence and `C` the edge-to-face curl. For a supplied step
+`h`, use
+
+```text
+B^(1)   = B^n     + (h/2) C E^n,
+E^(n+1) = E^n     - h C^T B^(1) + h J^n,
+B^(n+1) = B^(1)   + (h/2) C E^(n+1),
+rho^(n+1) = rho^n + h d0^T J^n.
+```
+
+The current sign is an incidence convention: positive current on an oriented
+edge transfers positive charge from its tail vertex to its head vertex.
+With the electric Gauss condition
+
+```text
+d0^T E^n = rho^n,
+```
+
+the sourced tick gives
+
+```text
+d0^T E^(n+1) = rho^(n+1)
+```
+
+exactly. Magnetic Gauss is preserved during each magnetic half-step. Total
+charge is conserved on a periodic lattice. A one-edge current pulse moves one
+unit of charge to the neighboring vertex with no bookkeeping repair.
+
+The same construction supplies the static and propagating pieces of weak-field
+electromagnetism in one lattice language.
+
+- At fixed neutral charge, minimizing `||E||^2/2` gives
+  `E=d0 phi` and the cubic-lattice Poisson equation
+  `d0^T d0 phi=rho`.
+- Its periodic Green function is axis-cubic and approaches
+  `1/(4 pi r)`. Fits on `L=48,64,96,128` converge monotonically; the `L=128`
+  fitted coefficient is within `0.9%` of `1/(4 pi)`.
+- Gradient currents occupy the longitudinal Coulomb sector. Co-curl currents
+  are divergence-free and occupy the transverse photon sector. The two are
+  orthogonal by `C d0=0`.
+- At every generic nonzero Fourier symbol, the curl-coupled source projector
+  has rank two, matching the two photon polarizations proved by the parent.
+- A local edge-current impulse has a strict finite support cone under the
+  three-layer update, and the sourced law covaries under all 48 cubic signed
+  permutations.
+
+This is a meaningful positive bridge: the previously source-free light
+candidate now has exact local continuity, Gauss coupling, the Coulomb sector,
+and the transverse photon sector in one executable law.
+
+It is not yet a derivation of electromagnetism from the four axioms. The
+current is supplied rather than derived from the matter construction; the
+charge unit and electromagnetic coupling are not selected; the fields remain
+real, linear, and weak; accelerated-source radiation and Record readout are
+not established here; and no compact interacting qubit circuit is claimed.
+
+## 1. Exact cochain identities
+
+The physical-role compiler realizes the doubled cubic incidence chain
+
+```text
+vertices --d0--> edges --C--> faces --d2--> cubes
+```
+
+with
+
+```text
+C d0 = 0,                  d2 C = 0.
+```
+
+Every `d0` row joins two neighboring vertex roles through one edge role.
+Every `C` row reads the four edge roles around a face role. In the doubled
+physical lattice those incidence partners are one physical nearest-neighbor
+step apart.
+
+Define the electric charge represented by a field configuration as
+
+```text
+rho_E=d0^T E.
+```
+
+Only the electric shear and its onsite source change `E`. Therefore
+
+```text
+d0^T E^(n+1)
+ = d0^T E^n - h d0^T C^T B^(1) + h d0^T J^n
+ = rho_E^n + h d0^T J^n,
+```
+
+because `d0^T C^T=(C d0)^T=0`. Updating registered charge by the same
+incidence continuity equation keeps electric Gauss exact.
+
+For magnetic Gauss,
+
+```text
+d2 B^(1)=d2 B^n+(h/2)d2 C E^n=d2 B^n,
+d2 B^(n+1)=d2 B^(1)+(h/2)d2 C E^(n+1)=d2 B^(1).
+```
+
+On a periodic lattice the all-ones vertex vector is in the kernel of `d0`.
+Thus
+
+```text
+sum rho^(n+1)-sum rho^n
+ =h 1^T d0^T J
+ =h (d0 1)^T J
+ =0.
+```
+
+The runner verifies these identities over integers at `h=1/2` on the full
+`L=3` incidence block, not by comparing rounded trajectories.
+
+## 2. A local charge-transfer event
+
+Take an oriented edge `e=(tail -> head)` and set
+
+```text
+J_e=1/h,                   J_other=0.
+```
+
+Then
+
+```text
+h d0^T J = -delta_tail + delta_head.
+```
+
+One tick removes one unit from the tail and places it at the neighboring
+head. A distant opposite spectator charge keeps the periodic block neutral.
+The executable checks the complete vertex vector exactly.
+
+This is a kinematic source event. It does not yet show that a fermion hop
+produces this `J`, nor that Record selects the hop with a derived rate. Those
+are now sharply stated join obligations rather than missing definitions of
+charge or current.
+
+## 3. Static energy selects the lattice Coulomb field
+
+For a neutral vertex charge `rho`, minimize
+
+```text
+H_E(E)=(1/2) E^T E
+```
+
+subject to
+
+```text
+d0^T E=rho.
+```
+
+Introducing a vertex multiplier `phi` gives
+
+```text
+E=d0 phi,
+(d0^T d0) phi=rho.
+```
+
+The constant mode of `phi` is gauge and is fixed to zero mean. The runner
+solves this equation on the complete `L=3` block and reconstructs the input
+neutral charge to numerical tolerance.
+
+Any constraint-preserving variation `z` obeys `d0^T z=0`, including co-curl
+variations `z=C^T a` and the torus harmonic sector. Then
+
+```text
+(d0 phi)^T z=phi^T d0^T z=0.
+```
+
+So
+
+```text
+H_E(E+delta E)=H_E(E)+(1/2)||delta E||^2.
+```
+
+The Poisson field is therefore the unique minimum-energy field in its Gauss
+sector; adding a nonzero harmonic field also raises the energy. The executable
+checks the orthogonality with a nonzero deterministic curl variation, while
+the displayed identity covers the complete constraint kernel.
+
+For a unit source neutralized by the periodic background, the scalar Green
+function satisfies
+
+```text
+L G = delta_0 - 1/L^3,
+L=d0^T d0.
+```
+
+Its Fourier denominator is
+
+```text
+lambda(k)=4 sum_i sin^2(k_i/2).
+```
+
+The code constructs all `L^3` Fourier entries, removes only the constant
+mode, and inverse-transforms. For each of `L=48,64,96,128` it checks the
+Poisson residual and zero mean. It also verifies equality on the three
+coordinate axes. Fitting the on-axis window to
+
+```text
+G(r)=a/r+b+c/r^3
+```
+
+gives a coefficient `a` whose relative errors against `1/(4 pi)` decrease
+strictly across the four sizes and reach less than `0.009` at `L=128`.
+
+This establishes the lattice-to-infrared Coulomb shape and normalization in
+the runner's dimensionless field units. It does not determine the physical
+charge quantum, fine-structure constant, dielectric normalization, or meter
+conversion. The Green-function inverse characterizes or initializes the
+static solution; it is not an operation performed by the local time-update
+law.
+
+## 4. Longitudinal Coulomb and transverse photon sectors
+
+Two exact source families expose the split:
+
+```text
+J_L=d0 f,                  J_T=C^T a.
+```
+
+They obey
+
+```text
+C J_L=0,
+d0^T J_T=0,
+J_L^T J_T=f^T d0^T C^T a=0.
+```
+
+Thus `J_L` changes the vertex charge and populates the longitudinal electric
+field, while `J_T` changes no charge and directly excites the curl sector.
+The torus also has harmonic currents; they are not mislabeled as either local
+exact or local coexact sources.
+
+At a generic nonzero lattice symbol `s`, define
+
+```text
+P_L=s s^T/|s|^2,           P_T=I-P_L.
+```
+
+Then `rank(P_T)=2`, `C(s)P_L=0`, and `C(s)P_T=C(s)`. The runner checks these
+identities at generic and axial symbols. Together with the direct parent's
+phase calculation, this means a general conserved source decomposes into a
+nonpropagating Coulomb constraint sector and exactly two propagating
+curl-coupled photon sectors.
+
+This is a field-level Hodge decomposition. “Photon” still names the two
+transverse normal-mode branches of the supplied linear tick; quantized photon
+number, Fock structure, and detector clicks are not proved by this note.
+
+## 5. Locality, covariance, and reversibility boundary
+
+The source insertion `h J` is onsite on the same edge role as `E`. Charge
+continuity is a vertex-star sum of its incident edge currents. The two
+magnetic half-steps and one electric full-step retain the parent's physical
+nearest-neighbor layer structure.
+
+Starting from zero field and one edge-current impulse, the first complete
+cycle has support at periodic physical Manhattan distance at most one from
+the source edge. One subsequent source-free cycle reaches distance at most
+four. The exact number reflects the half/full/half layer schedule; the key
+claim is a finite causal cone, not continuum Lorentz invariance at the cutoff.
+
+Under a signed permutation `R`, use
+
+```text
+s -> R s,
+E -> R E,
+J -> R J,
+B -> det(R) R B.
+```
+
+The sourced Fourier tick covaries for all 48 signed permutations, including
+reflections. Current and electric field are polar; magnetic field is axial.
+
+For prescribed `J`, the update is affine. The homogeneous field map remains
+the exactly reversible parent tick, but an externally fixed source history is
+not itself a closed reversible dynamical system. Reversibility of a joint
+matter-field update requires the matter variables that generate `J`; it is
+not inferred from this forced-field calculation.
+
+## 6. What was and was not selected
+
+The construction uses no new axiom. It supplies a candidate law inside the
+freedom that the minimal-axioms document leaves open. Specifically:
+
+- incidence and the role geometry supply the chain identities;
+- the source-free parent supplies the finite-depth Maxwell tick;
+- positive electric energy supplies the static Poisson minimizer; and
+- a conserved edge current supplies the source insertion.
+
+None of those steps makes the source current emerge from Admissibility or
+Record. The kinetic primitive fixes a spacetime normalization form; it does
+not select this field payload, coupling, or leapfrog schedule.
+
+The shortest high-value continuation is therefore a matter-current join:
+given a local charged matter hop, construct the same edge `J`, prove the joint
+matter-field Gauss generator is preserved, and test energy exchange and
+reversibility. A driven-radiation check is useful next evidence, but cannot by
+itself retire the supplied-current wall.
+
+## 7. Prior-art boundary
+
+The finite-difference curl staggering and leapfrog idea are standard and are
+not claimed as new numerical electrodynamics; see K. S. Yee,
+[“Numerical solution of initial boundary value problems involving Maxwell's
+equations in isotropic media”](https://doi.org/10.1109/TAP.1966.1138693)
+(1966). Local cellular-automaton constructions with Maxwell sectors also
+exist, including [*Quantum Cellular Automaton Theory of
+Light*](https://arxiv.org/abs/1407.6928) and the Maxwell discussion in
+[*Free Quantum Field Theory from Quantum Cellular
+Automata*](https://arxiv.org/abs/1601.04832).
+
+The repo-specific result is the exact composition of four previously separate
+obligations on its role-compiled one-qubit-site geometry: local sourced tick,
+incidence continuity, Gauss preservation, and the Coulomb/transverse split.
+It is an existence and integration theorem for this program, not a claim to
+have discovered Maxwell's equations.
+
+## 8. Executable evidence
+
+The runner reports `TOTAL: PASS=17 FAIL=0`. It checks:
+
+- the full vertex-edge-face-cube incidence complex;
+- exact integer electric continuity and both magnetic half-step constraints;
+- total charge conservation and the source-free parent reduction;
+- exact one-edge transfer of one unit of charge;
+- the finite-block Poisson solve and minimum-energy orthogonality;
+- periodic Green functions at `L=48,64,96,128`, including cubic axes and the
+  infrared `1/(4 pi r)` coefficient;
+- exact longitudinal/co-curl source separation;
+- rank two of the nonzero transverse Fourier projector;
+- the finite impulse support cone; and
+- all 48 cubic transformations with the correct polar/axial assignments.
+
+## No-Go Discipline Gate
+
+This is a positive theorem, but it names several walls. The gate keeps those
+unclosed joins from being rhetorically promoted into impossibility claims.
+
+### N1 — Alternative route enumeration
+
+| Honesty | Route | Outcome |
+|---|---|---|
+| **ATTEMPTED** | vertex charge plus edge-incidence current | **Positive:** exact continuity, Gauss preservation, charge transfer, Coulomb, and transverse coupling; checks 1-17. |
+| **ATTEMPTED** | arbitrary edge source without a charge update | Field update exists, but the separately stored charge ceases to match electric Gauss unless it obeys the same continuity equation. |
+| **ATTEMPTED** | static energy minimization | **Positive:** lattice Poisson and Coulomb Green function; checks 7-11. |
+| **ATTEMPTED** | longitudinal/co-curl Hodge split | **Positive:** orthogonal charge and photon source sectors; checks 12-15. |
+| **OPEN** | derive `J` from a local charged matter hop | Highest-value joint matter-field obligation; no result is imported from an open matter PR. |
+| **OPEN** | compact group-valued source update | Needed beyond the real weak-field branch. |
+| **OPEN** | enlarged local unitary with E/B as observables | Possible route around the raw-field unitary boundary; source/readout compiler absent. |
+| **OPEN** | driven retarded radiation and flux | Same field law can be tested, but it would not derive the matter source. |
+
+### N2 — Wall-independence audit
+
+Use
+
+```text
+W1 = matter derivation of the edge current,
+W2 = compact nonlinear gauge interaction,
+W3 = onsite finite-payload unitary compiler,
+W4 = Record preparation and detector readout,
+W5 = physical coupling and unit normalization.
+```
+
+| Pair | Independent? | Reason |
+|---|---:|---|
+| W1, W2 | yes | a conserved matter current can exist in a linear field theory; compactness does not identify its carrier |
+| W1, W3 | yes | current conservation does not construct a unitary field payload |
+| W1, W4 | yes | a kinematic current does not select or register an outcome |
+| W1, W5 | yes | current shape does not fix its charge quantum or coupling |
+| W2, W3 | yes | a compact classical update need not be an onsite qubit circuit |
+| W2, W4 | yes | nonlinear gauge closure does not supply records |
+| W2, W5 | yes | compactness does not determine alpha |
+| W3, W4 | yes | unitary dynamics and registered outcomes are distinct obligations |
+| W3, W5 | yes | a compiler does not select physical units |
+| W4, W5 | yes | measurement/readout does not fix the interaction strength |
+
+### N3 — Hidden-wall scan
+
+The lattice is periodic. Charges are neutral in finite volume. Fields and
+sources are real and linear. The step is supplied and set to `h=1/2` in the
+finite-block checks. Coulomb convergence is numerical at four named sizes;
+the incidence identities are exact. The source history is external. The
+torus harmonic sector is present. The theorem does not assume that a fermion
+construction already supplies the required current.
+
+### N4 — Residual matching
+
+| Surface | Its residual | Match here |
+|---|---|---|
+| local photon-tick parent | charged sources and electromagnetic dictionary absent | **positive partial closure:** conserved source, Gauss, Coulomb, and transverse join |
+| radius-one raw-unitary boundary | minimal raw E/B complete map cannot transport | **unchanged:** finite-depth field tick used; no raw onsite-unitary claim |
+| physical role compiler | spatial edge/face law but no dynamics or source | **exact reuse:** current is onsite on edge roles and constraints use its incidence |
+| minimal axioms | no supplied transition law | **unchanged:** sourced tick remains downstream candidate physics |
+| kinetic primitive | spacetime normalization but no dynamics selector | **unchanged:** no source coefficient or coupling derived from it |
+
+### N5 — Rhetoric and resolution audit
+
+“Exact” applies to incidence, integer continuity, finite-block charge transfer,
+and algebraic projector identities. “Coulomb” applies to the stated periodic
+Green function and its measured infrared coefficient. “Photon” imports only
+the parent's two transverse field-mode branches. “Local” applies per update
+layer and to the finite support cone. No sentence says the four axioms derive
+Maxwell, matter, electric charge, alpha, quantization, or Record outcomes.
+
+The cached output carries all five resolution lines:
+
+```text
+per_element: every incidence sign, one-edge charge transfer, and source coefficient is checked
+per_site: vertex charge, edge current, edge electric field, and face magnetic updates are local
+per_mode: longitudinal and rank-two transverse source projectors are checked at generic momenta
+per_block: exact continuity, Hodge separation, Poisson minimization, cubic covariance, and causal support are checked
+lattice_wide: full incidence blocks and L=48,64,96,128 Green functions recover the three-dimensional Coulomb coefficient
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The approved kinetic primitive was read directly. It neither blocks nor
+proves this source bridge. The shortest partial closures are:
+
+1. connect one reversible charged matter hop to one oriented edge current;
+2. show the field energy change is the negative of matter work in the same
+   joint tick;
+3. drive a transverse localized source and recover retarded radiation and
+   lattice Poynting flux; and
+4. compile the resulting observables into finite local possibility payloads
+   and Record events.
+
+No axiom update is justified merely by the existence of these open compiler
+steps.
+
+### N7 — Steelman
+
+A hostile reviewer should say that this is standard sourced lattice Maxwell,
+not a fundamental derivation. That is correct. The scientific value is not a
+new Maxwell equation; it is eliminating a program-specific compatibility
+doubt. The exact source-free photon tick, the role-compiled one-site geometry,
+the charge continuity law, and the static Coulomb field can coexist without a
+new axiom or a nonlocal projection.
+
+The reviewer can also object that a supplied classical current smuggles in
+the matter law. That objection survives and sets the next terminal
+obligation. The note therefore stops at “source bridge” and does not claim an
+end-to-end electromagnetic sector.
+
+### N8 — Cross-cycle echo
+
+The immediately preceding cycles first found a source-free Maxwell generator,
+then replaced its nonlocal exact exponential with a finite-depth local tick,
+then bounded one overly strict raw-unitary implementation. This cycle follows
+the positive escape retained by those results rather than treating the strict
+radius-one block as a general obstruction. It also avoids the recurring error
+of treating a constraint identity as a derived interaction: `C d0=0` protects
+Gauss, while the source coefficient and matter current remain supplied.
+
+**Gate result:** PASS for the scoped positive bridge. Four positive route
+families are executed, four enlarged routes remain open, and no named wall is
+promoted into a general no-go.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- `C d0` or `d2 C` is nonzero on the physical incidence block;
+- sourced electric Gauss disagrees with the vertex continuity update;
+- a magnetic half-step changes magnetic Gauss;
+- an oriented unit current fails to transfer one charge tail-to-head;
+- the Poisson field is not the minimum-energy field in its neutral Gauss
+  sector;
+- the periodic Green function fails its Poisson equation or its cubic-axis
+  equality;
+- the fitted infrared coefficient does not approach `1/(4 pi)` on the named
+  size ladder;
+- longitudinal and co-curl currents fail to be orthogonal;
+- a generic nonzero curl-coupled projector does not have rank two;
+- the current impulse outruns the stated finite layer cone; or
+- the sourced symbol fails polar/axial covariance under a cubic transform.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=17 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15784,
- "node_count": 5569,
+ "edge_count": 15789,
+ "node_count": 5570,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18705,6 +18705,10 @@
   "u1_auxiliary_face_local_conditionals_unconditional_gauge_measure_bounded_theorem_note_2026-09-03": {
    "deps_hash": "fff5d03a38f8",
    "out_degree": 3
+  },
+  "u1_conserved_vertex_charge_edge_current_coulomb_photon_bridge_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "ea98d6401b17",
+   "out_degree": 5
   },
   "u1_det_sector_bi_orbit_quotient_step_law_baseline_decomposition_bounded_theorem_note_2026-06-10": {
    "deps_hash": "2c3aa3968ee1",

--- a/logs/runner-cache/u1_conserved_source_coulomb_photon_bridge_2026_09_03.txt
+++ b/logs/runner-cache/u1_conserved_source_coulomb_photon_bridge_2026_09_03.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py
+runner_sha256: 88b5ddc19323887fa52c0ab08e67442491e7df93a88a77b382e4595c3971557f
+input_fingerprint_sha256: 22f044cfa2a499320bd96020c09c8a58072af3fb4e4f3ccde3ade7321bb6b6f1
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.38
+status: ok
+----- stdout -----
+[PASS] 01 the source bridge uses the exact vertex-edge-face-cube incidence complex
+[PASS] 02 the electric Gauss law and discrete continuity equation agree exactly over integers
+[PASS] 03 magnetic Gauss remains exact during both sourced magnetic half-steps
+[PASS] 04 incidence continuity conserves total charge on the periodic lattice
+[PASS] 05 zero current reduces exactly to the parent finite-depth photon tick
+[PASS] 06 one oriented edge current transports one unit charge to its neighboring vertex exactly
+[PASS] 07 the finite-torus Poisson solve reconstructs the neutral Gauss field
+[PASS] 08 the Poisson field is orthogonal to curl variations and minimizes electric energy
+[PASS] 09 each FFT Green function solves the neutralized cubic Poisson equation
+[PASS] 10 the lattice Coulomb Green function agrees on all three coordinate axes
+[PASS] 11 the fitted lattice Green coefficient converges monotonically to 1/(4 pi)
+[PASS] 12 a gradient current changes charge but has exactly zero transverse curl
+[PASS] 13 a co-curl current is charge-neutral and couples nontrivially to photon fields
+[PASS] 14 longitudinal Coulomb and transverse photon source sectors are orthogonal
+[PASS] 15 the Fourier source split leaves exactly two curl-coupled transverse components
+[PASS] 16 a local current impulse has a strict one-cycle and two-cycle causal support cone
+[PASS] 17 the sourced tick covaries under all 48 cubic transformations with polar current
+per_element: every incidence sign, one-edge charge transfer, and source coefficient is checked
+per_site: vertex charge, edge current, edge electric field, and face magnetic updates are local
+per_mode: longitudinal and rank-two transverse source projectors are checked at generic momenta
+per_block: exact continuity, Hodge separation, Poisson minimization, cubic covariance, and causal support are checked
+lattice_wide: full incidence blocks and L=48,64,96,128 Green functions recover the three-dimensional Coulomb coefficient
+TOTAL: PASS=17 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py
+++ b/scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Checks for a conserved source bridge into the local Maxwell photon tick.
+
+Charge lives on vertex roles and current on edge roles.  With the incidence
+orientation used by the light stack, rho' = rho + h d0^T J and the sourced
+electric shear E' = E - h C^T B + h J preserve Gauss exactly.  Static
+minimum-energy fields give the cubic-lattice Coulomb Green function, while
+the Hodge-transverse current sector couples to the two photon branches.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+
+import numpy as np
+
+from u1_local_reversible_yee_leapfrog_tick_2026_09_03 import (
+    all_cubic_transformations,
+    leapfrog_tick,
+    magnetic_shear,
+    periodic_l1,
+)
+from u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03 import (
+    curl_symbol,
+    physical_incidence,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "scripts/u1_local_reversible_yee_leapfrog_tick_2026_09_03.py",
+    "scripts/u1_radius_one_onsite_unitary_maxwell_obstruction_2026_09_03.py",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def sourced_tick(
+    curl: np.ndarray,
+    electric: np.ndarray,
+    magnetic: np.ndarray,
+    current: np.ndarray,
+    step: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    magnetic_half = magnetic + 0.5 * step * curl @ electric
+    electric_new = electric - step * curl.T @ magnetic_half + step * current
+    magnetic_new = magnetic_half + 0.5 * step * curl @ electric_new
+    return electric_new, magnetic_new
+
+
+def lattice_laplacian(field: np.ndarray) -> np.ndarray:
+    result = 6.0 * field
+    for axis in range(3):
+        result = result - np.roll(field, 1, axis=axis) - np.roll(field, -1, axis=axis)
+    return result
+
+
+def torus_green(size: int) -> np.ndarray:
+    momenta = 2.0 * math.pi * np.fft.fftfreq(size)
+    eigenvalues = 4.0 * (
+        np.sin(0.5 * momenta[:, None, None]) ** 2
+        + np.sin(0.5 * momenta[None, :, None]) ** 2
+        + np.sin(0.5 * momenta[None, None, :]) ** 2
+    )
+    inverse = np.zeros_like(eigenvalues)
+    inverse[eigenvalues > 1.0e-14] = 1.0 / eigenvalues[eigenvalues > 1.0e-14]
+    return np.fft.ifftn(inverse).real
+
+
+def fit_coulomb_coefficient(green: np.ndarray) -> tuple[float, float, float]:
+    size = green.shape[0]
+    radii = np.arange(4, size // 5, dtype=float)
+    values = green[radii.astype(int), 0, 0]
+    design = np.column_stack((1.0 / radii, np.ones_like(radii), 1.0 / radii**3))
+    coefficient, offset, lattice_correction = np.linalg.lstsq(
+        design, values, rcond=None
+    )[0]
+    return float(coefficient), float(offset), float(lattice_correction)
+
+
+def source_symbol_tick(
+    momentum: np.ndarray,
+    electric: np.ndarray,
+    magnetic: np.ndarray,
+    current: np.ndarray,
+    step: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    return sourced_tick(curl_symbol(momentum), electric, magnetic, current, step)
+
+
+def main() -> int:
+    checks = Checks()
+    (
+        vertices,
+        edges,
+        faces,
+        cubes,
+        gradient,
+        curl_integer,
+        divergence,
+    ) = physical_incidence(3)
+    curl = curl_integer.astype(float)
+    checks.check(
+        np.array_equal(curl_integer @ gradient, np.zeros((81, 27), dtype=int))
+        and np.array_equal(divergence @ curl_integer, np.zeros((27, 81), dtype=int)),
+        "the source bridge uses the exact vertex-edge-face-cube incidence complex",
+    )
+
+    # Exact rational h=1/2 sourced update.  B_half has denominator 4,
+    # E_new denominator 8, and B_new denominator 32.
+    electric_integer = np.array(
+        [(7 * index + 3) % 11 - 5 for index in range(len(edges))], dtype=np.int64
+    )
+    potential_integer = np.array(
+        [(5 * index + 1) % 9 - 4 for index in range(len(edges))], dtype=np.int64
+    )
+    magnetic_integer = curl_integer @ potential_integer
+    current_integer = np.array(
+        [(3 * index + 2) % 7 - 3 for index in range(len(edges))], dtype=np.int64
+    )
+    charge_integer = gradient.T @ electric_integer
+    magnetic_half_numerator = 4 * magnetic_integer + curl_integer @ electric_integer
+    electric_new_numerator = (
+        8 * electric_integer
+        - curl_integer.T @ magnetic_half_numerator
+        + 4 * current_integer
+    )
+    magnetic_new_numerator = (
+        8 * magnetic_half_numerator + curl_integer @ electric_new_numerator
+    )
+    charge_new_numerator = 2 * charge_integer + gradient.T @ current_integer
+    checks.check(
+        np.array_equal(
+            gradient.T @ electric_new_numerator,
+            4 * charge_new_numerator,
+        ),
+        "the electric Gauss law and discrete continuity equation agree exactly over integers",
+    )
+    checks.check(
+        np.array_equal(
+            divergence @ magnetic_half_numerator,
+            np.zeros(len(cubes), dtype=np.int64),
+        )
+        and np.array_equal(
+            divergence @ magnetic_new_numerator,
+            np.zeros(len(cubes), dtype=np.int64),
+        ),
+        "magnetic Gauss remains exact during both sourced magnetic half-steps",
+    )
+    checks.check(
+        int(np.sum(charge_new_numerator)) == 0
+        and int(np.sum(charge_integer)) == 0,
+        "incidence continuity conserves total charge on the periodic lattice",
+    )
+
+    step = 0.5
+    electric = electric_integer.astype(float)
+    magnetic = magnetic_integer.astype(float)
+    zero_current = np.zeros(len(edges))
+    source_free_electric, source_free_magnetic = sourced_tick(
+        curl, electric, magnetic, zero_current, step
+    )
+    parent_tick = leapfrog_tick(curl, step) @ np.concatenate((electric, magnetic))
+    checks.check(
+        np.max(
+            np.abs(
+                np.concatenate((source_free_electric, source_free_magnetic))
+                - parent_tick
+            )
+        )
+        < 1.0e-13,
+        "zero current reduces exactly to the parent finite-depth photon tick",
+    )
+
+    vertex_index = {point: index for index, point in enumerate(vertices)}
+    edge_index = {point: index for index, point in enumerate(edges)}
+    tail = vertices[0]
+    physical_size = 6
+    head = ((tail[0] + 2) % physical_size, tail[1], tail[2])
+    midpoint = ((tail[0] + 1) % physical_size, tail[1], tail[2])
+    spectator = vertices[len(vertices) // 2]
+    old_charge = np.zeros(len(vertices))
+    old_charge[vertex_index[tail]] = 1.0
+    old_charge[vertex_index[spectator]] = -1.0
+    unit_current = np.zeros(len(edges))
+    unit_current[edge_index[midpoint]] = 1.0 / step
+    new_charge = old_charge + step * gradient.T @ unit_current
+    expected_charge = np.zeros(len(vertices))
+    expected_charge[vertex_index[head]] = 1.0
+    expected_charge[vertex_index[spectator]] = -1.0
+    checks.check(
+        np.array_equal(new_charge, expected_charge),
+        "one oriented edge current transports one unit charge to its neighboring vertex exactly",
+    )
+
+    laplacian = gradient.T @ gradient
+    potential = np.linalg.pinv(laplacian.astype(float), rcond=1.0e-13) @ old_charge
+    coulomb_electric = gradient @ potential
+    checks.check(
+        np.max(np.abs(gradient.T @ coulomb_electric - old_charge)) < 2.0e-13
+        and abs(float(np.mean(potential))) < 2.0e-14,
+        "the finite-torus Poisson solve reconstructs the neutral Gauss field",
+    )
+
+    deterministic_face = np.array(
+        [(11 * index + 4) % 13 - 6 for index in range(len(faces))], dtype=float
+    )
+    divergence_free_variation = curl.T @ deterministic_face
+    base_energy = 0.5 * float(coulomb_electric @ coulomb_electric)
+    varied_energy = 0.5 * float(
+        (coulomb_electric + divergence_free_variation)
+        @ (coulomb_electric + divergence_free_variation)
+    )
+    checks.check(
+        abs(float(coulomb_electric @ divergence_free_variation)) < 2.0e-11
+        and varied_energy > base_energy + 1.0,
+        "the Poisson field is orthogonal to curl variations and minimizes electric energy",
+    )
+
+    green_sizes = (48, 64, 96, 128)
+    coulomb_coefficients = []
+    poisson_ok = True
+    cubic_green_ok = True
+    zero_mean_ok = True
+    for size in green_sizes:
+        green = torus_green(size)
+        source = np.zeros_like(green)
+        source[0, 0, 0] = 1.0
+        source -= 1.0 / size**3
+        poisson_ok = poisson_ok and bool(
+            np.max(np.abs(lattice_laplacian(green) - source)) < 2.0e-12
+        )
+        zero_mean_ok = zero_mean_ok and abs(float(np.mean(green))) < 2.0e-17
+        radii = range(1, size // 5)
+        cubic_green_ok = cubic_green_ok and all(
+            abs(green[radius, 0, 0] - green[0, radius, 0]) < 2.0e-15
+            and abs(green[radius, 0, 0] - green[0, 0, radius]) < 2.0e-15
+            for radius in radii
+        )
+        coefficient, _offset, _correction = fit_coulomb_coefficient(green)
+        coulomb_coefficients.append(coefficient)
+    checks.check(
+        poisson_ok and zero_mean_ok,
+        "each FFT Green function solves the neutralized cubic Poisson equation",
+    )
+    checks.check(
+        cubic_green_ok,
+        "the lattice Coulomb Green function agrees on all three coordinate axes",
+    )
+    continuum_coefficient = 1.0 / (4.0 * math.pi)
+    relative_errors = tuple(
+        abs(value / continuum_coefficient - 1.0)
+        for value in coulomb_coefficients
+    )
+    checks.check(
+        all(left > right for left, right in zip(relative_errors, relative_errors[1:]))
+        and relative_errors[-1] < 0.009,
+        "the fitted lattice Green coefficient converges monotonically to 1/(4 pi)",
+    )
+
+    # Exact Hodge separation of source currents.
+    vertex_profile = np.array(
+        [(index * 7 + 1) % 10 - 4 for index in range(len(vertices))], dtype=float
+    )
+    longitudinal_current = gradient @ vertex_profile
+    face_profile = np.array(
+        [(index * 5 + 2) % 12 - 5 for index in range(len(faces))], dtype=float
+    )
+    transverse_current = curl.T @ face_profile
+    checks.check(
+        np.max(np.abs(curl @ longitudinal_current)) < 1.0e-13
+        and np.linalg.norm(gradient.T @ longitudinal_current) > 1.0,
+        "a gradient current changes charge but has exactly zero transverse curl",
+    )
+    checks.check(
+        np.max(np.abs(gradient.T @ transverse_current)) < 1.0e-13
+        and np.linalg.norm(curl @ transverse_current) > 1.0,
+        "a co-curl current is charge-neutral and couples nontrivially to photon fields",
+    )
+    checks.check(
+        abs(float(longitudinal_current @ transverse_current)) < 2.0e-11,
+        "longitudinal Coulomb and transverse photon source sectors are orthogonal",
+    )
+
+    transverse_rank_ok = True
+    source_projection_ok = True
+    for momentum in (
+        np.array([0.3, 0.7, 1.1]),
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.8, 1.2, 0.4]),
+    ):
+        norm_squared = float(momentum @ momentum)
+        longitudinal_projector = np.outer(momentum, momentum) / norm_squared
+        transverse_projector = np.eye(3) - longitudinal_projector
+        transverse_rank_ok = transverse_rank_ok and (
+            np.linalg.matrix_rank(transverse_projector, tol=1.0e-12) == 2
+        )
+        symbol = curl_symbol(momentum)
+        source_projection_ok = source_projection_ok and bool(
+            np.max(np.abs(symbol @ longitudinal_projector)) < 2.0e-12
+            and np.max(
+                np.abs(symbol @ transverse_projector - symbol)
+            )
+            < 2.0e-12
+        )
+    checks.check(
+        transverse_rank_ok and source_projection_ok,
+        "the Fourier source split leaves exactly two curl-coupled transverse components",
+    )
+
+    # An impulse cannot outrun the finite-depth local layers.
+    (
+        _vertices5,
+        edges5,
+        faces5,
+        _cubes5,
+        _gradient5,
+        curl5_integer,
+        _divergence5,
+    ) = physical_incidence(5)
+    curl5 = curl5_integer.astype(float)
+    impulse = np.zeros(len(edges5))
+    impulse[0] = 1.0
+    electric5 = np.zeros(len(edges5))
+    magnetic5 = np.zeros(len(faces5))
+    electric5, magnetic5 = sourced_tick(
+        curl5, electric5, magnetic5, impulse, step
+    )
+    field_sites5 = edges5 + faces5
+    source_site = edges5[0]
+    support_one = np.flatnonzero(
+        np.abs(np.concatenate((electric5, magnetic5))) > 1.0e-13
+    )
+    max_distance_one = max(
+        periodic_l1(source_site, field_sites5[index], 10)
+        for index in support_one
+    )
+    electric5, magnetic5 = sourced_tick(
+        curl5, electric5, magnetic5, np.zeros(len(edges5)), step
+    )
+    support_two = np.flatnonzero(
+        np.abs(np.concatenate((electric5, magnetic5))) > 1.0e-13
+    )
+    max_distance_two = max(
+        periodic_l1(source_site, field_sites5[index], 10)
+        for index in support_two
+    )
+    checks.check(
+        max_distance_one == 1 and max_distance_two <= 4,
+        "a local current impulse has a strict one-cycle and two-cycle causal support cone",
+    )
+
+    cubic_source_ok = True
+    sample_electric = np.array([0.2, -0.3, 0.7])
+    sample_magnetic = np.array([-0.4, 0.8, 0.1])
+    sample_current = np.array([0.6, -0.2, 0.5])
+    for momentum in (
+        np.array([0.3, 0.7, 1.1]),
+        np.array([1.0, 0.0, 0.0]),
+    ):
+        electric_out, magnetic_out = source_symbol_tick(
+            momentum,
+            sample_electric,
+            sample_magnetic,
+            sample_current,
+            step,
+        )
+        for transform in all_cubic_transformations():
+            determinant = int(round(np.linalg.det(transform)))
+            transformed_electric, transformed_magnetic = source_symbol_tick(
+                transform @ momentum,
+                transform @ sample_electric,
+                determinant * transform @ sample_magnetic,
+                transform @ sample_current,
+                step,
+            )
+            cubic_source_ok = cubic_source_ok and bool(
+                np.max(np.abs(transformed_electric - transform @ electric_out))
+                < 2.0e-12
+                and np.max(
+                    np.abs(
+                        transformed_magnetic
+                        - determinant * transform @ magnetic_out
+                    )
+                )
+                < 2.0e-12
+            )
+    checks.check(
+        cubic_source_ok,
+        "the sourced tick covaries under all 48 cubic transformations with polar current",
+    )
+
+    print(
+        "per_element: every incidence sign, one-edge charge transfer, and source coefficient is checked"
+    )
+    print(
+        "per_site: vertex charge, edge current, edge electric field, and face magnetic updates are local"
+    )
+    print(
+        "per_mode: longitudinal and rank-two transverse source projectors are checked at generic momenta"
+    )
+    print(
+        "per_block: exact continuity, Hodge separation, Poisson minimization, cubic covariance, and causal support are checked"
+    )
+    print(
+        "lattice_wide: full incidence blocks and L=48,64,96,128 Green functions recover the three-dimensional Coulomb coefficient"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Extends the verified finite-depth local photon tick with vertex charge and edge current.

- exact integer continuity and electric Gauss preservation
- magnetic Gauss preserved through both half-steps
- exact one-edge transfer of one unit of charge
- minimum-energy lattice Poisson field and infrared 1/(4 pi r) Coulomb coefficient
- orthogonal longitudinal Coulomb and rank-two transverse photon source sectors
- finite impulse support cone and all 48 cubic transformations

Runner: TOTAL: PASS=17 FAIL=0. The source, identity-pinned cache, bounded theorem note, N1-N8 scope packet, and graph acknowledgment are included.

## Scope

This is a source-science PR, not an audit verdict. It changes no TOE score, axiom, primitive, or audit status. The current is supplied rather than derived from matter; compact interactions, physical coupling normalization, Record readout, and a joint matter-field unitary remain open.

## Validation

- targeted runner 17/17
- cache freshness check clean
- staged claim typing clean
- vocabulary lint clean
- repository invariants with enforced links clean
- strict audit lint has no new source error in the ordinary check; the full pre-commit seeding pass is intentionally not landed because it tries to create unaudited ledger rows for the entire unmerged stack