### PR TITLE
science(light): exact source work leaves a pure radiation packet

### DIFF
--- a/docs/U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,584 @@
+# Exact Midpoint Source Work and a Closed-Dipole Pure Radiation Packet
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct source parent:**
+[`U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Photon-tick parent:**
+[`U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Physical role compiler:**
+[`U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Kinetic normalization boundary:**
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+
+**Runner:**
+[`scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py`](../scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/u1_exact_source_work_closed_dipole_radiation_2026_09_03.txt`](../logs/runner-cache/u1_exact_source_work_closed_dipole_radiation_2026_09_03.txt)
+
+## Result up front
+
+The sourced local photon tick has an exact finite-step work law. Write its
+positive modified field energy as
+
+```text
+H_h(E,B)
+  =(1/2)(||E||^2+||B||^2)
+   -(h^2/8)||C E||^2.
+```
+
+For one sourced update
+
+```text
+B^(1) =B +(h/2) C E,
+E'    =E -h C^T B^(1)+h J,
+B'    =B^(1)+(h/2) C E',
+```
+
+the energy change is exactly
+
+```text
+H_h(E',B')-H_h(E,B)
+  =h J^T (E+E')/2.
+```
+
+This is not a small-step approximation. At `h=1/2`, the runner proves the
+cross and quadratic parts as integer matrix identities on the complete
+`162`-field block. The equality also holds in deterministic full-field
+trials and reduces to the parent's exact conservation law when `J=0`.
+
+The work identity gives a direct radiation experiment. Start from no charge
+and no field. Apply one edge current `J` for one tick, then apply `-J` on the
+same edge for the next tick. With `J_e=1/h`, the first tick creates a unit
+positive/negative nearest-neighbor charge pair and the second returns every
+vertex charge to zero. The field does not return to zero. It is
+
+```text
+E_2=-h^3 C^T C J,
+B_2= h^2 C J -(h^4/2) C C^T C J.
+```
+
+Therefore `E_2` is co-curl, `B_2` is curl, both Gauss laws hold, and neither
+field has a constant harmonic component. The source has made a temporary
+electric dipole, closed it, and left only a nonzero transverse field packet.
+By the photon-tick parent's spectrum, that packet is a superposition of its
+two propagating photon branches rather than a residual Coulomb field.
+
+For `h=1/2` and the unit nearest-neighbor dipole, the residual modified field
+energy is exactly `1/2`, equal to the accumulated midpoint source work. On an
+`L=20` sparse role lattice, eight subsequent source-free cycles keep that
+energy fixed to `2e-13`, advance the exact nonzero-support radius through
+`3,5,...,19`, move the squared-field centroid monotonically from the source,
+and leave less than `0.2%` of squared field amplitude inside radius three.
+
+This closes a second source-level electromagnetic question: the conserved
+current does not merely satisfy Gauss and make a static Coulomb field. A
+closed, charge-conserving local history emits an energy-carrying transverse
+wave packet under the same finite-depth law.
+
+It still does not derive a matter current, quantize the field, construct a
+detector Record, fix the electric charge or fine-structure constant, or prove
+a compact finite-payload matter-field unitary. The exact work equation now
+states what a successful joint matter-field compiler must satisfy:
+
+```text
+Delta H_matter = -h J^T (E+E')/2
+```
+
+for a closed isolated tick, with the same orientation and staggering.
+
+## 1. Algebra of the exact work identity
+
+Let
+
+```text
+a=h/2,
+M_E=I-a^2 C^T C,
+M=diag(M_E,I),
+H_h(x)=(1/2)x^T M x,
+x=(E,B).
+```
+
+The source-free tick is `x_0'=U_h x` and obeys
+
+```text
+U_h^T M U_h=M.
+```
+
+Adding `J` in the electric full-step changes the final state by
+
+```text
+R_h J=(h J,a h C J).
+```
+
+Thus
+
+```text
+x'=U_h x+R_h J.
+```
+
+The energy change has one cross term and one quadratic source term:
+
+```text
+Delta H
+ =x^T U_h^T M R_h J
+  +(1/2)J^T R_h^T M R_h J.
+```
+
+Using the last magnetic half-step gives
+
+```text
+M_E E_0'+a C^T B_0'
+ =E_0'+a C^T B^(1),
+```
+
+and the electric update gives
+
+```text
+(E+E')/2
+ =E_0'+a C^T B^(1)+(h/2)J.
+```
+
+Meanwhile
+
+```text
+R_h^T M R_h=h^2 I.
+```
+
+Combining the cross and quadratic pieces yields
+
+```text
+Delta H=h J^T(E+E')/2.
+```
+
+At `h=1/2`, the runner removes all denominators:
+
+```text
+U=U_num/32,
+M=M_num/16,
+R=R_num/8,
+R_num=(4I,C)^T.
+```
+
+It verifies the two independent integer identities
+
+```text
+U_num^T M_num R_num
+ =32(32 P_E^T+U_num^T P_E^T),
+
+R_num^T M_num R_num=256 I,
+```
+
+where `P_E` selects the electric coordinates. These are the coefficientwise
+statement of the work theorem for every old field and every current on the
+named block.
+
+The sign is the source parent's incidence convention. Positive `J` increases
+the field by `+hJ`; an isolated matter supplier must lose the same work. No
+claim is made that a separately stipulated source conserves total energy.
+
+## 2. A charge excursion that ends with no charge
+
+Start with
+
+```text
+rho_0=0,                    E_0=0,                    B_0=0.
+```
+
+Use the source history
+
+```text
+J_0=J,                      J_1=-J.
+```
+
+The exact continuity rule gives
+
+```text
+rho_1=h d0^T J,
+rho_2=rho_1-h d0^T J=0.
+```
+
+For one oriented edge with `J_e=1/h`, `rho_1` is `-1` at the tail and `+1`
+at the head. The runner checks the complete vertex vector, not only total
+charge.
+
+The first field update is
+
+```text
+E_1=hJ,
+B_1=(h^2/2) C J.
+```
+
+At the start of the second electric step,
+
+```text
+B^(1)_second=h^2 C J.
+```
+
+The reverse current cancels the direct electric insertion, but it cannot
+cancel the curl field that evolved during the intervening tick. Direct
+substitution produces
+
+```text
+E_2=-h^3 C^T C J,
+B_2=h^2 C J-(h^4/2)C C^T C J.
+```
+
+The runner evaluates both the two-step trajectory and this formula and finds
+them componentwise identical at `h=1/2`.
+
+Applying `J` and `-J` simultaneously is the zero-source control and leaves
+zero field. Reversing the pulse orientation reverses every field component
+and preserves the energy. The residual packet is therefore caused by the
+one-tick time separation, not a static source, floating offset, or hidden
+background.
+
+## 3. Why the residual field is radiation in this model
+
+The incidence identities give
+
+```text
+d0^T E_2=-h^3 d0^T C^T C J=0,
+d2 B_2=0.
+```
+
+More strongly,
+
+```text
+E_2 in image(C^T),          B_2 in image(C).
+```
+
+The longitudinal electric sector is `image(d0)`, and
+
+```text
+image(d0) perpendicular image(C^T)
+```
+
+because `C d0=0`. The three torus-constant electric and magnetic modes are
+also absent: the executable groups fields by their actual edge orientation
+and face normal and obtains zero sum in all six groups over integers.
+
+The residual state therefore has no charge, no longitudinal Coulomb field,
+and no harmonic zero mode. Every surviving component lies in the nonzero
+curl sector. The direct photon parent proves that this sector has exactly two
+positive and two negative finite-tick phases at every nonzero lattice
+momentum, corresponding to two real transverse polarizations.
+
+“Pure radiation packet” is used in that precise linear-field sense. The note
+does not infer photon-number eigenstates, a quantum vacuum, spontaneous
+emission rates, or detector clicks.
+
+## 4. Exact energy left by the unit dipole
+
+For the tested `h=1/2` and `J_e=2`, write the final state over denominator
+`32`:
+
+```text
+E_num=-4 C^T C J,
+B_num= 8 C J-C C^T C J.
+```
+
+With `M=M_num/16`, the runner computes over integers
+
+```text
+x_num^T M_num x_num=16384.
+```
+
+Since
+
+```text
+H=(1/2)(x_num/32)^T(M_num/16)(x_num/32),
+```
+
+the energy is exactly
+
+```text
+H_2=16384/32768=1/2.
+```
+
+The two midpoint work terms sum to the same `1/2`. This is useful beyond the
+particular source: it makes energy exchange a coefficient-level join
+criterion. A proposed matter update that supplies the same edge current but
+does not lose this amount is not yet a closed matter-field dynamics.
+
+## 5. Local propagation after the source closes
+
+The executable independently builds a sparse `L=20` physical curl with
+`24,000` edge and `24,000` face variables and `96,000` signed incidence
+entries. At `L=3` its site ordering and dense matrix are exactly identical to
+the role compiler, preventing a second discretization from silently entering
+the large-volume control.
+
+After the two source ticks, eight source-free cycles give
+
+```text
+support radius: 3,5,7,9,11,13,15,17,19.
+```
+
+All are before the radius-20 wrap boundary. The modified energy remains
+`1/2` to `2e-13` throughout. As a separate location diagnostic, the runner
+weights each edge and face by its squared raw field amplitude. That centroid
+moves outward strictly at every sampled cycle, and the fraction within
+physical Manhattan radius three falls from `1` to less than `0.002`.
+
+Squared raw amplitude is not labeled an exactly conserved local energy
+density; the exact conserved scalar is `H_h`, whose curl correction is local
+but can redistribute density conventions. The propagation claim is the
+combination of exact support, exact global energy, and the explicitly named
+amplitude-location diagnostic.
+
+## 6. Reversal and cubic covariance
+
+For a prescribed current, one sourced step is inverted by using `-h` with
+the same current:
+
+```text
+U_{-h,J} U_{h,J}=I
+```
+
+when the magnetic half-steps and source insertion are reversed in their
+palindromic order. Starting from the final packet, the runner reverses the
+two source values in time order with `-h` and returns every field component
+to exact zero.
+
+For every signed permutation `R`, transform
+
+```text
+s -> R s,
+E -> R E,
+J -> R J,
+B -> det(R) R B.
+```
+
+The runner checks all 48 transforms at generic and axial symbols. Both the
+driven field and the scalar midpoint work covary. Thus neither the radiation
+mechanism nor its energy exchange selects a preferred cubic axis.
+
+## 7. Program significance and the next join
+
+The light stack now has, at source level:
+
+1. a role-compiled local gauge measure;
+2. the minimal conservative Maxwell generator;
+3. a finite-depth reversible photon tick;
+4. conserved vertex charge and edge current;
+5. the static lattice Coulomb field;
+6. an exact field/source work law; and
+7. a closed charge history that leaves a causal transverse radiation packet.
+
+This is substantial classical weak-field closure. It is still a supplied-law
+chain rather than an axiom derivation, and its official audit status is
+unchanged.
+
+Open PR #7892 reports a local conserved current for the emergent fermion, and
+open PR #7903 reports a compact-link gauge coupling. Those are context-only
+pincer surfaces here: their code and conclusions are not imported as
+authority. Once available on one common source base, the high-value test is
+not merely to identify both symbols as `J`. It is to show, in one reversible
+joint update, all three equations
+
+```text
+Delta rho=d0^T(hJ),
+Delta H_field=h J^T(E+E')/2,
+Delta H_matter=-Delta H_field.
+```
+
+Passing those with the same local hop would close charge, Gauss, and energy
+exchange at once. Failure would identify the exact staggering or coupling
+coefficient that needs revision.
+
+## 8. Prior-art boundary
+
+Finite-difference Maxwell radiation is standard, beginning with K. S. Yee,
+[“Numerical solution of initial boundary value problems involving Maxwell's
+equations in isotropic media”](https://doi.org/10.1109/TAP.1966.1138693)
+(1966). The source parent names additional local cellular-automaton Maxwell
+precedents.
+
+This note does not claim a new radiation law. Its repo-specific theorem is
+that the exact modified-energy invariant of this particular finite-depth
+role-compiled tick has the midpoint work law, and that its exact incidence
+source can execute a closed Record-sized dipole history leaving only the
+already classified photon sector.
+
+## 9. Executable evidence
+
+The runner reports `TOTAL: PASS=22 FAIL=0`. It checks:
+
+- the exact incidence complex;
+- the two integer matrix identities constituting the source-work theorem;
+- deterministic full-field work controls and the zero-source limit;
+- unit dipole creation and exact charge return;
+- the componentwise closed-pulse formula;
+- both final Gauss laws, transverse images, and absence of harmonic fields;
+- exact rational packet energy and equality to accumulated work;
+- exact reversed-history recovery and orientation reversal;
+- sparse/dense compiler identity;
+- eight-cycle large-volume energy conservation, support, centroid, and
+  near-source departure;
+- all 48 cubic transformations; and
+- simultaneous-current cancellation as the temporal-separation control.
+
+## No-Go Discipline Gate
+
+This is a positive theorem with named unclosed joins. The gate prevents those
+joins from turning into unsupported impossibility claims.
+
+### N1 — Alternative route enumeration
+
+| Honesty | Route | Outcome |
+|---|---|---|
+| **ATTEMPTED** | exact metric expansion | **Positive:** integer cross and quadratic identities give midpoint work; checks 2-5. |
+| **ATTEMPTED** | closed one-edge dipole history | **Positive:** charge returns to zero and leaves a pure curl/co-curl packet; checks 6-13. |
+| **ATTEMPTED** | reverse-time history | **Positive:** the packet returns exactly to vacuum; check 14. |
+| **ATTEMPTED** | large sparse propagation | **Positive:** exact energy and finite outward support through radius 19; checks 16-20. |
+| **OPEN** | local matter hop supplies `J` and loses opposite work | Direct end-to-end pincer target; not assumed from another open PR. |
+| **OPEN** | local Poynting-density convention | Global work is exact; no unique local energy-density/flux split is selected here. |
+| **OPEN** | compact finite-payload quantum implementation | Needed beyond the real weak-field field coordinates. |
+| **OPEN** | Record preparation and detector absorption | Emission field exists; outcome statistics and clicks are not compiled. |
+
+### N2 — Wall-independence audit
+
+Use
+
+```text
+W1 = reversible matter-current energy join,
+W2 = compact finite-payload quantum compiler,
+W3 = local energy-density and flux convention,
+W4 = Record source preparation and detector readout,
+W5 = coupling and unit normalization.
+```
+
+| Pair | Independent? | Reason |
+|---|---:|---|
+| W1, W2 | yes | a classical joint symplectic law could balance work without a finite qubit payload |
+| W1, W3 | yes | global matter/field energy balance does not select one local flux density |
+| W1, W4 | yes | a conserved reversible current does not select a registered event |
+| W1, W5 | yes | work balance fixes matching coefficients, not their physical value |
+| W2, W3 | yes | a quantum compiler need not choose a classical density convention |
+| W2, W4 | yes | unitary payload and Record formation remain distinct |
+| W2, W5 | yes | finite payload does not determine electric charge |
+| W3, W4 | yes | local flux bookkeeping does not create a detector outcome |
+| W3, W5 | yes | a Poynting convention does not set alpha |
+| W4, W5 | yes | readout does not normalize the coupling |
+
+### N3 — Hidden-wall scan
+
+The theorem uses real linear fields, periodic blocks, supplied `h=1/2`, an
+external current history, and the parent's positive local metric. The exact
+work algebra is finite-block but coefficientwise. The propagation diagnostic
+uses an `L=20` torus before radius-20 wrap, and squared amplitude is not called
+the exact local energy. “Radiation” means the source-free nonzero curl sector
+of the proved tick, not a quantized photon count or experimental detector
+signal.
+
+### N4 — Residual matching
+
+| Surface | Residual | Match here |
+|---|---|---|
+| conserved-source parent | accelerated source, radiation, and energy exchange open | **positive partial closure:** closed dipole radiates and field work is exact |
+| photon-tick parent | source-free positive metric | **exact reuse:** same metric and homogeneous evolution |
+| radius-one raw-unitary boundary | no minimal raw-coordinate unitary transport | **unchanged:** finite-depth field map used |
+| matter-current PR context | current exists on another open source branch | **not imported:** joint energy loss remains to be executed |
+| minimal axioms | no dynamics or Hamiltonian selector | **unchanged:** supplied downstream law |
+
+### N5 — Rhetoric and resolution audit
+
+“Exact” refers to the displayed finite matrices, continuity, field formula,
+Gauss laws, rational energy, and reversal. “Pure radiation” refers to absence
+of charge, longitudinal field, and harmonic field inside the parent's linear
+mode classification. “Outward” refers to the named squared-amplitude centroid
+on `L=20`. No claim extends to photon quantization, spontaneous emission,
+continuum Lorentz symmetry at the cutoff, detector records, compact dynamics,
+or an axiom derivation.
+
+The cache contains all five resolution lines:
+
+```text
+per_element: each source coefficient, incidence sign, and exact work numerator is checked
+per_site: one edge pulse creates and erases charges only on its two neighboring vertices
+per_mode: the residual field lies in curl/co-curl images with no longitudinal or harmonic component
+per_block: exact work, Gauss laws, reversal, cubic covariance, and dipole controls are checked
+lattice_wide: an L=20 sparse block conserves energy and carries the packet from support radius 3 through 19
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The approved kinetic primitive supplies no current or work coefficient. The
+shortest positive continuation is to put the matter current and this field
+tick on one source base and prove opposite work in the matter sector. A
+secondary path derives a local Poynting balance for a declared density split.
+A third compiles source preparation and absorption into Record events. None
+requires an axiom edit before these explicit joins are attempted.
+
+### N7 — Steelman
+
+A hostile reviewer should say that a prescribed two-tick classical current is
+an antenna input, not matter. Correct. It proves that the field law has a
+coherent radiation response and a sharp work ledger; it does not prove the
+framework creates that source. The reviewer should demand the actual fermion
+hop, the same edge orientation, opposite matter work, and a joint reversible
+map. Those demands define the next test rather than invalidate this bounded
+field theorem.
+
+The reviewer can also reject squared-amplitude motion as Poynting flux. The
+note agrees: it uses that quantity only as a location diagnostic and does not
+claim a unique local flux law.
+
+### N8 — Cross-cycle echo
+
+The previous light cycles progressively removed false blockers: a nonlocal
+exact exponential did not prevent a local split tick, and failure of a strict
+raw-unitary block did not prevent positive field dynamics. This cycle follows
+the positive source route and keeps the same distinction. It also avoids a
+repeated program error in which matching a current symbol is treated as a
+joint theory: the new midpoint identity makes opposite matter work an
+independent terminal obligation.
+
+**Gate result:** PASS for the scoped positive work and radiation theorem.
+Four route families are executed, four enlarged joins remain open, and no
+remaining wall is stated as a no-go.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- either exact integer source-work matrix identity is nonzero;
+- a sourced full-field trial violates midpoint work;
+- the first pulse does not create only the neighboring unit dipole;
+- the reverse pulse leaves any vertex charge;
+- the two-step field differs from the displayed curl/co-curl formula;
+- either final Gauss law fails or a harmonic component remains;
+- the residual packet is zero or its exact energy differs from `1/2`;
+- accumulated work differs from residual field energy;
+- reverse-time source history fails to return the field to zero;
+- the sparse curl differs from the role compiler;
+- source-free packet energy drifts beyond the stated tolerance;
+- the support or centroid fails the named `L=20` ladder; or
+- source work changes under a cubic signed permutation.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=22 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15789,
- "node_count": 5570,
+ "edge_count": 15794,
+ "node_count": 5571,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18713,6 +18713,10 @@
   "u1_det_sector_bi_orbit_quotient_step_law_baseline_decomposition_bounded_theorem_note_2026-06-10": {
    "deps_hash": "2c3aa3968ee1",
    "out_degree": 4
+  },
+  "u1_exact_midpoint_source_work_closed_dipole_pure_radiation_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "7c6c9ed0203d",
+   "out_degree": 5
   },
   "u1_fermion_number_conservation_theorem_note_2026-05-02": {
    "deps_hash": "45b34f1904c9",

--- a/logs/runner-cache/u1_exact_source_work_closed_dipole_radiation_2026_09_03.txt
+++ b/logs/runner-cache/u1_exact_source_work_closed_dipole_radiation_2026_09_03.txt
@@ -1,0 +1,40 @@
+===== runner cache v1 =====
+runner: scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py
+runner_sha256: 32eaeafbca486646bdf97c4766f622ad96c4901dfcff375c921ea2984352a971
+input_fingerprint_sha256: 0f08a9b9d5a5abc3e13e0ce57cf5a3b460054cf4389c76303e7c270e3f451c26
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.42
+status: ok
+----- stdout -----
+[PASS] 01 the work and radiation checks use the exact physical incidence complex
+[PASS] 02 the source-work cross term holds exactly as an integer matrix identity
+[PASS] 03 the source-work quadratic term holds exactly as an integer matrix identity
+[PASS] 04 deterministic full-field trials reproduce midpoint source work
+[PASS] 05 zero source reduces the work theorem to exact parent field-energy conservation
+[PASS] 06 the first pulse creates a unit nearest-neighbor charge dipole
+[PASS] 07 the reversed second pulse returns every vertex charge exactly to zero
+[PASS] 08 the closed two-tick pulse has the derived curl/co-curl field formula exactly
+[PASS] 09 the post-dipole radiation packet obeys both Gauss laws exactly
+[PASS] 10 the returned charge leaves a nonzero field wholly in the transverse incidence images
+[PASS] 11 the pulse leaves no constant harmonic electric or magnetic field
+[PASS] 12 the unit-dipole radiation packet has positive modified energy exactly one half
+[PASS] 13 accumulated midpoint work equals the complete residual radiation energy
+[PASS] 14 reversing time and the ordered source history returns the packet to zero exactly
+[PASS] 15 reversing the dipole orientation reverses the field and keeps its energy
+[PASS] 16 the sparse large-volume propagator is byte-identical to the dense role curl at L=3
+[PASS] 17 the emitted packet conserves its exact modified energy for eight source-free cycles
+[PASS] 18 the radiation support advances on the exact finite causal ladder 3,5,...,19
+[PASS] 19 the squared-field centroid moves monotonically away from the closed source
+[PASS] 20 more than 99.8 percent of squared field amplitude leaves the radius-three source neighborhood
+[PASS] 21 source work and the driven field covary under all 48 cubic transformations
+[PASS] 22 simultaneous opposite currents cancel while a one-tick-separated pair radiates
+per_element: each source coefficient, incidence sign, and exact work numerator is checked
+per_site: one edge pulse creates and erases charges only on its two neighboring vertices
+per_mode: the residual field lies in curl/co-curl images with no longitudinal or harmonic component
+per_block: exact work, Gauss laws, reversal, cubic covariance, and dipole controls are checked
+lattice_wide: an L=20 sparse block conserves energy and carries the packet from support radius 3 through 19
+TOTAL: PASS=22 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py
+++ b/scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Exact source work and a closed two-tick dipole radiation packet.
+
+For the finite-depth local Maxwell tick, a supplied edge current obeys the
+exact discrete work identity
+
+    H_h(x') - H_h(x) = h J^T (E + E') / 2.
+
+A current pulse followed one tick later by its negative creates a temporary
+nearest-neighbor charge dipole, returns charge exactly to zero, and leaves a
+nonzero field entirely in the curl/co-curl photon sector.  Sparse propagation
+then checks exact field-energy conservation, the causal support ladder, and
+outward transport on a larger periodic block before wraparound.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import sparse
+
+from u1_conserved_source_coulomb_photon_bridge_2026_09_03 import sourced_tick
+from u1_local_reversible_yee_leapfrog_tick_2026_09_03 import (
+    all_cubic_transformations,
+    exact_half_step_matrices,
+    modified_energy_metric,
+    periodic_l1,
+)
+from u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03 import (
+    curl_symbol,
+    edge_axis,
+    face_boundary_sites,
+    physical_incidence,
+    role_bits,
+    role_kind,
+    sites,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "scripts/u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03.py",
+    "scripts/u1_local_reversible_yee_leapfrog_tick_2026_09_03.py",
+    "scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def field_energy(
+    curl: np.ndarray | sparse.spmatrix,
+    electric: np.ndarray,
+    magnetic: np.ndarray,
+    step: float,
+) -> float:
+    face_curl = curl @ electric
+    return float(
+        0.5 * (electric @ electric + magnetic @ magnetic)
+        - step**2 * (face_curl @ face_curl) / 8.0
+    )
+
+
+def source_work(
+    electric_old: np.ndarray,
+    electric_new: np.ndarray,
+    current: np.ndarray,
+    step: float,
+) -> float:
+    return float(0.5 * step * current @ (electric_old + electric_new))
+
+
+def sparse_physical_curl(
+    coarse_size: int,
+) -> tuple[
+    tuple[tuple[int, int, int], ...],
+    tuple[tuple[int, int, int], ...],
+    sparse.csr_matrix,
+]:
+    """Build the role compiler's curl without allocating a dense L^6 array."""
+
+    physical_size = 2 * coarse_size
+    sector = (0, 0, 0)
+    role_sites: dict[str, list[tuple[int, int, int]]] = {
+        "vertex": [],
+        "edge": [],
+        "face": [],
+        "cube": [],
+    }
+    for raw_point in sites(physical_size):
+        point = tuple(raw_point)
+        role_sites[role_kind(role_bits(point, sector))].append(point)
+    edges = tuple(sorted(role_sites["edge"]))
+    faces = tuple(sorted(role_sites["face"]))
+    edge_index = {point: index for index, point in enumerate(edges)}
+
+    rows: list[int] = []
+    columns: list[int] = []
+    values: list[int] = []
+    for row, face in enumerate(faces):
+        boundary = face_boundary_sites(
+            face, role_bits(face, sector), physical_size
+        )
+        for edge, sign in zip(boundary, (1, 1, -1, -1)):
+            rows.append(row)
+            columns.append(edge_index[edge])
+            values.append(sign)
+    curl = sparse.csr_matrix(
+        (values, (rows, columns)),
+        shape=(len(faces), len(edges)),
+        dtype=float,
+    )
+    return edges, faces, curl
+
+
+def closed_dipole_formula(
+    curl: np.ndarray,
+    current: np.ndarray,
+    step: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    curl_current = curl @ current
+    electric = -(step**3) * curl.T @ curl_current
+    magnetic = (
+        step**2 * curl_current
+        - 0.5 * step**4 * curl @ (curl.T @ curl_current)
+    )
+    return electric, magnetic
+
+
+def main() -> int:
+    checks = Checks()
+    (
+        vertices,
+        edges,
+        faces,
+        cubes,
+        gradient,
+        curl_integer,
+        divergence,
+    ) = physical_incidence(3)
+    curl = curl_integer.astype(float)
+    edge_count = len(edges)
+    face_count = len(faces)
+    total_count = edge_count + face_count
+    checks.check(
+        np.array_equal(curl_integer @ gradient, np.zeros((81, 27), dtype=int))
+        and np.array_equal(
+            divergence @ curl_integer, np.zeros((27, 81), dtype=int)
+        ),
+        "the work and radiation checks use the exact physical incidence complex",
+    )
+
+    # At h=1/2 the parent tick is U_num/32, its energy metric is M_num/16,
+    # and the affine source response is R_num/8 with R_num=(4I,C)^T.
+    magnetic_numerator, electric_numerator = exact_half_step_matrices(
+        curl_integer
+    )
+    tick_numerator = (
+        magnetic_numerator @ electric_numerator @ magnetic_numerator
+    )
+    metric_numerator = np.block(
+        [
+            [
+                16 * np.eye(edge_count, dtype=np.int64)
+                - curl_integer.T @ curl_integer,
+                np.zeros((edge_count, face_count), dtype=np.int64),
+            ],
+            [
+                np.zeros((face_count, edge_count), dtype=np.int64),
+                16 * np.eye(face_count, dtype=np.int64),
+            ],
+        ]
+    )
+    source_response_numerator = np.vstack(
+        (4 * np.eye(edge_count, dtype=np.int64), curl_integer)
+    )
+    electric_inclusion = np.vstack(
+        (
+            np.eye(edge_count, dtype=np.int64),
+            np.zeros((face_count, edge_count), dtype=np.int64),
+        )
+    )
+    checks.check(
+        np.array_equal(
+            tick_numerator.T
+            @ metric_numerator
+            @ source_response_numerator,
+            32
+            * (
+                32 * electric_inclusion
+                + tick_numerator.T @ electric_inclusion
+            ),
+        ),
+        "the source-work cross term holds exactly as an integer matrix identity",
+    )
+    checks.check(
+        np.array_equal(
+            source_response_numerator.T
+            @ metric_numerator
+            @ source_response_numerator,
+            256 * np.eye(edge_count, dtype=np.int64),
+        ),
+        "the source-work quadratic term holds exactly as an integer matrix identity",
+    )
+
+    step = 0.5
+    metric = modified_energy_metric(curl, step)
+    deterministic_fields = (
+        (
+            np.array(
+                [(7 * index + 2) % 13 - 6 for index in range(edge_count)],
+                dtype=float,
+            ),
+            np.array(
+                [(5 * index + 1) % 11 - 5 for index in range(face_count)],
+                dtype=float,
+            ),
+            np.array(
+                [(3 * index + 4) % 9 - 4 for index in range(edge_count)],
+                dtype=float,
+            ),
+        ),
+        (
+            np.linspace(-0.7, 0.9, edge_count),
+            np.linspace(0.6, -0.4, face_count),
+            np.cos(np.arange(edge_count, dtype=float)),
+        ),
+    )
+    work_identity_ok = True
+    for electric_old, magnetic_old, current in deterministic_fields:
+        electric_new, magnetic_new = sourced_tick(
+            curl, electric_old, magnetic_old, current, step
+        )
+        state_old = np.concatenate((electric_old, magnetic_old))
+        state_new = np.concatenate((electric_new, magnetic_new))
+        energy_change = 0.5 * float(
+            state_new @ metric @ state_new - state_old @ metric @ state_old
+        )
+        work_identity_ok = work_identity_ok and (
+            abs(
+                energy_change
+                - source_work(electric_old, electric_new, current, step)
+            )
+            < 3.0e-11
+        )
+    checks.check(
+        work_identity_ok,
+        "deterministic full-field trials reproduce midpoint source work",
+    )
+
+    zero_current = np.zeros(edge_count)
+    electric_old, magnetic_old, _current = deterministic_fields[0]
+    electric_free, magnetic_free = sourced_tick(
+        curl, electric_old, magnetic_old, zero_current, step
+    )
+    checks.check(
+        abs(
+            field_energy(curl, electric_free, magnetic_free, step)
+            - field_energy(curl, electric_old, magnetic_old, step)
+        )
+        < 2.0e-11,
+        "zero source reduces the work theorem to exact parent field-energy conservation",
+    )
+
+    # A current followed by its negative makes and then erases a local charge
+    # dipole, while the one-tick delay leaves a transverse field packet.
+    current = np.zeros(edge_count)
+    current[0] = 1.0 / step
+    charge = np.zeros(len(vertices))
+    electric = np.zeros(edge_count)
+    magnetic = np.zeros(face_count)
+    electric_before = electric.copy()
+    electric, magnetic = sourced_tick(
+        curl, electric, magnetic, current, step
+    )
+    work_first = source_work(electric_before, electric, current, step)
+    charge = charge + step * gradient.T @ current
+    first_charge = charge.copy()
+    checks.check(
+        tuple(sorted(first_charge[first_charge != 0.0])) == (-1.0, 1.0)
+        and np.count_nonzero(first_charge) == 2,
+        "the first pulse creates a unit nearest-neighbor charge dipole",
+    )
+
+    electric_before = electric.copy()
+    electric, magnetic = sourced_tick(
+        curl, electric, magnetic, -current, step
+    )
+    work_second = source_work(electric_before, electric, -current, step)
+    charge = charge - step * gradient.T @ current
+    checks.check(
+        np.array_equal(charge, np.zeros(len(vertices))),
+        "the reversed second pulse returns every vertex charge exactly to zero",
+    )
+
+    expected_electric, expected_magnetic = closed_dipole_formula(
+        curl, current, step
+    )
+    checks.check(
+        np.array_equal(electric, expected_electric)
+        and np.array_equal(magnetic, expected_magnetic),
+        "the closed two-tick pulse has the derived curl/co-curl field formula exactly",
+    )
+
+    current_integer = np.zeros(edge_count, dtype=np.int64)
+    current_integer[0] = 2
+    curl_current = curl_integer @ current_integer
+    co_curl_current = curl_integer.T @ curl_current
+    electric_final_numerator = -4 * co_curl_current
+    magnetic_final_numerator = (
+        8 * curl_current - curl_integer @ co_curl_current
+    )
+    final_state_numerator = np.concatenate(
+        (electric_final_numerator, magnetic_final_numerator)
+    )
+    checks.check(
+        np.array_equal(
+            gradient.T @ electric_final_numerator,
+            np.zeros(len(vertices), dtype=np.int64),
+        )
+        and np.array_equal(
+            divergence @ magnetic_final_numerator,
+            np.zeros(len(cubes), dtype=np.int64),
+        ),
+        "the post-dipole radiation packet obeys both Gauss laws exactly",
+    )
+    checks.check(
+        np.count_nonzero(final_state_numerator) > 0
+        and np.array_equal(
+            electric_final_numerator, -4 * curl_integer.T @ curl_current
+        ),
+        "the returned charge leaves a nonzero field wholly in the transverse incidence images",
+    )
+    checks.check(
+        all(
+            int(
+                np.sum(
+                    electric_final_numerator[
+                        [
+                            index
+                            for index, edge in enumerate(edges)
+                            if edge_axis(role_bits(edge, (0, 0, 0))) == axis
+                        ]
+                    ]
+                )
+            )
+            == 0
+            and int(
+                np.sum(
+                    magnetic_final_numerator[
+                        [
+                            index
+                            for index, face in enumerate(faces)
+                            if role_bits(face, (0, 0, 0))[axis] == 0
+                        ]
+                    ]
+                )
+            )
+            == 0
+            for axis in range(3)
+        ),
+        "the pulse leaves no constant harmonic electric or magnetic field",
+    )
+
+    exact_energy_numerator = int(
+        final_state_numerator @ metric_numerator @ final_state_numerator
+    )
+    checks.check(
+        exact_energy_numerator == 16384,
+        "the unit-dipole radiation packet has positive modified energy exactly one half",
+    )
+    final_energy = field_energy(curl, electric, magnetic, step)
+    checks.check(
+        abs(final_energy - (work_first + work_second)) < 2.0e-13
+        and abs(final_energy - 0.5) < 2.0e-13,
+        "accumulated midpoint work equals the complete residual radiation energy",
+    )
+
+    reversed_electric, reversed_magnetic = sourced_tick(
+        curl, electric, magnetic, -current, -step
+    )
+    reversed_electric, reversed_magnetic = sourced_tick(
+        curl, reversed_electric, reversed_magnetic, current, -step
+    )
+    checks.check(
+        np.array_equal(reversed_electric, np.zeros(edge_count))
+        and np.array_equal(reversed_magnetic, np.zeros(face_count)),
+        "reversing time and the ordered source history returns the packet to zero exactly",
+    )
+
+    opposite_electric = np.zeros(edge_count)
+    opposite_magnetic = np.zeros(face_count)
+    opposite_electric, opposite_magnetic = sourced_tick(
+        curl, opposite_electric, opposite_magnetic, -current, step
+    )
+    opposite_electric, opposite_magnetic = sourced_tick(
+        curl, opposite_electric, opposite_magnetic, current, step
+    )
+    checks.check(
+        np.array_equal(opposite_electric, -electric)
+        and np.array_equal(opposite_magnetic, -magnetic),
+        "reversing the dipole orientation reverses the field and keeps its energy",
+    )
+
+    sparse_edges3, sparse_faces3, sparse_curl3 = sparse_physical_curl(3)
+    checks.check(
+        sparse_edges3 == edges
+        and sparse_faces3 == faces
+        and np.array_equal(sparse_curl3.toarray(), curl_integer),
+        "the sparse large-volume propagator is byte-identical to the dense role curl at L=3",
+    )
+
+    # Large sparse propagation before the light cone wraps around the L=20
+    # coarse torus. Squared raw amplitude is used only as a location diagnostic;
+    # exact conservation is checked with the modified field energy above.
+    large_size = 20
+    large_edges, large_faces, large_curl = sparse_physical_curl(large_size)
+    edge_index = {point: index for index, point in enumerate(large_edges)}
+    source_site = (
+        2 * (large_size // 2) + 1,
+        2 * (large_size // 2),
+        2 * (large_size // 2),
+    )
+    large_current = np.zeros(len(large_edges))
+    large_current[edge_index[source_site]] = 1.0 / step
+    large_electric = np.zeros(len(large_edges))
+    large_magnetic = np.zeros(len(large_faces))
+    large_electric, large_magnetic = sourced_tick(
+        large_curl,
+        large_electric,
+        large_magnetic,
+        large_current,
+        step,
+    )
+    large_electric, large_magnetic = sourced_tick(
+        large_curl,
+        large_electric,
+        large_magnetic,
+        -large_current,
+        step,
+    )
+    all_sites = large_edges + large_faces
+    distances = np.array(
+        [periodic_l1(source_site, point, 2 * large_size) for point in all_sites]
+    )
+    energies = []
+    centroids = []
+    near_fractions = []
+    support_radii = []
+    for _cycle in range(9):
+        energies.append(
+            field_energy(
+                large_curl, large_electric, large_magnetic, step
+            )
+        )
+        weights = np.concatenate((large_electric**2, large_magnetic**2))
+        centroids.append(float(weights @ distances / np.sum(weights)))
+        near_fractions.append(
+            float(np.sum(weights[distances <= 3]) / np.sum(weights))
+        )
+        support_radii.append(
+            int(np.max(distances[np.abs(weights) > 1.0e-26]))
+        )
+        large_electric, large_magnetic = sourced_tick(
+            large_curl,
+            large_electric,
+            large_magnetic,
+            np.zeros(len(large_edges)),
+            step,
+        )
+    checks.check(
+        max(abs(value - 0.5) for value in energies) < 2.0e-13,
+        "the emitted packet conserves its exact modified energy for eight source-free cycles",
+    )
+    checks.check(
+        support_radii == list(range(3, 20, 2)),
+        "the radiation support advances on the exact finite causal ladder 3,5,...,19",
+    )
+    checks.check(
+        all(left < right for left, right in zip(centroids, centroids[1:]))
+        and centroids[-1] > 8.9,
+        "the squared-field centroid moves monotonically away from the closed source",
+    )
+    checks.check(
+        near_fractions[0] == 1.0 and near_fractions[-1] < 0.002,
+        "more than 99.8 percent of squared field amplitude leaves the radius-three source neighborhood",
+    )
+
+    # The work scalar and source update must not pick a preferred cubic axis.
+    cubic_work_ok = True
+    sample_electric = np.array([0.2, -0.3, 0.7])
+    sample_magnetic = np.array([-0.4, 0.8, 0.1])
+    sample_current = np.array([0.6, -0.2, 0.5])
+    for symbol in (
+        np.array([0.3, 0.7, 1.1]),
+        np.array([1.0, 0.0, 0.0]),
+    ):
+        curl_block = curl_symbol(symbol)
+        electric_out, magnetic_out = sourced_tick(
+            curl_block,
+            sample_electric,
+            sample_magnetic,
+            sample_current,
+            step,
+        )
+        work = source_work(
+            sample_electric, electric_out, sample_current, step
+        )
+        for transform in all_cubic_transformations():
+            determinant = int(round(np.linalg.det(transform)))
+            transformed_electric, transformed_magnetic = sourced_tick(
+                curl_symbol(transform @ symbol),
+                transform @ sample_electric,
+                determinant * transform @ sample_magnetic,
+                transform @ sample_current,
+                step,
+            )
+            transformed_work = source_work(
+                transform @ sample_electric,
+                transformed_electric,
+                transform @ sample_current,
+                step,
+            )
+            cubic_work_ok = cubic_work_ok and bool(
+                abs(transformed_work - work) < 2.0e-13
+                and np.max(
+                    np.abs(transformed_electric - transform @ electric_out)
+                )
+                < 2.0e-12
+                and np.max(
+                    np.abs(
+                        transformed_magnetic
+                        - determinant * transform @ magnetic_out
+                    )
+                )
+                < 2.0e-12
+            )
+    checks.check(
+        cubic_work_ok,
+        "source work and the driven field covary under all 48 cubic transformations",
+    )
+
+    # A simultaneous cancellation is the zero-source control. The nonzero
+    # packet above is caused by the one-tick temporal separation, not by a
+    # hidden static source or an arithmetic offset.
+    cancel_electric, cancel_magnetic = sourced_tick(
+        curl,
+        np.zeros(edge_count),
+        np.zeros(face_count),
+        current - current,
+        step,
+    )
+    checks.check(
+        np.array_equal(cancel_electric, np.zeros(edge_count))
+        and np.array_equal(cancel_magnetic, np.zeros(face_count)),
+        "simultaneous opposite currents cancel while a one-tick-separated pair radiates",
+    )
+
+    print(
+        "per_element: each source coefficient, incidence sign, and exact work numerator is checked"
+    )
+    print(
+        "per_site: one edge pulse creates and erases charges only on its two neighboring vertices"
+    )
+    print(
+        "per_mode: the residual field lies in curl/co-curl images with no longitudinal or harmonic component"
+    )
+    print(
+        "per_block: exact work, Gauss laws, reversal, cubic covariance, and dipole controls are checked"
+    )
+    print(
+        "lattice_wide: an L=20 sparse block conserves energy and carries the packet from support radius 3 through 19"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

The finite-depth sourced photon tick obeys the exact discrete work law

H_field(new) - H_field(old) = h J dot (E_old + E_new)/2.

A one-edge current followed one tick later by its negative creates a unit neighboring charge dipole, returns every charge to zero, and leaves a nonzero field entirely in the curl/co-curl sector with no longitudinal or harmonic component. At h=1/2 its modified energy is exactly 1/2 and equals accumulated source work.

On an L=20 sparse role lattice the packet keeps that energy for eight source-free cycles, advances through exact support radii 3,5,...,19, and leaves under 0.2 percent of squared field amplitude near the source.

Runner: TOTAL: PASS=22 FAIL=0. Includes exact integer identities, identity-pinned cache, bounded theorem note, N1-N8 scope packet, and graph acknowledgment.

## Why this matters

This turns the source bridge into a sharp matter-light join criterion. A future joint local hop must satisfy continuity and also lose exactly the work gained by the field. Open PRs #7892 and #7903 are context-only pincer surfaces; they are not imported as authority here.

## Scope

Source science only, not an audit verdict. No TOE score, axiom, primitive, or audit status changes. The fields remain real and weak, the current is prescribed, and quantization, compact finite payload, coupling normalization, and Record detection remain open.

## Validation

- runner 22/22
- cache identity fresh
- claim typing clean
- vocabulary lint clean
- repository invariants and enforced links clean
- strict audit lint clean apart from repository baseline warnings/notices