### PR TITLE
science(light): finite-step matter current meets operator field work

### DIFF
--- a/docs/U1_FINITE_STEP_GAUGE_COVARIANT_MATTER_CURRENT_OPERATOR_WORK_INTERFACE_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_FINITE_STEP_GAUGE_COVARIANT_MATTER_CURRENT_OPERATOR_WORK_INTERFACE_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,553 @@
+# Finite-Step Gauge-Covariant Matter Current and Operator Work Interface
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct field-work parent:**
+[`U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Conserved-source parent:**
+[`U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Photon-tick parent:**
+[`U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_LOCAL_REVERSIBLE_YEE_LEAPFROG_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Kinetic normalization boundary:**
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+
+**Runner:**
+[`scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py`](../scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/u1_finite_step_matter_current_operator_work_interface_2026_09_03.txt`](../logs/runner-cache/u1_finite_step_matter_current_operator_work_interface_2026_09_03.txt)
+
+## Result up front
+
+A finite local matter hop supplies exactly the kind of edge current required
+by the sourced photon tick, but it is not generally the instantaneous current
+`i[H,n]` evaluated at the start of the tick.
+
+For an oriented two-site charged hop with link phase `A`, hopping coefficient
+`t`, tail/head number projectors `n_t,n_h`, and
+
+```text
+H_b(A)=-t(cos(A) X+sin(A) Y),
+V_h(A)=exp(-i h H_b(A)),
+```
+
+define the finite-step oriented current by the actual transported charge:
+
+```text
+Jbar_h(A)=(V_h^dagger n_h V_h-n_h)/h.
+```
+
+Then, as operator identities,
+
+```text
+V_h^dagger n_t V_h-n_t=-h Jbar_h,
+V_h^dagger n_h V_h-n_h=+h Jbar_h.
+```
+
+The current is Hermitian, local to the bond, gauge covariant, reverses sign
+with bond orientation, and has the closed form
+
+```text
+Jbar_h(A)
+ = [sin(2th)/(2h)] [cos(A)Y-sin(A)X]
+   +[(1-cos(2th))/(2h)] Z.
+```
+
+Its first term tends to the familiar instantaneous current
+
+```text
+J_0=i[H_b,n_h]=t[cos(A)Y-sin(A)X],
+```
+
+while the `Z` term is the finite transported-charge correction. On a
+refinement ladder, `Jbar_h` differs from the current evolved to the temporal
+midpoint by `O(h^2)`, but differs from the initial instantaneous current by
+`O(h)`. At a resolved tick the correction is large and cannot be silently
+dropped.
+
+The construction composes locally. A three-site two-layer hop satisfies exact
+continuity at every site. On an `L=4` cubic torus, all `192` positive-axis
+bonds split into six matchings by axis and tail parity; every operational
+current remains on its two-site bond, the six layers form a unitary tick, and
+all `64` vertex continuity equations hold to `3e-14`.
+
+There is also a required operator-ordering correction to the field-work
+parent. If `J`, `E`, and `B` are noncommuting Hermitian operators, the exact
+field energy change is
+
+```text
+Delta H_field
+  =(h/4) sum_e {J_e,E_e+E'_e},
+```
+
+where `{A,B}=AB+BA`. The unsymmetrized classical product is generally
+non-Hermitian and fails the energy identity. When current and field commute,
+the anticommutator reduces exactly to the parent's classical midpoint work.
+
+This is a positive matter-light interface result. It removes two hidden join
+errors before the branches meet:
+
+1. use the integrated current of each finite matter layer, not an endpoint
+   current; and
+2. use symmetrized operator work when the current contains noncommuting link
+   operators.
+
+It does not yet construct a closed backreacting matter-field tick. The link
+phase is supplied during each matter hop, and this note proves the field work
+gained but not the equal matter energy lost. The exact remaining target is
+
+```text
+Delta H_matter
+  =-(h/4) sum_e {Jbar_e,E_e+E'_e}
+```
+
+inside one layerwise local, reversible, gauge-preserving update.
+
+## 1. The exact finite-step current
+
+Use the one-particle bond basis
+
+```text
+|tail>, |head>.
+```
+
+The endpoint projectors are
+
+```text
+n_t=(I+Z)/2,               n_h=(I-Z)/2.
+```
+
+The oriented link transporter appears through
+
+```text
+H_b(A)=-t(cos(A)X+sin(A)Y).
+```
+
+Since the Pauli direction squares to identity,
+
+```text
+V_h(A)
+ =cos(th)I+i sin(th)(cos(A)X+sin(A)Y).
+```
+
+Total number is exactly conserved because
+
+```text
+n_t+n_h=I.
+```
+
+Rather than approximating the transported charge, define the current from
+the endpoint difference:
+
+```text
+Jbar_h=(n_h'-n_h)/h.
+```
+
+The two continuity equations then follow without truncation. Direct Pauli
+reduction gives
+
+```text
+Jbar_h
+ =[sin(2th)/(2h)](cos(A)Y-sin(A)X)
+  +[(1-cos(2th))/(2h)]Z.
+```
+
+The runner checks the definition, formula, Hermiticity, tracelessness,
+unitarity, and both endpoint equations over `5 x 3 x 3=45` phase, hopping,
+and step combinations.
+
+The formula is not merely notation. Expanding at small `h` gives
+
+```text
+Jbar_h
+ =J_0+t^2 h Z+O(h^2).
+```
+
+Thus an initial-time insertion of `J_0` misses an order-`h` polarization term
+in the current, producing an order-`h^2` charge error per tick. Evaluating the
+instantaneous current at the temporal midpoint absorbs the odd correction,
+so its current error is `O(h^2)`. The executable observes refinement ratios
+of two for the endpoint error and four for the midpoint error.
+
+This is the smallest correction required to connect a continuous Hamiltonian
+current to an exact finite-tick Gauss law.
+
+## 2. Gauge covariance and orientation
+
+Let endpoint gauge phases be `alpha_t,alpha_h`. The matter basis transforms by
+
+```text
+G=diag(exp(i alpha_t),exp(i alpha_h)),
+```
+
+and the link phase by
+
+```text
+A' = A+alpha_h-alpha_t.
+```
+
+Then
+
+```text
+H_b(A')=G H_b(A) G^dagger,
+V_h(A')=G V_h(A) G^dagger,
+Jbar_h(A')=G Jbar_h(A) G^dagger.
+```
+
+The runner checks three nontrivial phase triples. Swapping tail and head and
+sending `A -> -A` gives
+
+```text
+X Jbar_h(A) X=-Jbar_h(-A).
+```
+
+Thus the current has the same oriented-edge transformation required by the
+incidence source. Setting `t=0` returns the exact zero operator.
+
+This is a gauge-covariant bond interface. It does not derive which phase or
+hopping coefficient the framework selects.
+
+## 3. Layerwise continuity on overlapping hops
+
+For one bond unitary, locality is immediate. On a lattice, adjacent bond
+Hamiltonians overlap and cannot all occupy one disjoint circuit layer. The
+correct finite-depth construction uses edge colors.
+
+The runner first uses an open chain
+
+```text
+0 -- 1 -- 2
+```
+
+with the `0->1` hop followed by the `1->2` hop. Let `V_1,V_2` be the two
+unitaries. The first current is represented in the initial frame. The second
+is local on sites `1,2` when it is executed; if both increments are written
+in the initial Heisenberg frame, it is pulled back through `V_1`:
+
+```text
+J_12^(initial)=V_1^dagger J_12^(operational) V_1.
+```
+
+The exact final changes are
+
+```text
+Delta n_0=-h J_01,
+Delta n_1= h J_01-h J_12^(initial),
+Delta n_2= h J_12^(initial).
+```
+
+All three matrices agree with direct conjugation by `V_2 V_1`. Updating the
+two electric link operators by the same layer currents preserves
+
+```text
+d0^T E-n
+```
+
+at every vertex.
+
+There is an important locality distinction. `J_12^(operational)` has support
+only on sites `1,2`; its initial-frame representative has nonzero `0,2`
+matrix element after the first hop. Therefore an implementation that first
+aggregates every current in the old-time frame expands support. The positive
+local construction updates the corresponding field source after each colored
+matter layer.
+
+For an even periodic cubic lattice, color every positive-axis edge by
+
+```text
+(axis, tail-coordinate parity).
+```
+
+There are six colors. On `L=4`, each color contains `32` disjoint edges and
+covers all `64` vertices exactly once; the colors cover all `192` oriented
+bonds. The runner assigns nonuniform deterministic phases and hopping
+coefficients, builds all six block-diagonal unitaries, transports each
+operational current through its actual prefix, and checks continuity at all
+`64` vertices.
+
+This is an explicit lattice-wide finite-depth compiler for exact charge
+transport. It is not yet the complete matter-plus-photon circuit because the
+field shear and matter energy backreaction still need to be interleaved.
+
+## 4. Operator-valued field work
+
+The field-work parent used commuting real coordinates. A gauge-invariant
+matter current can contain link operators and therefore need not commute with
+the electric field. The ordering cannot be guessed by copying the classical
+formula.
+
+Write the field energy with its symmetric numeric coefficient matrix:
+
+```text
+H_h=(1/2) x^T M x.
+```
+
+This expression is Hermitian even for noncommuting Hermitian components
+because `M` is real symmetric. The sourced update remains a numeric linear
+map
+
+```text
+x'=U x+R J.
+```
+
+Expanding without commuting `x` through `J` gives
+
+```text
+Delta H
+ =(1/2) sum_ij M_ij[(Ux)_i(RJ)_j+(RJ)_i(Ux)_j]
+  +(1/2)(RJ)^T M(RJ).
+```
+
+The same coefficient identities proved by the classical parent reduce this
+to
+
+```text
+Delta H
+ =(h/4) sum_e [J_e(E_e+E'_e)+(E_e+E'_e)J_e]
+ =(h/4) sum_e {J_e,E_e+E'_e}.
+```
+
+The runner instantiates all three electric and magnetic components with
+noncommuting Pauli combinations and puts an actual integrated bond current in
+the source vector. The operator residual is below `3e-15`. The result is
+Hermitian.
+
+As an adversarial control it evaluates the left-ordered classical expression
+
+```text
+(h/2) sum_e J_e(E_e+E'_e).
+```
+
+That operator differs from the true energy change by more than `0.04` and
+from its own adjoint by more than `0.08`. The missing anticommutator is a
+physical operator-ordering error, not cosmetic notation.
+
+When every field and current is a scalar multiple of identity, the runner
+recovers the classical midpoint law exactly. It also evaluates the operator
+identity in a nontrivial complex matter state and obtains equal expectation
+values.
+
+## 5. What this does to the matter-light pincer
+
+Open PR #7892 reports an instantaneous conserved current for the emergent
+fermion. Open PR #7903 reports a compact-link matter/gauge coupling. They are
+context-only pointers in this source: neither branch is imported as proof
+authority.
+
+The present theorem states the finite-tick interface those sources must meet.
+For each local colored hop:
+
+1. compute or realize the integrated current from the actual unitary charge
+   transfer;
+2. apply that current to the corresponding oriented electric link in the same
+   operational layer;
+3. preserve `d0^T E-rho` exactly; and
+4. make the matter sector lose the anticommutator work gained by the field.
+
+Items 1-3 are positive here for a generic gauge-covariant charged hop. Item 4
+is the remaining energy-backreaction join. This is narrower and more useful
+than the prior statement “matter current must couple to Maxwell.” It exposes
+the temporal averaging, layer schedule, and operator ordering that determine
+whether the join is actually valid.
+
+## 6. Program and axiom boundary
+
+No axiom update is implied. The minimal axioms leave the transition law,
+hopping coefficient, link phase, and Hamiltonian supplier open. The approved
+kinetic primitive normalizes spacetime form but does not select the bond
+unitary or its field coupling.
+
+The result is nevertheless positive TOE-directed science. At source level,
+the following pieces now share one exact interface language:
+
+- local gauge-covariant matter transfer;
+- finite-step conserved charge/current;
+- layerwise electric Gauss preservation;
+- sourced transverse photon dynamics; and
+- Hermitian operator field work.
+
+What remains is not “find a current.” It is construct one joint reversible
+matter-field layer whose matter energy changes by the negative operator work,
+then compile its finite field payload and Record observables.
+
+## 7. Executable evidence
+
+The runner reports `TOTAL: PASS=24 FAIL=0`. It checks:
+
+- `45` bond phase/hopping/step combinations for unitarity, conservation,
+  endpoint continuity, Hermiticity, and the analytic current formula;
+- endpoint-versus-midpoint refinement orders and a resolved finite-step
+  correction;
+- endpoint gauge covariance, orientation reversal, and the zero-hop control;
+- a two-layer overlapping three-site schedule;
+- exact Gauss-residual preservation with integrated link currents;
+- operational versus initial-frame current support;
+- all six matchings and all `192` bonds on an `L=4` cubic torus;
+- continuity at all `64` torus vertices;
+- noncommuting anticommutator field work;
+- failure and non-Hermiticity of the unsymmetrized product;
+- the commuting classical limit; and
+- a nontrivial state expectation value.
+
+## No-Go Discipline Gate
+
+The positive interface includes a negative control on endpoint current and
+unsymmetrized work. This gate keeps those failures inside their exact scope.
+
+### N1 — Alternative route enumeration
+
+| Honesty | Route | Outcome |
+|---|---|---|
+| **ATTEMPTED** | current from exact endpoint charge difference | **Positive:** exact finite-step continuity and analytic local current; checks 1-5. |
+| **ATTEMPTED** | initial instantaneous current | First-order current error on the refinement ladder; useful only as an infrared approximation; checks 6-8. |
+| **ATTEMPTED** | temporal-midpoint instantaneous current | Positive second-order approximation, but not the exact finite current; check 6. |
+| **ATTEMPTED** | layerwise edge coloring | **Positive:** local six-layer cubic tick with exact vertex continuity; checks 12-19. |
+| **ATTEMPTED** | aggregate all currents in the old-time frame | Continuity survives algebraically but support spreads across prior layers; check 17. |
+| **ATTEMPTED** | anticommutator operator work | **Positive:** exact Hermitian field-energy change; checks 20-21 and 24. |
+| **ATTEMPTED** | left-ordered classical work | Fails and is non-Hermitian for noncommuting fields; check 22. |
+| **OPEN** | joint gauge-link backreaction layer | Must make matter lose the exact anticommutator work while retaining locality and reversibility. |
+
+### N2 — Wall-independence audit
+
+Use
+
+```text
+W1 = exact matter energy backreaction,
+W2 = compact finite field payload,
+W3 = interleaved matter/field layer schedule,
+W4 = Record preparation and readout,
+W5 = coupling normalization and charge selection.
+```
+
+| Pair | Independent? | Reason |
+|---|---:|---|
+| W1, W2 | yes | an unbounded rotor can exchange exact energy without a finite compiler |
+| W1, W3 | yes | a global energy-preserving map need not have a local layer schedule |
+| W1, W4 | yes | energy balance does not form a Record |
+| W1, W5 | yes | opposite work fixes matching, not the physical coupling value |
+| W2, W3 | yes | finite payload does not itself supply a collision schedule |
+| W2, W4 | yes | a finite Hilbert carrier and outcome readout are distinct |
+| W2, W5 | yes | payload dimension does not set electric charge |
+| W3, W4 | yes | local scheduling does not select registered outcomes |
+| W3, W5 | yes | edge coloring does not normalize the coupling |
+| W4, W5 | yes | readout does not fix interaction strength |
+
+### N3 — Hidden-wall scan
+
+The matter calculation is the one-particle sector of a supplied two-site
+hopping Hamiltonian. The link phase is external. The `L=4` torus is even so
+the six parity matchings exist. Numerical tolerances test analytic operator
+identities. Currents are operationally local layer by layer; their aggregated
+initial-frame representatives are explicitly not called local. The field
+work theorem uses the parent's linear weak-field metric. No actual emergent
+fermion code, compact-link PR, Record event, or finite field payload is
+silently imported.
+
+### N4 — Residual matching
+
+| Surface | Residual | Match here |
+|---|---|---|
+| exact-work parent | matter current and opposite matter work absent | **positive partial closure:** finite matter current and operator field work; opposite matter work remains |
+| conserved-source parent | current supplied as a c-number | **positive extension:** current now comes from exact unitary charge transfer |
+| matter current context | continuous instantaneous current | **interface correction:** integrated current required at finite step |
+| compact gauge context | link operator may not commute with E | **interface correction:** anticommutator work required |
+| minimal axioms | transition law not selected | **unchanged:** bond hop remains supplied physics |
+
+### N5 — Rhetoric and resolution audit
+
+“Exact” refers to the unitary definition, endpoint differences, continuity,
+Gauss residual, and operator algebra. “Lattice-wide” refers to the explicit
+`L=4`, 64-vertex, 192-bond colored schedule and the general even-cubic coloring
+construction. “Local” refers to the operational layer, not every current
+pulled back to the initial Heisenberg frame. The endpoint and ordered-product
+failures are not generalized into no-go statements about other integrators or
+joint Hamiltonians.
+
+The cache contains all five resolution lines:
+
+```text
+per_element: the oriented bond phase, finite current, and operator anticommutator coefficients are checked
+per_site: exact tail/head continuity and each operational two-site current support are checked
+per_mode: instantaneous, midpoint, and integrated current orders are separated on a refinement ladder
+per_block: one-bond gauge covariance, three-site colored continuity, Gauss preservation, and operator work are checked
+lattice_wide: the layerwise construction generalizes by finite edge coloring; no global solve or all-at-once current is used
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The approved kinetic primitive supplies no matter current or ordering rule.
+The shortest positive route is a local backreaction layer on one bond, tested
+first in the joint charge-one sector: make its matter Hamiltonian change by
+the negative anticommutator work, then compose it with the six-color schedule.
+An exact continuous-time local Hamiltonian is a second route but would reopen
+the already identified finite-tick locality distinction. A discrete-gradient
+or collision-model layer is a third route. None demands an axiom edit before
+construction is attempted.
+
+### N7 — Steelman
+
+A hostile reviewer should object that defining current from transported charge
+makes continuity tautological. It does. The nontrivial content is the explicit
+local formula, its gauge/orientation behavior, its finite-step difference from
+`i[H,n]`, and its successful composition across overlapping lattice layers.
+Those are exactly the points a matter-to-field compiler can get wrong.
+
+The reviewer should also object that the link phase is external and total
+energy is not yet conserved. That objection survives. This is an interface
+theorem, not a completed coupled theory. The next test must dynamize the link
+and close opposite matter work.
+
+### N8 — Cross-cycle echo
+
+Earlier source cycles correctly matched classical continuity but could have
+invited an invalid direct substitution of a continuous current operator into
+a finite tick. This cycle catches that mismatch before integration. It also
+extends the exact classical work identity rather than assuming commuting
+matter/link operators. The explicit left-ordered failure prevents a symbolic
+name match from being mistaken for a quantum energy theorem.
+
+**Gate result:** PASS for the bounded finite-step current and operator-work
+interface. Seven route variants are executed, the strongest positive compiler
+is explicit, and the one remaining energy-backreaction route stays open.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- the bond unitary is not unitary or fails total charge conservation;
+- the integrated current fails either endpoint continuity equation;
+- the analytic current formula, gauge covariance, or orientation rule fails;
+- endpoint and midpoint refinement orders do not separate as stated;
+- an operational colored-layer current has off-bond support;
+- any of the three-site or 64-site continuity equations fails;
+- the integrated current fails to preserve the electric Gauss residual;
+- anticommutator work differs from the operator field-energy change;
+- the anticommutator work is non-Hermitian;
+- the left-ordered control accidentally satisfies the noncommuting identity;
+  or
+- the commuting operator limit fails to recover classical midpoint work.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=24 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15794,
- "node_count": 5571,
+ "edge_count": 15799,
+ "node_count": 5572,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18721,6 +18721,10 @@
   "u1_fermion_number_conservation_theorem_note_2026-05-02": {
    "deps_hash": "45b34f1904c9",
    "out_degree": 2
+  },
+  "u1_finite_step_gauge_covariant_matter_current_operator_work_interface_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "0f6db339869e",
+   "out_degree": 5
   },
   "u1_local_reversible_yee_leapfrog_tick_bounded_theorem_note_2026-09-03": {
    "deps_hash": "a2e328a10f1b",

--- a/logs/runner-cache/u1_finite_step_matter_current_operator_work_interface_2026_09_03.txt
+++ b/logs/runner-cache/u1_finite_step_matter_current_operator_work_interface_2026_09_03.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py
+runner_sha256: c2609a282f5695b3be5f0799839e3ddfb033e1947c119366067eaeeafcaac6ae
+input_fingerprint_sha256: abd48da7e2ed0fcb4c45c4dc1ec69a32db96f267059de6c25f8574f51c2c2838
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.20
+status: ok
+----- stdout -----
+[PASS] 01 every charged bond Hamiltonian is Hermitian and every finite hop is unitary
+[PASS] 02 the finite bond hop conserves total matter charge exactly
+[PASS] 03 the integrated oriented current obeys exact endpoint continuity
+[PASS] 04 the finite-step current is Hermitian and traceless throughout the grid
+[PASS] 05 the analytic sine-cosine current formula matches the unitary definition
+[PASS] 06 the exact integrated current approaches the midpoint current quadratically
+[PASS] 07 using the instantaneous endpoint current instead leaves a first-order tick error
+[PASS] 08 the finite-step correction is nonzero at a resolved tick and cannot be dropped
+[PASS] 09 the finite-step current covaries with the charged hop under endpoint gauge phases
+[PASS] 10 reversing the bond orientation reverses the integrated current
+[PASS] 11 a zero hopping coefficient produces exactly zero finite-step current
+[PASS] 12 two overlapping colored bond layers compose to an exact unitary
+[PASS] 13 the two-layer three-site hop obeys exact finite-step continuity at every vertex
+[PASS] 14 the colored matter schedule preserves total charge
+[PASS] 15 using the integrated layer currents preserves the electric Gauss residual exactly
+[PASS] 16 each operational current is confined to its active two-site bond layer
+[PASS] 17 aggregating layers in the initial frame spreads support, so local field coupling must follow the layers
+[PASS] 18 the L=4 cubic torus decomposes all 192 bonds into six local matching layers
+[PASS] 19 the six-layer cubic matter tick obeys finite-step continuity at all 64 vertices
+[PASS] 20 the field-energy change equals anticommutator midpoint work for noncommuting currents
+[PASS] 21 the symmetrized operator work is Hermitian
+[PASS] 22 the unsymmetrized classical product fails as a noncommuting work observable
+[PASS] 23 commuting field and current operators reduce to the classical midpoint law
+[PASS] 24 the operator work identity agrees in a nontrivial matter-state expectation value
+per_element: the oriented bond phase, finite current, and operator anticommutator coefficients are checked
+per_site: exact tail/head continuity and each operational two-site current support are checked
+per_mode: instantaneous, midpoint, and integrated current orders are separated on a refinement ladder
+per_block: one-bond gauge covariance, three-site colored continuity, Gauss preservation, and operator work are checked
+lattice_wide: the layerwise construction generalizes by finite edge coloring; no global solve or all-at-once current is used
+TOTAL: PASS=24 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py
+++ b/scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Finite-step charged-hop current and operator-valued field-work checks.
+
+An instantaneous matter current i[H,n] is not the exact current of a finite
+tick.  For a local bond unitary V, the step-integrated oriented current is
+
+    Jbar = (V^dagger n_head V - n_head) / h.
+
+It obeys exact endpoint continuity, composes layer by layer on overlapping
+bonds, and preserves the electric Gauss residual when used in the sourced
+field shear.  For noncommuting operator currents, the field-work theorem is
+the anticommutator midpoint law rather than the classical ordered product.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03 import (
+    curl_symbol,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "scripts/u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03.py",
+    "scripts/u1_local_reversible_yee_leapfrog_tick_2026_09_03.py",
+    "scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py",
+    "scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py",
+)
+
+
+IDENTITY_2 = np.eye(2, dtype=complex)
+PAULI_X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)
+PAULI_Y = np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=complex)
+PAULI_Z = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
+NUMBER_TAIL = 0.5 * (IDENTITY_2 + PAULI_Z)
+NUMBER_HEAD = 0.5 * (IDENTITY_2 - PAULI_Z)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def bond_hamiltonian(phase: float, hopping: float) -> np.ndarray:
+    """One-particle charged hop on an oriented tail-to-head link."""
+
+    return -hopping * (
+        math.cos(phase) * PAULI_X + math.sin(phase) * PAULI_Y
+    )
+
+
+def bond_unitary(phase: float, hopping: float, step: float) -> np.ndarray:
+    direction = math.cos(phase) * PAULI_X + math.sin(phase) * PAULI_Y
+    angle = hopping * step
+    return math.cos(angle) * IDENTITY_2 + 1.0j * math.sin(angle) * direction
+
+
+def instantaneous_current(phase: float, hopping: float) -> np.ndarray:
+    hamiltonian = bond_hamiltonian(phase, hopping)
+    return 1.0j * (
+        hamiltonian @ NUMBER_HEAD - NUMBER_HEAD @ hamiltonian
+    )
+
+
+def integrated_current(phase: float, hopping: float, step: float) -> np.ndarray:
+    unitary = bond_unitary(phase, hopping, step)
+    return (
+        unitary.conj().T @ NUMBER_HEAD @ unitary - NUMBER_HEAD
+    ) / step
+
+
+def analytic_integrated_current(
+    phase: float, hopping: float, step: float
+) -> np.ndarray:
+    tangent_direction = (
+        math.cos(phase) * PAULI_Y - math.sin(phase) * PAULI_X
+    )
+    angle = 2.0 * hopping * step
+    return (
+        math.sin(angle) * tangent_direction
+        + (1.0 - math.cos(angle)) * PAULI_Z
+    ) / (2.0 * step)
+
+
+def hermitian_exponential(hamiltonian: np.ndarray, step: float) -> np.ndarray:
+    eigenvalues, eigenvectors = np.linalg.eigh(hamiltonian)
+    return (
+        eigenvectors
+        @ np.diag(np.exp(-1.0j * step * eigenvalues))
+        @ eigenvectors.conj().T
+    )
+
+
+def embedded_bond_hamiltonian(
+    size: int,
+    tail: int,
+    head: int,
+    phase: float,
+    hopping: float,
+) -> np.ndarray:
+    result = np.zeros((size, size), dtype=complex)
+    result[head, tail] = -hopping * np.exp(1.0j * phase)
+    result[tail, head] = -hopping * np.exp(-1.0j * phase)
+    return result
+
+
+def zero_operator(dimension: int = 2) -> np.ndarray:
+    return np.zeros((dimension, dimension), dtype=complex)
+
+
+def linear_operator_map(
+    coefficients: np.ndarray, operators: list[np.ndarray]
+) -> list[np.ndarray]:
+    return [
+        sum(
+            (
+                coefficients[row, column] * operators[column]
+                for column in range(len(operators))
+            ),
+            zero_operator(operators[0].shape[0]),
+        )
+        for row in range(coefficients.shape[0])
+    ]
+
+
+def combine_operators(
+    first: list[np.ndarray],
+    second: list[np.ndarray],
+    first_coefficient: float = 1.0,
+    second_coefficient: float = 1.0,
+) -> list[np.ndarray]:
+    return [
+        first_coefficient * left + second_coefficient * right
+        for left, right in zip(first, second)
+    ]
+
+
+def sourced_operator_tick(
+    curl: np.ndarray,
+    electric: list[np.ndarray],
+    magnetic: list[np.ndarray],
+    current: list[np.ndarray],
+    step: float,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    magnetic_half = combine_operators(
+        magnetic,
+        linear_operator_map(curl, electric),
+        second_coefficient=0.5 * step,
+    )
+    electric_new = combine_operators(
+        combine_operators(
+            electric,
+            linear_operator_map(curl.T, magnetic_half),
+            second_coefficient=-step,
+        ),
+        current,
+        second_coefficient=step,
+    )
+    magnetic_new = combine_operators(
+        magnetic_half,
+        linear_operator_map(curl, electric_new),
+        second_coefficient=0.5 * step,
+    )
+    return electric_new, magnetic_new
+
+
+def operator_field_energy(
+    curl: np.ndarray,
+    electric: list[np.ndarray],
+    magnetic: list[np.ndarray],
+    step: float,
+) -> np.ndarray:
+    dimension = electric[0].shape[0]
+    curl_electric = linear_operator_map(curl, electric)
+    squares = sum(
+        (operator @ operator for operator in electric + magnetic),
+        zero_operator(dimension),
+    )
+    curl_squares = sum(
+        (operator @ operator for operator in curl_electric),
+        zero_operator(dimension),
+    )
+    return 0.5 * squares - step**2 * curl_squares / 8.0
+
+
+def symmetrized_operator_work(
+    electric_old: list[np.ndarray],
+    electric_new: list[np.ndarray],
+    current: list[np.ndarray],
+    step: float,
+) -> np.ndarray:
+    dimension = electric_old[0].shape[0]
+    return 0.25 * step * sum(
+        (
+            current[index] @ (electric_old[index] + electric_new[index])
+            + (electric_old[index] + electric_new[index]) @ current[index]
+            for index in range(len(current))
+        ),
+        zero_operator(dimension),
+    )
+
+
+def cubic_colored_schedule(
+    size: int, step: float
+) -> tuple[bool, bool, bool]:
+    """Check six matching layers and their integrated continuity on a torus."""
+
+    vertices = tuple(
+        (first, second, third)
+        for first in range(size)
+        for second in range(size)
+        for third in range(size)
+    )
+    vertex_index = {point: index for index, point in enumerate(vertices)}
+    edges: list[tuple[int, int, int, int, float, float]] = []
+    for tail_point in vertices:
+        for axis in range(3):
+            head_point_list = list(tail_point)
+            head_point_list[axis] = (head_point_list[axis] + 1) % size
+            head_point = tuple(head_point_list)
+            edge_number = len(edges)
+            phase = 0.031 * (1 + (7 * edge_number) % 19)
+            hopping = 0.22 + 0.01 * ((5 * edge_number) % 11)
+            edges.append(
+                (
+                    vertex_index[tail_point],
+                    vertex_index[head_point],
+                    axis,
+                    tail_point[axis] % 2,
+                    phase,
+                    hopping,
+                )
+            )
+
+    matching_ok = len(edges) == 3 * size**3
+    colors = tuple((axis, parity) for axis in range(3) for parity in range(2))
+    for color in colors:
+        color_edges = [edge for edge in edges if edge[2:4] == color]
+        endpoints = [
+            endpoint for edge in color_edges for endpoint in edge[:2]
+        ]
+        matching_ok = matching_ok and (
+            len(color_edges) == size**3 // 2
+            and len(endpoints) == len(set(endpoints)) == size**3
+        )
+
+    dimension = len(vertices)
+    identity = np.eye(dimension, dtype=complex)
+    number_operators = tuple(
+        np.diag(
+            [1.0 if index == vertex else 0.0 for index in range(dimension)]
+        ).astype(complex)
+        for vertex in range(dimension)
+    )
+    complete_unitary = identity.copy()
+    divergence_increments = [
+        zero_operator(dimension) for _vertex in range(dimension)
+    ]
+    operational_locality_ok = True
+
+    for color in colors:
+        layer_unitary = identity.copy()
+        layer_currents: list[tuple[int, int, np.ndarray]] = []
+        for tail, head, axis, parity, phase, hopping in edges:
+            if (axis, parity) != color:
+                continue
+            local_unitary = bond_unitary(phase, hopping, step)
+            layer_unitary[np.ix_((tail, head), (tail, head))] = local_unitary
+            local_current = integrated_current(phase, hopping, step)
+            current_operator = zero_operator(dimension)
+            current_operator[np.ix_((tail, head), (tail, head))] = local_current
+            outside = current_operator.copy()
+            outside[np.ix_((tail, head), (tail, head))] = 0.0
+            operational_locality_ok = operational_locality_ok and bool(
+                np.max(np.abs(outside)) < 1.0e-15
+            )
+            layer_currents.append((tail, head, current_operator))
+
+        for tail, head, current_operator in layer_currents:
+            initial_current = (
+                complete_unitary.conj().T
+                @ current_operator
+                @ complete_unitary
+            )
+            divergence_increments[tail] -= step * initial_current
+            divergence_increments[head] += step * initial_current
+        complete_unitary = layer_unitary @ complete_unitary
+
+    continuity_ok = bool(
+        np.max(
+            np.abs(complete_unitary.conj().T @ complete_unitary - identity)
+        )
+        < 2.0e-14
+    )
+    for vertex in range(dimension):
+        number_new = (
+            complete_unitary.conj().T
+            @ number_operators[vertex]
+            @ complete_unitary
+        )
+        continuity_ok = continuity_ok and bool(
+            np.max(
+                np.abs(
+                    number_new
+                    - number_operators[vertex]
+                    - divergence_increments[vertex]
+                )
+            )
+            < 3.0e-14
+        )
+    return matching_ok, operational_locality_ok, continuity_ok
+
+
+def main() -> int:
+    checks = Checks()
+
+    phases = (-1.1, -0.2, 0.0, 0.7, 1.9)
+    hoppings = (0.25, 0.7, 1.1)
+    steps = (0.1, 0.3, 0.55)
+    unitary_ok = True
+    conservation_ok = True
+    continuity_ok = True
+    current_ok = True
+    formula_ok = True
+    for phase in phases:
+        for hopping in hoppings:
+            for step in steps:
+                hamiltonian = bond_hamiltonian(phase, hopping)
+                unitary = bond_unitary(phase, hopping, step)
+                current = integrated_current(phase, hopping, step)
+                number_tail_new = (
+                    unitary.conj().T @ NUMBER_TAIL @ unitary
+                )
+                number_head_new = (
+                    unitary.conj().T @ NUMBER_HEAD @ unitary
+                )
+                unitary_ok = unitary_ok and bool(
+                    np.max(
+                        np.abs(unitary.conj().T @ unitary - IDENTITY_2)
+                    )
+                    < 2.0e-15
+                    and np.max(np.abs(hamiltonian - hamiltonian.conj().T))
+                    < 2.0e-15
+                )
+                conservation_ok = conservation_ok and bool(
+                    np.max(
+                        np.abs(
+                            number_tail_new
+                            + number_head_new
+                            - NUMBER_TAIL
+                            - NUMBER_HEAD
+                        )
+                    )
+                    < 3.0e-15
+                )
+                continuity_ok = continuity_ok and bool(
+                    np.max(
+                        np.abs(
+                            number_tail_new - NUMBER_TAIL + step * current
+                        )
+                    )
+                    < 3.0e-15
+                    and np.max(
+                        np.abs(
+                            number_head_new - NUMBER_HEAD - step * current
+                        )
+                    )
+                    < 3.0e-15
+                )
+                current_ok = current_ok and bool(
+                    np.max(np.abs(current - current.conj().T)) < 2.0e-15
+                    and abs(np.trace(current)) < 2.0e-15
+                )
+                formula_ok = formula_ok and bool(
+                    np.max(
+                        np.abs(
+                            current
+                            - analytic_integrated_current(
+                                phase, hopping, step
+                            )
+                        )
+                    )
+                    < 3.0e-15
+                )
+    checks.check(
+        unitary_ok,
+        "every charged bond Hamiltonian is Hermitian and every finite hop is unitary",
+    )
+    checks.check(
+        conservation_ok,
+        "the finite bond hop conserves total matter charge exactly",
+    )
+    checks.check(
+        continuity_ok,
+        "the integrated oriented current obeys exact endpoint continuity",
+    )
+    checks.check(
+        current_ok,
+        "the finite-step current is Hermitian and traceless throughout the grid",
+    )
+    checks.check(
+        formula_ok,
+        "the analytic sine-cosine current formula matches the unitary definition",
+    )
+
+    phase = 0.37
+    hopping = 0.7
+    tangent = instantaneous_current(phase, hopping)
+    midpoint_errors = []
+    endpoint_errors = []
+    for step in (0.4, 0.2, 0.1, 0.05):
+        current = integrated_current(phase, hopping, step)
+        half_unitary = bond_unitary(phase, hopping, 0.5 * step)
+        midpoint_current = half_unitary.conj().T @ tangent @ half_unitary
+        midpoint_errors.append(float(np.linalg.norm(current - midpoint_current)))
+        endpoint_errors.append(float(np.linalg.norm(current - tangent)))
+    checks.check(
+        all(
+            3.95 < left / right < 4.05
+            for left, right in zip(midpoint_errors, midpoint_errors[1:])
+        ),
+        "the exact integrated current approaches the midpoint current quadratically",
+    )
+    checks.check(
+        all(
+            1.95 < left / right < 2.05
+            for left, right in zip(endpoint_errors, endpoint_errors[1:])
+        ),
+        "using the instantaneous endpoint current instead leaves a first-order tick error",
+    )
+    checks.check(
+        np.linalg.norm(
+            integrated_current(phase, hopping, 0.4) - tangent
+        )
+        > 0.25,
+        "the finite-step correction is nonzero at a resolved tick and cannot be dropped",
+    )
+
+    gauge_ok = True
+    for phase, alpha_tail, alpha_head in (
+        (0.37, 0.23, -0.51),
+        (-0.8, -0.4, 0.6),
+        (1.2, 0.9, -0.2),
+    ):
+        transformed_phase = phase + alpha_head - alpha_tail
+        gauge = np.diag(
+            np.exp(1.0j * np.array((alpha_tail, alpha_head)))
+        )
+        original_hamiltonian = bond_hamiltonian(phase, hopping)
+        transformed_hamiltonian = bond_hamiltonian(
+            transformed_phase, hopping
+        )
+        original_current = integrated_current(phase, hopping, 0.41)
+        transformed_current = integrated_current(
+            transformed_phase, hopping, 0.41
+        )
+        gauge_ok = gauge_ok and bool(
+            np.max(
+                np.abs(
+                    transformed_hamiltonian
+                    - gauge @ original_hamiltonian @ gauge.conj().T
+                )
+            )
+            < 3.0e-15
+            and np.max(
+                np.abs(
+                    transformed_current
+                    - gauge @ original_current @ gauge.conj().T
+                )
+            )
+            < 3.0e-15
+        )
+    checks.check(
+        gauge_ok,
+        "the finite-step current covaries with the charged hop under endpoint gauge phases",
+    )
+
+    swap = PAULI_X
+    orientation_ok = True
+    for phase in phases:
+        current = integrated_current(phase, 0.7, 0.41)
+        reversed_current = integrated_current(-phase, 0.7, 0.41)
+        orientation_ok = orientation_ok and bool(
+            np.max(
+                np.abs(swap @ current @ swap + reversed_current)
+            )
+            < 4.0e-15
+        )
+    checks.check(
+        orientation_ok,
+        "reversing the bond orientation reverses the integrated current",
+    )
+    checks.check(
+        np.array_equal(
+            integrated_current(0.9, 0.0, 0.37), zero_operator()
+        ),
+        "a zero hopping coefficient produces exactly zero finite-step current",
+    )
+
+    # Two colored layers on an open three-site chain.  The second operational
+    # current is local on sites 1-2; its initial Heisenberg representative is
+    # pulled through the first layer when the two increments are aggregated.
+    dimension = 3
+    number = tuple(
+        np.diag(
+            [1.0 if index == vertex else 0.0 for index in range(dimension)]
+        ).astype(complex)
+        for vertex in range(dimension)
+    )
+    layer_step = 0.4
+    first_hamiltonian = embedded_bond_hamiltonian(
+        dimension, 0, 1, 0.2, 0.7
+    )
+    second_hamiltonian = embedded_bond_hamiltonian(
+        dimension, 1, 2, -0.3, 0.5
+    )
+    first_unitary = hermitian_exponential(first_hamiltonian, layer_step)
+    second_unitary = hermitian_exponential(second_hamiltonian, layer_step)
+    complete_unitary = second_unitary @ first_unitary
+    first_current = (
+        first_unitary.conj().T @ number[1] @ first_unitary - number[1]
+    ) / layer_step
+    second_current_operational = (
+        second_unitary.conj().T @ number[2] @ second_unitary - number[2]
+    ) / layer_step
+    second_current_initial = (
+        first_unitary.conj().T
+        @ second_current_operational
+        @ first_unitary
+    )
+    incidence = np.array([[-1, 1, 0], [0, -1, 1]], dtype=int)
+    initial_currents = (first_current, second_current_initial)
+    layered_continuity_ok = True
+    for vertex in range(dimension):
+        number_new = (
+            complete_unitary.conj().T
+            @ number[vertex]
+            @ complete_unitary
+        )
+        divergence_current = layer_step * sum(
+            (
+                incidence[edge, vertex] * initial_currents[edge]
+                for edge in range(2)
+            ),
+            zero_operator(dimension),
+        )
+        layered_continuity_ok = layered_continuity_ok and bool(
+            np.max(
+                np.abs(number_new - number[vertex] - divergence_current)
+            )
+            < 4.0e-15
+        )
+    checks.check(
+        np.max(
+            np.abs(
+                complete_unitary.conj().T
+                @ complete_unitary
+                - np.eye(dimension)
+            )
+        )
+        < 3.0e-15,
+        "two overlapping colored bond layers compose to an exact unitary",
+    )
+    checks.check(
+        layered_continuity_ok,
+        "the two-layer three-site hop obeys exact finite-step continuity at every vertex",
+    )
+    checks.check(
+        np.max(
+            np.abs(
+                complete_unitary.conj().T
+                @ sum(number)
+                @ complete_unitary
+                - sum(number)
+            )
+        )
+        < 3.0e-15,
+        "the colored matter schedule preserves total charge",
+    )
+
+    gauss_ok = True
+    for vertex in range(dimension):
+        electric_new_divergence = layer_step * sum(
+            (
+                incidence[edge, vertex] * initial_currents[edge]
+                for edge in range(2)
+            ),
+            zero_operator(dimension),
+        )
+        matter_new = (
+            complete_unitary.conj().T
+            @ number[vertex]
+            @ complete_unitary
+        )
+        initial_gauss_residual = -number[vertex]
+        final_gauss_residual = electric_new_divergence - matter_new
+        gauss_ok = gauss_ok and bool(
+            np.max(
+                np.abs(final_gauss_residual - initial_gauss_residual)
+            )
+            < 4.0e-15
+        )
+    checks.check(
+        gauss_ok,
+        "using the integrated layer currents preserves the electric Gauss residual exactly",
+    )
+
+    first_local = first_current.copy()
+    first_local[0:2, 0:2] = 0.0
+    second_local = second_current_operational.copy()
+    second_local[1:3, 1:3] = 0.0
+    checks.check(
+        np.max(np.abs(first_local)) < 2.0e-15
+        and np.max(np.abs(second_local)) < 2.0e-15,
+        "each operational current is confined to its active two-site bond layer",
+    )
+    checks.check(
+        abs(second_current_initial[0, 2]) > 0.1
+        and abs(second_current_operational[0, 2]) < 2.0e-15,
+        "aggregating layers in the initial frame spreads support, so local field coupling must follow the layers",
+    )
+
+    matching_ok, cubic_locality_ok, cubic_continuity_ok = (
+        cubic_colored_schedule(4, 0.2)
+    )
+    checks.check(
+        matching_ok and cubic_locality_ok,
+        "the L=4 cubic torus decomposes all 192 bonds into six local matching layers",
+    )
+    checks.check(
+        cubic_continuity_ok,
+        "the six-layer cubic matter tick obeys finite-step continuity at all 64 vertices",
+    )
+
+    # Noncommuting operator-valued version of the exact source-work law.
+    field_step = 0.5
+    curl = curl_symbol(np.array([0.3, 0.7, 1.1]))
+    electric_old = [
+        0.2 * PAULI_X + 0.1 * PAULI_Z,
+        -0.3 * PAULI_Y + 0.2 * PAULI_Z,
+        0.4 * PAULI_X - 0.2 * PAULI_Y,
+    ]
+    magnetic_old = [
+        0.1 * PAULI_Y + 0.3 * PAULI_Z,
+        -0.5 * PAULI_X + 0.2 * PAULI_Y,
+        0.2 * IDENTITY_2 - 0.1 * PAULI_Z,
+    ]
+    operator_current = [
+        integrated_current(0.37, 0.7, field_step),
+        -0.4 * PAULI_Y + 0.1 * PAULI_Z,
+        0.2 * PAULI_X + 0.4 * PAULI_Z,
+    ]
+    electric_new, magnetic_new = sourced_operator_tick(
+        curl,
+        electric_old,
+        magnetic_old,
+        operator_current,
+        field_step,
+    )
+    energy_change = operator_field_energy(
+        curl, electric_new, magnetic_new, field_step
+    ) - operator_field_energy(
+        curl, electric_old, magnetic_old, field_step
+    )
+    symmetric_work = symmetrized_operator_work(
+        electric_old, electric_new, operator_current, field_step
+    )
+    checks.check(
+        np.max(np.abs(energy_change - symmetric_work)) < 3.0e-15,
+        "the field-energy change equals anticommutator midpoint work for noncommuting currents",
+    )
+    checks.check(
+        np.max(np.abs(symmetric_work - symmetric_work.conj().T)) < 3.0e-15,
+        "the symmetrized operator work is Hermitian",
+    )
+
+    ordered_work = 0.5 * field_step * sum(
+        (
+            operator_current[index]
+            @ (electric_old[index] + electric_new[index])
+            for index in range(3)
+        ),
+        zero_operator(),
+    )
+    checks.check(
+        np.max(np.abs(energy_change - ordered_work)) > 0.04
+        and np.max(np.abs(ordered_work - ordered_work.conj().T)) > 0.08,
+        "the unsymmetrized classical product fails as a noncommuting work observable",
+    )
+
+    commuting_current = [
+        0.3 * IDENTITY_2,
+        -0.2 * IDENTITY_2,
+        0.4 * IDENTITY_2,
+    ]
+    commuting_electric = [
+        0.1 * IDENTITY_2,
+        -0.5 * IDENTITY_2,
+        0.2 * IDENTITY_2,
+    ]
+    commuting_magnetic = [
+        -0.3 * IDENTITY_2,
+        0.4 * IDENTITY_2,
+        0.6 * IDENTITY_2,
+    ]
+    commuting_new_electric, commuting_new_magnetic = sourced_operator_tick(
+        curl,
+        commuting_electric,
+        commuting_magnetic,
+        commuting_current,
+        field_step,
+    )
+    commuting_change = operator_field_energy(
+        curl,
+        commuting_new_electric,
+        commuting_new_magnetic,
+        field_step,
+    ) - operator_field_energy(
+        curl, commuting_electric, commuting_magnetic, field_step
+    )
+    commuting_symmetric = symmetrized_operator_work(
+        commuting_electric,
+        commuting_new_electric,
+        commuting_current,
+        field_step,
+    )
+    checks.check(
+        np.max(np.abs(commuting_change - commuting_symmetric)) < 2.0e-15
+        and np.max(
+            np.abs(
+                commuting_symmetric
+                - 0.5
+                * field_step
+                * sum(
+                    (
+                        commuting_current[index]
+                        @ (
+                            commuting_electric[index]
+                            + commuting_new_electric[index]
+                        )
+                        for index in range(3)
+                    ),
+                    zero_operator(),
+                )
+            )
+        )
+        < 2.0e-15,
+        "commuting field and current operators reduce to the classical midpoint law",
+    )
+
+    state = np.array([1.0, 1.0j], dtype=complex) / math.sqrt(2.0)
+    checks.check(
+        abs(
+            float(np.real(state.conj().T @ energy_change @ state))
+            - float(np.real(state.conj().T @ symmetric_work @ state))
+        )
+        < 2.0e-15,
+        "the operator work identity agrees in a nontrivial matter-state expectation value",
+    )
+
+    print(
+        "per_element: the oriented bond phase, finite current, and operator anticommutator coefficients are checked"
+    )
+    print(
+        "per_site: exact tail/head continuity and each operational two-site current support are checked"
+    )
+    print(
+        "per_mode: instantaneous, midpoint, and integrated current orders are separated on a refinement ladder"
+    )
+    print(
+        "per_block: one-bond gauge covariance, three-site colored continuity, Gauss preservation, and operator work are checked"
+    )
+    print(
+        "lattice_wide: the layerwise construction generalizes by finite edge coloring; no global solve or all-at-once current is used"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

A local charged bond unitary supplies an exact finite-step edge current from transported endpoint charge. It is not generally the instantaneous i[H,n] current:

- exact tail/head continuity and gauge covariance
- analytic sine-cosine integrated-current formula
- endpoint current has first-order tick error; temporal midpoint is second-order
- six matching layers cover all 192 bonds of an L=4 cubic torus and satisfy continuity at all 64 vertices
- layerwise field insertion preserves the electric Gauss residual
- aggregating later currents into the old-time frame expands support, so matter and field layers must be interleaved

For noncommuting link/current operators, exact field work is the Hermitian anticommutator midpoint. The naive ordered classical product is non-Hermitian and fails explicitly.

Runner: TOTAL: PASS=24 FAIL=0. Includes an identity-pinned cache, bounded theorem note, N1-N8 scope packet, and citation-graph acknowledgment.

## Significance

This supplies the finite-tick interface needed to join the photon stack to the conserved-current and compact-link work in open PRs #7892 and #7903, without importing those open branches as authority. The remaining joint obligation is exact opposite matter energy backreaction in the same interleaved local layer.

## Scope

Source science only, not an audit verdict. No TOE score, axiom, primitive, or audit status changes. The tested matter model is a supplied one-particle charged hop; the link phase is external, and the finite field payload and Record layer remain open.

## Validation

- runner 24/24
- cache identity fresh
- claim typing clean
- vocabulary lint clean
- repository invariants and enforced links clean
- strict audit lint clean apart from repository baseline warnings/notices