### PR TITLE
science(light): quantum link closes exact local matter-field backreaction

### DIFF
--- a/docs/U1_QUANTUM_LINK_EXACT_LOCAL_BACKREACTION_AND_COLORED_FLOQUET_ENERGY_FORK_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/U1_QUANTUM_LINK_EXACT_LOCAL_BACKREACTION_AND_COLORED_FLOQUET_ENERGY_FORK_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,603 @@
+# Quantum-Link Exact Local Backreaction and the Colored Floquet Energy Fork
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct interface parent:**
+[`U1_FINITE_STEP_GAUGE_COVARIANT_MATTER_CURRENT_OPERATOR_WORK_INTERFACE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_FINITE_STEP_GAUGE_COVARIANT_MATTER_CURRENT_OPERATOR_WORK_INTERFACE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Field-work parent:**
+[`U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_EXACT_MIDPOINT_SOURCE_WORK_CLOSED_DIPOLE_PURE_RADIATION_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Conserved-source parent:**
+[`U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_CONSERVED_VERTEX_CHARGE_EDGE_CURRENT_COULOMB_PHOTON_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Kinetic normalization boundary:**
+[`KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md`](KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md)
+
+**Runner:**
+[`scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py`](../scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.txt`](../logs/runner-cache/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.txt)
+
+## Result up front
+
+The local matter-field energy-backreaction join can be closed exactly on one
+oriented bond with a finite flux carrier.
+
+Let a link have flux states
+
+```text
+m=-S,...,+S,
+```
+
+electric operator `E|m>=m|m>`, and hard-cutoff raising operator
+
+```text
+U|m>=|m+1> for m<S,        U|S>=0.
+```
+
+Put one charge on the two endpoint matter states `|tail>,|head>`, and use
+
+```text
+H_E=(g^2/2) E^2,
+H_hop=-t[U tensor |head><tail|+U^dagger tensor |tail><head|],
+H_bond=H_E+H_hop.
+```
+
+The joint Hamiltonian commutes with both endpoint Gauss generators
+
+```text
+G_tail=-E-n_tail,
+G_head=+E-n_head.
+```
+
+Its exact finite unitary `V=exp(-ih H_bond)` therefore preserves Gauss and
+total matter charge. If
+
+```text
+E'=V^dagger E V,
+Jbar=(E'-E)/h,
+```
+
+then the same Hermitian integrated current obeys
+
+```text
+Jbar=(n_head'-n_head)/h
+    =-(n_tail'-n_tail)/h.
+```
+
+Most importantly, the local energy exchange closes exactly:
+
+```text
+Delta H_E
+ =(g^2 h/4){Jbar,E+E'},
+Delta H_hop=-Delta H_E,
+Delta H_bond=0.
+```
+
+The runner verifies this over `S=1,2,3` and three independent coupling,
+hopping, and step triples. This is the missing one-bond backreaction theorem:
+matter transfer, flux response, Gauss, unitarity, and opposite work coexist in
+one local finite-payload unitary.
+
+The result exposes a separate lattice-wide choice. On two adjacent bonds that
+share the middle matter site, each local Hamiltonian still commutes with all
+three Gauss generators and each operational layer closes its own work exactly.
+But the two bond Hamiltonians do not commute. Consequently:
+
+- the unsplit unitary `exp[-ih(H_1+H_2)]` conserves the summed Hamiltonian
+  exactly;
+- the finite-depth Lie product has `O(h^2)` one-tick summed-energy drift;
+- the palindromic `H_1/2-H_2-H_1/2` product is exactly unitary,
+  Gauss-preserving, and reversible, and suppresses that drift to `O(h^3)`;
+- the palindromic product has an exactly conserved Hermitian principal Floquet
+  generator `H_F`; and
+- `H_F-H_1-H_2=O(h^2)` and contains resolved cross-bond matrix entries absent
+  from the simple summed Hamiltonian.
+
+Two disjoint bonds commute and provide the exact control: their layer product
+equals the unsplit exponential and conserves the summed energy.
+
+Thus local backreaction is not blocked. The remaining fork is which energy
+and time law the program intends at finite lattice step:
+
+1. exact evolution under a time-independent summed Hamiltonian;
+2. a strict finite-depth reversible tick whose exact energy is its Floquet
+   generator; or
+3. a larger collision/clock carrier engineered to conserve a simple local
+   summed energy exactly.
+
+No axiom currently selects among these. The result therefore advances the
+matter-light lane and identifies a real global schedule decision without
+turning it into a no-go.
+
+## 1. The finite quantum link
+
+The hard-cutoff shift satisfies
+
+```text
+[E,U]=U
+```
+
+exactly, including at the upper boundary because both sides annihilate
+`|S>`. It is not unitary:
+
+```text
+U^dagger U=I-|S><S|.
+```
+
+That cost is explicit. The full bond Hamiltonian is nevertheless Hermitian,
+so its exponential is exactly unitary.
+
+The hopping term connects
+
+```text
+|m,tail> <-> |m+1,head>
+```
+
+for `m=-S,...,S-1`. The finite Hilbert space decomposes into `2S` paired
+two-state transfer sectors and two dark boundary states,
+
+```text
+|S,tail>,                   |-S,head>.
+```
+
+The runner checks this degree census for `S=1,2,3`. This is a finite link
+model, not the infinite compact rotor and not a cyclic shift that wraps
+maximum flux into minimum flux.
+
+The endpoint Gauss values agree across every paired transition. For example,
+
+```text
+G_tail |m,tail>=(-m-1)|m,tail>,
+G_tail |m+1,head>=(-m-1)|m+1,head>,
+```
+
+and similarly for `G_head`. Hence
+
+```text
+[G_tail,H_bond]=[G_head,H_bond]=0.
+```
+
+Background charge constants may be added to both generators without changing
+the commutators. The displayed convention is chosen only to make the transfer
+algebra transparent.
+
+## 2. One current closes charge and flux simultaneously
+
+Under the exact bond unitary define
+
+```text
+O'=V^dagger O V.
+```
+
+Gauss conservation gives
+
+```text
+-(E'-E)-(n_tail'-n_tail)=0,
+(E'-E)-(n_head'-n_head)=0.
+```
+
+Therefore one finite-step operator
+
+```text
+Jbar=(E'-E)/h
+```
+
+is simultaneously the flux current, head charge gain, and negative tail
+charge gain. It is Hermitian because it is a difference of Hermitian
+operators.
+
+This directly realizes the interface parent's abstract current from endpoint
+transport, now with a dynamical link rather than an external phase. The
+runner also checks that `Jbar` approaches the instantaneous Heisenberg current
+
+```text
+i[H_bond,E]
+```
+
+linearly as `h` is refined. The finite current, not the instantaneous endpoint
+operator, is what belongs in an exact tick-level continuity equation.
+
+## 3. Exact opposite local work
+
+The electric energy change is
+
+```text
+Delta H_E
+ =(g^2/2)(E'^2-E^2).
+```
+
+For noncommuting `E` and `E'`, the difference of squares has the exact
+anticommutator identity
+
+```text
+E'^2-E^2=(1/2){E'+E,E'-E}.
+```
+
+Using `E'-E=h Jbar` gives
+
+```text
+Delta H_E=(g^2 h/4){Jbar,E+E'}.
+```
+
+Because `V` is generated by `H_bond`,
+
+```text
+V^dagger H_bond V=H_bond.
+```
+
+Therefore
+
+```text
+Delta H_hop=-Delta H_E.
+```
+
+This is precisely the operator-ordering target identified by the interface
+parent, with the electric coefficient `g^2` restored. It is not imposed as a
+ledger variable; both sides are independently conjugated operators from the
+same joint unitary.
+
+The largest numerical residual in the `S=1,2,3` parameter grid is below
+`2e-14`. The analytic reason is the commutation of `V` with its generator,
+not numerical tuning.
+
+The theorem closes the local electric part of matter-field backreaction. It
+does not yet include a magnetic plaquette layer or the photon tick's modified
+curl energy.
+
+## 4. Two adjacent bonds preserve Gauss layer by layer
+
+Now use two finite links and three one-particle matter sites,
+
+```text
+0 --e1-- 1 --e2-- 2.
+```
+
+Let `H_1` and `H_2` each contain its link electric energy and its covariant
+hop. The three Gauss generators are
+
+```text
+G_0=-E_1-n_0,
+G_1= E_1-E_2-n_1,
+G_2= E_2-n_2.
+```
+
+Every one of the six commutators
+
+```text
+[G_v,H_e]
+```
+
+vanishes. Thus any product of the local bond unitaries preserves every Gauss
+operator exactly, independent of product order or step size. Each individual
+layer also has the one-bond integrated-current and opposite-work identity.
+
+This is the constructive content needed by an edge-colored lattice schedule:
+Gauss does not accumulate a Trotter error. The difficulty below is energy of
+overlapping inactive interactions, not gauge consistency.
+
+## 5. Exact flow versus strict finite-depth composition
+
+Define
+
+```text
+H=H_1+H_2.
+```
+
+The exact unsplit flow
+
+```text
+U_exact(h)=exp(-ihH)
+```
+
+is unitary, Gauss-preserving, and conserves `H` exactly. On the two-bond test
+this is a finite local block. This note does not infer that exponentiating the
+full lattice sum produces a strict bounded-depth circuit.
+
+The one-sided colored product
+
+```text
+U_L(h)=exp(-ihH_2) exp(-ihH_1)
+```
+
+is finite depth and Gauss-preserving, but the runner obtains
+
+```text
+||U_L^dagger H U_L-H||=O(h^2).
+```
+
+The palindromic product
+
+```text
+U_S(h)
+ =exp[-i(h/2)H_1] exp(-ihH_2) exp[-i(h/2)H_1]
+```
+
+obeys
+
+```text
+U_S(-h)=U_S(h)^dagger
+```
+
+and suppresses the summed-energy drift to
+
+```text
+||U_S^dagger H U_S-H||=O(h^3).
+```
+
+On the refinement ladder `h=0.4,0.2,0.1,0.05`, the Lie errors fall by four
+and the palindromic errors by eight, for both flow error and energy drift.
+The runner checks operator norms, not one selected initial state.
+
+The reason is visible locally:
+
+```text
+[H_1,H_2] != 0
+```
+
+when the bonds share matter site `1`. Evolving with `H_1` changes the inactive
+`H_2` hopping operator. On two disjoint bonds the commutator vanishes, the
+product equals `exp[-ih(H_1+H_2)]`, and summed energy is exact. This control
+isolates overlap rather than flux truncation as the splitting residual.
+
+No no-go follows. Longer products, collision carriers, time-dependent energy,
+and exact lattice Hamiltonian evolution remain distinct routes.
+
+## 6. The exact Floquet energy
+
+For each tested small step, the palindromic unitary has a principal Hermitian
+generator `H_F` defined by
+
+```text
+U_S=exp(-ih H_F).
+```
+
+The runner constructs it from a complex Schur decomposition and principal
+eigenphases. It verifies
+
+```text
+U_S^dagger H_F U_S=H_F
+```
+
+to `7e-15`. Therefore the finite-depth tick does have an exact conserved
+energy generator on the tested block.
+
+However,
+
+```text
+||H_F-H||=O(h^2).
+```
+
+Entries of `H_F` at matrix positions where the simple `H_1+H_2` is zero are
+also nonzero and scale as `O(h^2)`. They are cross-bond corrections generated
+by the palindromic composition.
+
+This is a bounded two-bond statement. It does not prove that the principal
+Floquet logarithm on an infinite lattice is finite range, quasi-local under
+the required bound, unique across eigenphase crossings, or acceptable as the
+physical energy. Those are precisely the global questions now exposed.
+
+## 7. The decision and next discriminator
+
+The local result is unambiguous: exact quantum matter-field backreaction is
+possible with finite payload and no Gauss or work mismatch.
+
+The global decision is about time architecture:
+
+| Route | Exact gains | Current cost |
+|---|---|---|
+| unsplit time-independent Hamiltonian | unitarity, Gauss, simple summed energy | strict finite-depth full-lattice tick not constructed |
+| palindromic colored tick | finite depth, unitarity, Gauss, reversibility, exact `H_F` | `H_F` has step-dependent cross-bond corrections |
+| enlarged collision/clock law | may keep a simple locally conserved energy and finite depth | extra carrier and explicit construction required |
+
+The highest-value next test is to add the smallest magnetic plaquette layer
+to a matter-link block and ask three questions together:
+
+1. does the palindromic tick retain the weak-field two-photon sector;
+2. how far does the exact principal Floquet generator spread; and
+3. can its leading correction be represented by the existing physical
+   neighboring roles rather than a new axiom or payload?
+
+That discriminator connects the exact local backreaction proved here to the
+already constructed sourceful photon stack.
+
+## 8. Program and prior-art boundary
+
+The electric-flux plus covariant-hopping Hamiltonian belongs to the standard
+Hamiltonian lattice-gauge family; see J. Kogut and L. Susskind,
+[“Hamiltonian formulation of Wilson's lattice gauge
+theories”](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.11.395)
+(1975). Product-formula order improvement is likewise standard.
+
+The repo-specific contribution is the exact finite-step interface census:
+the same integrated operator closes flux, endpoint charge, Gauss, and
+anticommutator work, followed by an explicit test of the strict colored-tick
+versus summed-energy fork that the sourceful photon program must choose.
+
+Open PR #7903 is a context-only compact-link matter construction. Its code
+and conclusions are not inputs to this theorem, and this source does not
+change its status.
+
+No axiom edit follows. The minimal axioms do not choose a Hamiltonian,
+product schedule, Floquet generator, flux cutoff, or energy observable. The
+science first needs the plaquette discriminator above.
+
+## 9. Executable evidence
+
+The runner reports `TOTAL: PASS=23 FAIL=0`. It checks:
+
+- exact hard-cutoff shift algebra and its nonunitary boundary;
+- transfer-sector and boundary-state counts for `S=1,2,3`;
+- both one-bond Gauss commutators;
+- joint unitarity, current equality, Gauss evolution, field work, opposite
+  hopping work, and total energy over nine parameter cases;
+- instantaneous-current convergence;
+- all six adjacent-bond Gauss commutators;
+- local exchange on each adjacent operational layer;
+- palindromic reversal and Gauss preservation;
+- exact unsplit energy;
+- Lie and palindromic flow/energy orders;
+- exact Floquet conservation, quadratic deviation, and cross-bond entries;
+- a disjoint-bond exact control; and
+- the shared-bond commutator and inactive-energy change.
+
+## No-Go Discipline Gate
+
+The positive local theorem is paired with a bounded colored-schedule failure.
+This gate prevents the `O(h^3)` drift from being promoted into a no-go for
+matter-light coupling or local energy.
+
+### N1 — Alternative route enumeration
+
+| Honesty | Route | Outcome |
+|---|---|---|
+| **ATTEMPTED** | exact one-bond joint exponential | **Positive:** finite payload, unitarity, Gauss, current, and opposite work; checks 1-11. |
+| **ATTEMPTED** | exact unsplit adjacent-bond exponential | **Positive:** exact summed energy and Gauss on the two-bond block; check 15. |
+| **ATTEMPTED** | one-sided colored product | Local and Gauss-preserving, with `O(h^2)` summed-energy drift; check 16. |
+| **ATTEMPTED** | palindromic colored product | **Positive:** local, reversible, Gauss-preserving; summed-energy drift `O(h^3)`; checks 14 and 17-18. |
+| **ATTEMPTED** | principal Floquet generator | **Positive exact invariant:** differs from simple `H` and gains cross-bond entries at `O(h^2)`; checks 19-21. |
+| **ATTEMPTED** | disjoint-bond product | **Positive control:** exact summed energy because the bonds commute; check 22. |
+| **OPEN** | longer product formula | May alter the correction order but does not automatically make simple `H` exact. |
+| **OPEN** | collision/clock carrier | Could conserve a simple local energy in strict finite depth; no construction tested here. |
+| **OPEN** | full lattice Hamiltonian flow | Exact energy route; strict bounded-depth realization remains untested. |
+
+### N2 — Wall-independence audit
+
+Use
+
+```text
+W1 = finite-depth versus exact summed-H evolution,
+W2 = locality/range of the exact Floquet generator,
+W3 = magnetic plaquette and photon survival,
+W4 = flux cutoff and boundary dark states,
+W5 = Record preparation/readout and coupling selection.
+```
+
+| Pair | Independent? | Reason |
+|---|---:|---|
+| W1, W2 | yes | a finite-depth tick always has a logarithm, whose locality is separate |
+| W1, W3 | yes | exact Hamiltonian evolution does not guarantee the desired photon branch |
+| W1, W4 | yes | product scheduling and flux truncation are distinct |
+| W1, W5 | yes | time architecture does not select records or coupling |
+| W2, W3 | yes | a local Floquet generator can have the wrong spectrum |
+| W2, W4 | yes | generator range is not fixed by link cutoff alone |
+| W2, W5 | yes | Floquet locality does not supply readout |
+| W3, W4 | yes | photon survival and boundary saturation are separate limits |
+| W3, W5 | yes | a photon branch does not fix charge or records |
+| W4, W5 | yes | payload boundary does not choose physical normalization |
+
+### N3 — Hidden-wall scan
+
+The link uses a hard cutoff, not a unitary cyclic rotor. Matter is restricted
+to the one-particle sector. The one-bond result includes only electric and
+hopping energy. The adjacent test has two links and three sites at `S=1`.
+Principal Floquet phases are taken only on the named small-step ladder. The
+operator norms cover the full finite blocks. No full lattice, plaquette,
+photon, continuum, Record, or axiom result is inferred.
+
+### N4 — Residual matching
+
+| Surface | Residual | Match here |
+|---|---|---|
+| finite-step current parent | opposite matter work absent | **positive closure on one bond:** exact joint unitary supplies it |
+| source-work parent | current externally supplied | **positive closure on one bond:** dynamical flux and matter produce one current |
+| photon tick | finite-depth free magnetic/electric field | **not yet joined:** magnetic plaquette layer remains |
+| compact-link context | matter and link Hamiltonian exist | **independent overlap:** current source not imported; finite-step work analyzed here |
+| minimal axioms | no transition/energy selector | **unchanged:** Hamiltonian and schedule remain supplied |
+
+### N5 — Rhetoric and resolution audit
+
+“Exact local backreaction” refers only to one active bond. “Exact summed
+energy” refers to the unsplit two-bond exponential and disjoint control.
+“Floquet energy” refers to the principal logarithm on the tested small finite
+block. The palindromic product is not said to conserve the naive summed
+Hamiltonian, and its failure is not generalized to longer products, enlarged
+carriers, or continuous local Hamiltonians.
+
+The cache contains all five resolution lines:
+
+```text
+per_element: finite flux raising, matter transfer, current, and anticommutator work are checked
+per_site: both endpoint Gauss generators and the shared middle-vertex generator are checked
+per_mode: instantaneous-current and Lie/Strang/Floquet refinement orders are resolved
+per_block: one-bond exact backreaction and two-bond overlapping/disjoint controls are checked
+lattice_wide: colored local layers preserve Gauss by composition; exact summed energy versus Floquet energy remains the global schedule choice
+```
+
+### N6 — Partial-closure paths and primitive check
+
+The approved kinetic primitive does not select an energy or update schedule.
+The shortest partial closure is the one-plaquette matter-link tick named in
+Section 7. If the exact `H_F` correction remains inside a bounded physical
+neighborhood and preserves the photon branch, the finite-depth route advances
+without an axiom edit. If it spreads beyond the allowed compiler, the exact
+Hamiltonian and collision-carrier routes remain live. A failure of one route
+would justify an interpretation decision before an axiom change.
+
+### N7 — Steelman
+
+A hostile reviewer should say the one-bond theorem is standard consequence of
+a gauge-invariant Hamiltonian. Correct. Its value is not novelty of the
+Kogut-Susskind mechanism; it is closing the repo's exact finite-step current
+and operator-work interface in one executable block.
+
+The reviewer should also reject a two-bond result as proof of global Floquet
+locality. The note agrees. The cross-bond correction is evidence that the
+global question is nontrivial, not evidence that it is impossible. The
+one-plaquette/full-neighborhood test is explicitly next.
+
+### N8 — Cross-cycle echo
+
+The immediately prior cycle found that old-time aggregation of colored
+currents expands support. This cycle implements the operational local layers
+and finds that Gauss and local work close, while energy of inactive overlapping
+terms becomes the remaining schedule residual. It avoids repeating the older
+mistake of treating exact local identities as automatic global conservation.
+The disjoint control and unsplit exact flow keep the positive alternatives
+visible.
+
+**Gate result:** PASS for the exact one-bond theorem and the bounded
+two-bond schedule fork. Six route families are executed, three enlarged routes
+remain open, and no global energy no-go is asserted.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- the hard-cutoff shift violates `[E,U]=U`;
+- a paired hop changes either endpoint Gauss value;
+- the joint exponential is nonunitary or changes a Gauss generator;
+- flux gain differs from head gain or negative tail gain;
+- electric work differs from the anticommutator expression;
+- hopping energy fails to lose the opposite work;
+- either adjacent local Hamiltonian violates a shared Gauss generator;
+- the palindromic product is not reversible or Gauss-preserving;
+- the stated Lie and palindromic refinement orders fail;
+- the unsplit flow changes the summed Hamiltonian;
+- the principal Floquet generator is non-Hermitian or not conserved;
+- its deviation or extra entries fail the quadratic ladder; or
+- disjoint bonds fail the commuting exact-energy control.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=23 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15799,
- "node_count": 5572,
+ "edge_count": 15804,
+ "node_count": 5573,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -18733,6 +18733,10 @@
   "u1_minimal_physical_neighbor_conservative_gauge_dynamics_uniquely_maxwell_bounded_theorem_note_2026-09-03": {
    "deps_hash": "def91c1a636d",
    "out_degree": 4
+  },
+  "u1_quantum_link_exact_local_backreaction_and_colored_floquet_energy_fork_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "58f8078fbd1a",
+   "out_degree": 5
   },
   "u1_radius_one_onsite_unitary_minimal_maxwell_tick_bounded_no_go_note_2026-09-03": {
    "deps_hash": "1f68ba61b53b",

--- a/logs/runner-cache/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.txt
+++ b/logs/runner-cache/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py
+runner_sha256: 60c9f90a8b2aa57fe8840f1e9b087f5b08bac9a6c0f37e250d4cc46fd89b29c1
+input_fingerprint_sha256: 8b06643de1815dd8eb85ea9dc939f9dc2d2b1c6da4ed0cf54d055ff565b5989b
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 0.32
+status: ok
+----- stdout -----
+[PASS] 01 the hard-cutoff quantum link obeys [E,U]=U exactly
+[PASS] 02 finite flux has one explicit nonunitary raising boundary at its top state
+[PASS] 03 both endpoint Gauss generators commute with every one-bond Hamiltonian
+[PASS] 04 each finite link decomposes into paired transfer sectors plus two boundary dark states
+[PASS] 05 the joint matter-flux evolution is unitary throughout the parameter grid
+[PASS] 06 the finite joint unitary preserves both endpoint Gauss operators
+[PASS] 07 one integrated current equals electric-flux gain and both matter endpoint transfers
+[PASS] 08 electric energy gain equals the anticommutator midpoint work
+[PASS] 09 the active matter hopping energy loses exactly the electric work
+[PASS] 10 the complete one-bond matter-plus-electric Hamiltonian is exactly conserved
+[PASS] 11 the exact flux current approaches its instantaneous commutator linearly in the step
+[PASS] 12 each adjacent bond Hamiltonian commutes with all three shared-vertex Gauss generators
+[PASS] 13 each operational adjacent-bond layer closes charge and opposite electric work exactly
+[PASS] 14 the palindromic adjacent-bond tick is exactly Gauss preserving and reversible
+[PASS] 15 the unsplit two-bond exponential exactly conserves the summed Hamiltonian
+[PASS] 16 a nonpalindromic two-color product has a quadratic one-tick energy drift
+[PASS] 17 the palindromic two-color product suppresses summed-energy drift to cubic order
+[PASS] 18 Lie and palindromic products approach the exact joint flow at orders two and three
+[PASS] 19 the principal palindromic Floquet generator is Hermitian and exactly conserved
+[PASS] 20 the conserved Floquet generator differs from the summed Hamiltonian at quadratic order
+[PASS] 21 the exact Floquet energy acquires resolved cross-bond entries at quadratic order
+[PASS] 22 disjoint colored bonds commute and conserve the summed energy exactly
+[PASS] 23 shared matter makes neighboring bond energies noncommute and exposes the splitting residual
+per_element: finite flux raising, matter transfer, current, and anticommutator work are checked
+per_site: both endpoint Gauss generators and the shared middle-vertex generator are checked
+per_mode: instantaneous-current and Lie/Strang/Floquet refinement orders are resolved
+per_block: one-bond exact backreaction and two-bond overlapping/disjoint controls are checked
+lattice_wide: colored local layers preserve Gauss by composition; exact summed energy versus Floquet energy remains the global schedule choice
+TOTAL: PASS=23 FAIL=0
+
+----- stderr -----
+

--- a/scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py
+++ b/scripts/u1_quantum_link_exact_backreaction_colored_floquet_2026_09_03.py
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+"""Quantum-link backreaction and overlapping-layer energy checks.
+
+A finite flux link and a two-site charge form an exact local joint unitary:
+matter transfer raises/lowers the oriented electric flux, both Gauss
+generators commute with the Hamiltonian, and electric work is exactly the
+negative change of hopping energy.  On two overlapping bonds, palindromic
+colored composition keeps unitarity, Gauss, and reversibility exactly but
+conserves the naive summed Hamiltonian only to third order per tick.  Its
+principal Floquet generator is exactly conserved and acquires cross-bond
+matrix elements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.linalg import schur
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/KINETIC_ISOTROPY_PRIMITIVE_NOTE_2026-06-09.md",
+    "scripts/u1_conserved_source_coulomb_photon_bridge_2026_09_03.py",
+    "scripts/u1_exact_source_work_closed_dipole_radiation_2026_09_03.py",
+    "scripts/u1_finite_step_matter_current_operator_work_interface_2026_09_03.py",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def commutator(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+    return left @ right - right @ left
+
+
+def hermitian_exponential(hamiltonian: np.ndarray, step: float) -> np.ndarray:
+    eigenvalues, eigenvectors = np.linalg.eigh(hamiltonian)
+    return (
+        eigenvectors
+        @ np.diag(np.exp(-1.0j * step * eigenvalues))
+        @ eigenvectors.conj().T
+    )
+
+
+def flux_shift(spin: int) -> tuple[np.ndarray, np.ndarray]:
+    flux = np.diag(np.arange(-spin, spin + 1, dtype=float))
+    shift = np.zeros_like(flux, dtype=complex)
+    for index in range(2 * spin):
+        shift[index + 1, index] = 1.0
+    return flux, shift
+
+
+def matter_transfer(size: int, tail: int, head: int) -> np.ndarray:
+    result = np.zeros((size, size), dtype=complex)
+    result[head, tail] = 1.0
+    return result
+
+
+def number_operator(size: int, vertex: int) -> np.ndarray:
+    result = np.zeros((size, size), dtype=complex)
+    result[vertex, vertex] = 1.0
+    return result
+
+
+@dataclass(frozen=True)
+class OneBond:
+    electric: np.ndarray
+    number_tail: np.ndarray
+    number_head: np.ndarray
+    electric_energy: np.ndarray
+    hopping_energy: np.ndarray
+    hamiltonian: np.ndarray
+    gauss_tail: np.ndarray
+    gauss_head: np.ndarray
+    shift: np.ndarray
+
+
+def one_bond_model(spin: int, coupling: float, hopping: float) -> OneBond:
+    flux, shift = flux_shift(spin)
+    rotor_identity = np.eye(2 * spin + 1, dtype=complex)
+    matter_identity = np.eye(2, dtype=complex)
+    number_tail_small = number_operator(2, 0)
+    number_head_small = number_operator(2, 1)
+    forward = matter_transfer(2, 0, 1)
+
+    electric = np.kron(flux, matter_identity)
+    number_tail = np.kron(rotor_identity, number_tail_small)
+    number_head = np.kron(rotor_identity, number_head_small)
+    joint_shift = np.kron(shift, forward)
+    electric_energy = 0.5 * coupling * electric @ electric
+    hopping_energy = -hopping * (joint_shift + joint_shift.conj().T)
+    hamiltonian = electric_energy + hopping_energy
+    return OneBond(
+        electric=electric,
+        number_tail=number_tail,
+        number_head=number_head,
+        electric_energy=electric_energy,
+        hopping_energy=hopping_energy,
+        hamiltonian=hamiltonian,
+        gauss_tail=-electric - number_tail,
+        gauss_head=electric - number_head,
+        shift=shift,
+    )
+
+
+@dataclass(frozen=True)
+class TwoBond:
+    electric_first: np.ndarray
+    electric_second: np.ndarray
+    numbers: tuple[np.ndarray, ...]
+    electric_energy_first: np.ndarray
+    electric_energy_second: np.ndarray
+    hopping_first: np.ndarray
+    hopping_second: np.ndarray
+    hamiltonian_first: np.ndarray
+    hamiltonian_second: np.ndarray
+    hamiltonian: np.ndarray
+    gauss: tuple[np.ndarray, ...]
+
+
+def two_bond_model(
+    spin: int,
+    coupling: float,
+    first_hopping: float,
+    second_hopping: float,
+    *,
+    shared: bool,
+) -> TwoBond:
+    flux, shift = flux_shift(spin)
+    rotor_dimension = 2 * spin + 1
+    rotor_identity = np.eye(rotor_dimension, dtype=complex)
+    matter_size = 3 if shared else 4
+    matter_identity = np.eye(matter_size, dtype=complex)
+
+    electric_first = np.kron(
+        np.kron(flux, rotor_identity), matter_identity
+    )
+    electric_second = np.kron(
+        np.kron(rotor_identity, flux), matter_identity
+    )
+    numbers = tuple(
+        np.kron(
+            np.kron(rotor_identity, rotor_identity),
+            number_operator(matter_size, vertex),
+        )
+        for vertex in range(matter_size)
+    )
+
+    first_tail, first_head = 0, 1
+    second_tail, second_head = (1, 2) if shared else (2, 3)
+    first_shift = np.kron(
+        np.kron(shift, rotor_identity),
+        matter_transfer(matter_size, first_tail, first_head),
+    )
+    second_shift = np.kron(
+        np.kron(rotor_identity, shift),
+        matter_transfer(matter_size, second_tail, second_head),
+    )
+    hopping_first = -first_hopping * (
+        first_shift + first_shift.conj().T
+    )
+    hopping_second = -second_hopping * (
+        second_shift + second_shift.conj().T
+    )
+    electric_energy_first = (
+        0.5 * coupling * electric_first @ electric_first
+    )
+    electric_energy_second = (
+        0.5 * coupling * electric_second @ electric_second
+    )
+    hamiltonian_first = electric_energy_first + hopping_first
+    hamiltonian_second = electric_energy_second + hopping_second
+    hamiltonian = hamiltonian_first + hamiltonian_second
+
+    if shared:
+        gauss = (
+            -electric_first - numbers[0],
+            electric_first - electric_second - numbers[1],
+            electric_second - numbers[2],
+        )
+    else:
+        gauss = (
+            -electric_first - numbers[0],
+            electric_first - numbers[1],
+            -electric_second - numbers[2],
+            electric_second - numbers[3],
+        )
+    return TwoBond(
+        electric_first=electric_first,
+        electric_second=electric_second,
+        numbers=numbers,
+        electric_energy_first=electric_energy_first,
+        electric_energy_second=electric_energy_second,
+        hopping_first=hopping_first,
+        hopping_second=hopping_second,
+        hamiltonian_first=hamiltonian_first,
+        hamiltonian_second=hamiltonian_second,
+        hamiltonian=hamiltonian,
+        gauss=gauss,
+    )
+
+
+def evolved(operator: np.ndarray, unitary: np.ndarray) -> np.ndarray:
+    return unitary.conj().T @ operator @ unitary
+
+
+def spectral_norm(operator: np.ndarray) -> float:
+    return float(np.linalg.norm(operator, ord=2))
+
+
+def principal_floquet_generator(
+    unitary: np.ndarray, step: float
+) -> np.ndarray:
+    triangular, vectors = schur(unitary, output="complex")
+    phases = np.angle(np.diag(triangular))
+    generator = (
+        vectors @ np.diag(-phases / step) @ vectors.conj().T
+    )
+    return 0.5 * (generator + generator.conj().T)
+
+
+def local_exchange_residuals(
+    electric: np.ndarray,
+    number_tail: np.ndarray,
+    number_head: np.ndarray,
+    electric_energy: np.ndarray,
+    hopping_energy: np.ndarray,
+    hamiltonian: np.ndarray,
+    coupling: float,
+    step: float,
+) -> tuple[float, float, float, float, float]:
+    unitary = hermitian_exponential(hamiltonian, step)
+    electric_new = evolved(electric, unitary)
+    tail_new = evolved(number_tail, unitary)
+    head_new = evolved(number_head, unitary)
+    integrated_current = (electric_new - electric) / step
+    electric_change = evolved(electric_energy, unitary) - electric_energy
+    hopping_change = evolved(hopping_energy, unitary) - hopping_energy
+    work = 0.25 * coupling * step * (
+        integrated_current @ (electric + electric_new)
+        + (electric + electric_new) @ integrated_current
+    )
+    return (
+        spectral_norm(head_new - number_head - step * integrated_current),
+        spectral_norm(tail_new - number_tail + step * integrated_current),
+        spectral_norm(electric_change - work),
+        spectral_norm(hopping_change + work),
+        spectral_norm(evolved(hamiltonian, unitary) - hamiltonian),
+    )
+
+
+def main() -> int:
+    checks = Checks()
+    coupling = 1.3
+    hopping = 0.7
+    step = 0.4
+
+    shift_algebra_ok = True
+    boundary_cost_ok = True
+    gauss_generator_ok = True
+    component_count_ok = True
+    for spin in (1, 2, 3):
+        model = one_bond_model(spin, coupling, hopping)
+        flux, shift = flux_shift(spin)
+        shift_algebra_ok = shift_algebra_ok and bool(
+            np.array_equal(commutator(flux, shift), shift)
+        )
+        boundary_cost_ok = boundary_cost_ok and bool(
+            np.max(np.abs(shift.conj().T @ shift - np.eye(2 * spin + 1)))
+            == 1.0
+            and np.count_nonzero(shift[-1, :]) == 1
+            and np.count_nonzero(shift[:, -1]) == 0
+        )
+        gauss_generator_ok = gauss_generator_ok and bool(
+            np.max(
+                np.abs(commutator(model.gauss_tail, model.hamiltonian))
+            )
+            < 1.0e-15
+            and np.max(
+                np.abs(commutator(model.gauss_head, model.hamiltonian))
+            )
+            < 1.0e-15
+        )
+        adjacency = np.abs(model.hopping_energy) > 1.0e-14
+        degrees = np.count_nonzero(adjacency, axis=1)
+        component_count_ok = component_count_ok and bool(
+            np.count_nonzero(degrees == 1) == 4 * spin
+            and np.count_nonzero(degrees == 0) == 2
+            and np.max(degrees) == 1
+        )
+    checks.check(
+        shift_algebra_ok,
+        "the hard-cutoff quantum link obeys [E,U]=U exactly",
+    )
+    checks.check(
+        boundary_cost_ok,
+        "finite flux has one explicit nonunitary raising boundary at its top state",
+    )
+    checks.check(
+        gauss_generator_ok,
+        "both endpoint Gauss generators commute with every one-bond Hamiltonian",
+    )
+    checks.check(
+        component_count_ok,
+        "each finite link decomposes into paired transfer sectors plus two boundary dark states",
+    )
+
+    unitary_ok = True
+    gauss_evolution_ok = True
+    current_ok = True
+    work_ok = True
+    opposite_work_ok = True
+    energy_ok = True
+    for spin in (1, 2, 3):
+        for local_coupling, local_hopping, local_step in (
+            (1.3, 0.7, 0.4),
+            (0.8, 0.45, 0.23),
+            (1.7, 0.9, 0.17),
+        ):
+            model = one_bond_model(
+                spin, local_coupling, local_hopping
+            )
+            unitary = hermitian_exponential(
+                model.hamiltonian, local_step
+            )
+            electric_new = evolved(model.electric, unitary)
+            current = (electric_new - model.electric) / local_step
+            head_current = (
+                evolved(model.number_head, unitary) - model.number_head
+            ) / local_step
+            tail_current = -(
+                evolved(model.number_tail, unitary) - model.number_tail
+            ) / local_step
+            residuals = local_exchange_residuals(
+                model.electric,
+                model.number_tail,
+                model.number_head,
+                model.electric_energy,
+                model.hopping_energy,
+                model.hamiltonian,
+                local_coupling,
+                local_step,
+            )
+            unitary_ok = unitary_ok and bool(
+                spectral_norm(
+                    unitary.conj().T @ unitary
+                    - np.eye(unitary.shape[0])
+                )
+                < 4.0e-15
+            )
+            gauss_evolution_ok = gauss_evolution_ok and bool(
+                spectral_norm(
+                    evolved(model.gauss_tail, unitary) - model.gauss_tail
+                )
+                < 4.0e-15
+                and spectral_norm(
+                    evolved(model.gauss_head, unitary) - model.gauss_head
+                )
+                < 4.0e-15
+            )
+            current_ok = current_ok and bool(
+                spectral_norm(current - head_current) < 2.0e-14
+                and spectral_norm(current - tail_current) < 2.0e-14
+                and spectral_norm(current - current.conj().T) < 2.0e-14
+            )
+            work_ok = work_ok and residuals[0] < 2.0e-14
+            work_ok = work_ok and residuals[1] < 2.0e-14
+            work_ok = work_ok and residuals[2] < 2.0e-14
+            opposite_work_ok = opposite_work_ok and residuals[3] < 2.0e-14
+            energy_ok = energy_ok and residuals[4] < 2.0e-14
+    checks.check(
+        unitary_ok,
+        "the joint matter-flux evolution is unitary throughout the parameter grid",
+    )
+    checks.check(
+        gauss_evolution_ok,
+        "the finite joint unitary preserves both endpoint Gauss operators",
+    )
+    checks.check(
+        current_ok,
+        "one integrated current equals electric-flux gain and both matter endpoint transfers",
+    )
+    checks.check(
+        work_ok,
+        "electric energy gain equals the anticommutator midpoint work",
+    )
+    checks.check(
+        opposite_work_ok,
+        "the active matter hopping energy loses exactly the electric work",
+    )
+    checks.check(
+        energy_ok,
+        "the complete one-bond matter-plus-electric Hamiltonian is exactly conserved",
+    )
+
+    model = one_bond_model(2, coupling, hopping)
+    tangent_current = 1.0j * commutator(
+        model.hamiltonian, model.electric
+    )
+    tangent_errors = []
+    for trial_step in (0.4, 0.2, 0.1, 0.05):
+        unitary = hermitian_exponential(model.hamiltonian, trial_step)
+        integrated = (
+            evolved(model.electric, unitary) - model.electric
+        ) / trial_step
+        tangent_errors.append(spectral_norm(integrated - tangent_current))
+    checks.check(
+        all(
+            1.90 < left / right < 2.10
+            for left, right in zip(tangent_errors, tangent_errors[1:])
+        ),
+        "the exact flux current approaches its instantaneous commutator linearly in the step",
+    )
+
+    shared = two_bond_model(1, 1.2, 0.7, 0.55, shared=True)
+    local_gauss_ok = all(
+        spectral_norm(commutator(generator, local_hamiltonian)) < 1.0e-15
+        for generator in shared.gauss
+        for local_hamiltonian in (
+            shared.hamiltonian_first,
+            shared.hamiltonian_second,
+        )
+    )
+    checks.check(
+        local_gauss_ok,
+        "each adjacent bond Hamiltonian commutes with all three shared-vertex Gauss generators",
+    )
+
+    first_exchange = local_exchange_residuals(
+        shared.electric_first,
+        shared.numbers[0],
+        shared.numbers[1],
+        shared.electric_energy_first,
+        shared.hopping_first,
+        shared.hamiltonian_first,
+        1.2,
+        0.31,
+    )
+    second_exchange = local_exchange_residuals(
+        shared.electric_second,
+        shared.numbers[1],
+        shared.numbers[2],
+        shared.electric_energy_second,
+        shared.hopping_second,
+        shared.hamiltonian_second,
+        1.2,
+        0.31,
+    )
+    checks.check(
+        max(first_exchange + second_exchange) < 5.0e-15,
+        "each operational adjacent-bond layer closes charge and opposite electric work exactly",
+    )
+
+    trial_steps = (0.4, 0.2, 0.1, 0.05)
+    lie_energy_drifts = []
+    strang_energy_drifts = []
+    lie_flow_errors = []
+    strang_flow_errors = []
+    floquet_deviations = []
+    floquet_extra_entries = []
+    floquet_conservation_ok = True
+    exact_flow_ok = True
+    gauss_tick_ok = True
+    reversal_ok = True
+    for trial_step in trial_steps:
+        first_full = hermitian_exponential(
+            shared.hamiltonian_first, trial_step
+        )
+        second_full = hermitian_exponential(
+            shared.hamiltonian_second, trial_step
+        )
+        first_half = hermitian_exponential(
+            shared.hamiltonian_first, 0.5 * trial_step
+        )
+        lie_tick = second_full @ first_full
+        strang_tick = first_half @ second_full @ first_half
+        exact_tick = hermitian_exponential(shared.hamiltonian, trial_step)
+
+        lie_energy_drifts.append(
+            spectral_norm(
+                evolved(shared.hamiltonian, lie_tick) - shared.hamiltonian
+            )
+        )
+        strang_energy_drifts.append(
+            spectral_norm(
+                evolved(shared.hamiltonian, strang_tick)
+                - shared.hamiltonian
+            )
+        )
+        lie_flow_errors.append(spectral_norm(lie_tick - exact_tick))
+        strang_flow_errors.append(spectral_norm(strang_tick - exact_tick))
+        exact_flow_ok = exact_flow_ok and bool(
+            spectral_norm(
+                evolved(shared.hamiltonian, exact_tick)
+                - shared.hamiltonian
+            )
+            < 5.0e-15
+        )
+        gauss_tick_ok = gauss_tick_ok and all(
+            spectral_norm(evolved(generator, strang_tick) - generator)
+            < 5.0e-15
+            for generator in shared.gauss
+        )
+        negative_first_half = hermitian_exponential(
+            shared.hamiltonian_first, -0.5 * trial_step
+        )
+        negative_second = hermitian_exponential(
+            shared.hamiltonian_second, -trial_step
+        )
+        reverse_tick = (
+            negative_first_half @ negative_second @ negative_first_half
+        )
+        reversal_ok = reversal_ok and bool(
+            spectral_norm(reverse_tick @ strang_tick - np.eye(27))
+            < 5.0e-15
+        )
+
+        floquet = principal_floquet_generator(strang_tick, trial_step)
+        floquet_conservation_ok = floquet_conservation_ok and bool(
+            spectral_norm(evolved(floquet, strang_tick) - floquet)
+            < 7.0e-15
+            and spectral_norm(floquet - floquet.conj().T) < 2.0e-15
+        )
+        floquet_deviations.append(
+            spectral_norm(floquet - shared.hamiltonian)
+        )
+        zero_mask = np.abs(shared.hamiltonian) < 1.0e-14
+        floquet_extra_entries.append(float(np.max(np.abs(floquet[zero_mask]))))
+
+    checks.check(
+        gauss_tick_ok and reversal_ok,
+        "the palindromic adjacent-bond tick is exactly Gauss preserving and reversible",
+    )
+    checks.check(
+        exact_flow_ok,
+        "the unsplit two-bond exponential exactly conserves the summed Hamiltonian",
+    )
+    checks.check(
+        all(
+            3.8 < left / right < 4.2
+            for left, right in zip(lie_energy_drifts, lie_energy_drifts[1:])
+        )
+        and lie_energy_drifts[0] > 0.04,
+        "a nonpalindromic two-color product has a quadratic one-tick energy drift",
+    )
+    checks.check(
+        all(
+            7.8 < left / right < 8.2
+            for left, right in zip(
+                strang_energy_drifts, strang_energy_drifts[1:]
+            )
+        )
+        and strang_energy_drifts[0] < 0.005,
+        "the palindromic two-color product suppresses summed-energy drift to cubic order",
+    )
+    checks.check(
+        all(
+            3.8 < left / right < 4.2
+            for left, right in zip(lie_flow_errors, lie_flow_errors[1:])
+        )
+        and all(
+            7.8 < left / right < 8.2
+            for left, right in zip(strang_flow_errors, strang_flow_errors[1:])
+        ),
+        "Lie and palindromic products approach the exact joint flow at orders two and three",
+    )
+    checks.check(
+        floquet_conservation_ok,
+        "the principal palindromic Floquet generator is Hermitian and exactly conserved",
+    )
+    checks.check(
+        all(
+            3.9 < left / right < 4.1
+            for left, right in zip(
+                floquet_deviations, floquet_deviations[1:]
+            )
+        ),
+        "the conserved Floquet generator differs from the summed Hamiltonian at quadratic order",
+    )
+    checks.check(
+        all(value > 5.0e-5 for value in floquet_extra_entries)
+        and all(
+            3.9 < left / right < 4.1
+            for left, right in zip(
+                floquet_extra_entries, floquet_extra_entries[1:]
+            )
+        ),
+        "the exact Floquet energy acquires resolved cross-bond entries at quadratic order",
+    )
+
+    disjoint = two_bond_model(1, 1.2, 0.7, 0.55, shared=False)
+    disjoint_step = 0.4
+    disjoint_first = hermitian_exponential(
+        disjoint.hamiltonian_first, disjoint_step
+    )
+    disjoint_second = hermitian_exponential(
+        disjoint.hamiltonian_second, disjoint_step
+    )
+    disjoint_product = disjoint_second @ disjoint_first
+    disjoint_exact = hermitian_exponential(
+        disjoint.hamiltonian, disjoint_step
+    )
+    checks.check(
+        spectral_norm(
+            commutator(
+                disjoint.hamiltonian_first,
+                disjoint.hamiltonian_second,
+            )
+        )
+        < 1.0e-15
+        and spectral_norm(disjoint_product - disjoint_exact) < 5.0e-15
+        and spectral_norm(
+            evolved(disjoint.hamiltonian, disjoint_product)
+            - disjoint.hamiltonian
+        )
+        < 5.0e-15,
+        "disjoint colored bonds commute and conserve the summed energy exactly",
+    )
+
+    shared_commutator = spectral_norm(
+        commutator(
+            shared.hamiltonian_first, shared.hamiltonian_second
+        )
+    )
+    inactive_hop_change = spectral_norm(
+        evolved(
+            shared.hopping_second,
+            hermitian_exponential(shared.hamiltonian_first, 0.4),
+        )
+        - shared.hopping_second
+    )
+    checks.check(
+        shared_commutator > 0.3 and inactive_hop_change > 0.1,
+        "shared matter makes neighboring bond energies noncommute and exposes the splitting residual",
+    )
+
+    print(
+        "per_element: finite flux raising, matter transfer, current, and anticommutator work are checked"
+    )
+    print(
+        "per_site: both endpoint Gauss generators and the shared middle-vertex generator are checked"
+    )
+    print(
+        "per_mode: instantaneous-current and Lie/Strang/Floquet refinement orders are resolved"
+    )
+    print(
+        "per_block: one-bond exact backreaction and two-bond overlapping/disjoint controls are checked"
+    )
+    print(
+        "lattice_wide: colored local layers preserve Gauss by composition; exact summed energy versus Floquet energy remains the global schedule choice"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

A finite hard-cutoff flux link and charged two-site hop form one exact local joint unitary in which:

- matter transfer, head/tail charge change, and electric-flux change share one integrated current
- both endpoint Gauss generators are preserved
- electric energy gain equals anticommutator midpoint work
- hopping energy loses exactly the same work
- total one-bond matter-plus-electric energy is exactly conserved

The runner verifies S=1,2,3 and nine parameter cases.

## Global schedule discriminator

For adjacent bonds sharing matter, every operational layer still closes Gauss and local work. The unsplit two-bond exponential conserves the summed Hamiltonian exactly. A finite-depth palindromic colored tick remains exactly unitary, reversible, and Gauss-preserving, but its naive summed-energy drift is cubic per tick. Its principal Floquet generator is exactly conserved, differs at quadratic order, and gains resolved cross-bond entries. Disjoint bonds are the exact commuting control.

Runner: TOTAL: PASS=23 FAIL=0. Includes identity-pinned cache, bounded theorem note, N1-N8 scope packet, and graph acknowledgment.

## Significance

This closes the local backreaction obligation left by #7924. The remaining choice is global time architecture: exact summed-H evolution, strict colored Floquet ticks, or an enlarged collision carrier. The next discriminator is the smallest matter-link-plus-plaquette block and survival of the photon sector.

## Scope

Source science only, not an audit verdict. No TOE score, axiom, primitive, or audit status changes. The link has a hard flux cutoff and two dark boundary states; matter is one-particle; the magnetic plaquette, full lattice Floquet locality, Record layer, and coupling selection remain open.

## Validation

- runner 23/23
- cache identity fresh
- claim typing clean
- vocabulary lint clean
- repository invariants and enforced links clean
- strict audit lint clean apart from repository baseline warnings/notices