### PR TITLE
science(light): resolve spin-half electric stiffness

### DIFF
--- a/docs/SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,531 @@
+# Spin-Half Cubic Ice Has Positive Finite-Volume Topological Electric Stiffness at First Order
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct finite-qubit parent:**
+[`SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Maxwell-generator parent:**
+[`U1_ROLE_COMPILED_YEE_MAXWELL_GENERATOR_AND_TIME_SELECTION_FORK_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_ROLE_COMPILED_YEE_MAXWELL_GENERATOR_AND_TIME_SELECTION_FORK_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py`](../scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py)
+
+**Helper runner:**
+[`scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py`](../scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.txt`](../logs/runner-cache/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.txt)
+
+## Result up front
+
+The one-qubit cubic-ice carrier has a positive electric stiffness on the
+`delta V<0` side of its Rokhsar-Kivelson (RK) point at first order, in the
+tested finite-volume and shrinking-field-density limit.
+
+Write the microscopic Hamiltonian near the soluble point as
+
+```text
+H(V)=H_RK + delta V N_f,
+delta V=V-J,
+```
+
+where `N_f` counts flippable square plaquettes. In a fixed electric-flux
+sector, first-order perturbation theory gives
+
+```text
+delta E(Phi)=delta V <N_f>_Phi.
+```
+
+For `delta V<0`, a sector with fewer flippable plaquettes lies higher. The
+runner establishes that ordering in two complementary ways.
+
+First, it exhausts all `9600` three-of-six configurations on the `L=2` torus,
+constructs the complete reversible square-move graph, and finds `937`
+connected components. The `864`-state zero-flux component is uniquely the
+most flippable, with
+
+```text
+<N_f>_0=8.
+```
+
+All six signed unit-flux components are exactly cubic- and
+inversion-degenerate. Each contains `464` states and has
+
+```text
+<N_f>_|Phi|=1 = 188/29,
+<N_f>_0-<N_f>_|Phi|=1 = 44/29 > 0.
+```
+
+Every nonzero-flux component has a smaller maximum mean flippability than the
+zero-flux mobile component. Reversing the perturbation sign supplies a sharp
+control: for `delta V>0`, one of the many frozen zero-flippability components
+wins instead.
+
+Second, the runner constructs noncontractible alternating loops carrying
+signed flux along all three cubic axes and runs chains targeting the uniform
+RK measure on `L=6,8,10,12`. For each nonzero magnitude it averages six chains, one for
+each axis and sign; each chain uses a different initial line placement and
+random seed. Three independent chains supply each zero-flux reference. All
+`120` chains preserve exact three-of-six Gauss charge and their assigned
+topological flux.
+
+At each volume, the data fit
+
+```text
+<N_f>_(L,Phi)=a_L-c_L Phi^2/L.
+```
+
+The independently fitted coefficients are
+
+```text
+L=6       c=1.674857 +/- 0.141886
+L=8       c=1.884728 +/- 0.151700
+L=10      c=1.449046 +/- 0.157112
+L=12      c=1.260166 +/- 0.173252.
+```
+
+Every coefficient is positive by more than seven reported standard errors.
+A common weighted fit with a separate intercept for each volume gives
+
+```text
+c=1.591937 +/- 0.077393.
+```
+
+An unweighted common fit gives `c=1.483284`. Its residual sum of squares is
+`1.734259`, compared with
+
+```text
+linear in |Phi|       3.623267
+linear in |Phi|/L     4.413888
+quadratic in Phi      4.410875
+nonzero-sector step  27.987299.
+```
+
+Every model receives an independent intercept at each volume, so this
+comparison tests the flux dependence rather than the extensive background.
+
+For `delta V<0`, the measured first-order flux cost is therefore
+
+```text
+Delta E(Phi)
+ =|delta V| [<N_f>_0-<N_f>_Phi]
+ =|delta V| c Phi^2/L + finite-volume corrections.
+```
+
+Matching it to the Maxwell topological-sector energy
+
+```text
+Delta E_Maxwell(Phi)=U Phi^2/(2L)
+```
+
+gives, in the displayed electric-field normalization,
+
+```text
+U/|delta V|=2c=3.183873 +/- 0.154786.
+```
+
+This is the electric coefficient missing from the direct parent. That parent
+already measures positive magnetic stiffness on the same one-qubit carrier.
+Together they give a positive `U K` product and hence two conditional linear
+Maxwell branches in the quadratic long-wavelength theory.
+
+The result is bounded. It is a first derivative at the RK point, measured on
+four finite volumes. It does not independently establish the complete
+thermodynamic phase at finite `delta V`, its real-time spectrum, or a physical
+site compiler. Those stronger statements remain separate.
+
+## 1. Exact topological-sector graph
+
+The microscopic variables and staggered electric flux are defined in the
+direct parent. On `L=2`, the runner enumerates every choice of `12` occupied
+links among `24`, then retains exactly those with three occupied links at all
+eight vertices. It obtains `9600` states across `125` electric-flux triples.
+
+For every state, the runner constructs all alternating square flips with
+their geometric multiplicities. It checks that every destination is in the
+ice set, that every move preserves the complete flux triple, and that the
+reverse edge has the same multiplicity. Breadth-first search then partitions
+the graph into `937` connected components, `177` of them mobile.
+
+At the RK point, the equal-amplitude state on each connected component is an
+exact zero of the RK projector Hamiltonian. The derivative of its energy with
+respect to `V` is the component mean of `N_f`. Thus component flippability is
+the exact finite-volume first-order discriminator; no fitted Hamiltonian
+coefficient is inserted.
+
+Only one mobile component attains mean flippability `8`, and it has zero
+electric flux. Cubic rotations and flux inversion generate six unit-flux
+components. The runner obtains their equal size and mean as exact integer
+relations, not floating-point coincidences:
+
+```text
+size=464,
+29 sum_state N_f(state)=188 x 464.
+```
+
+For `delta V<0`, maximizing `<N_f>` minimizes the first-order energy. The
+zero-flux component is therefore selected exactly on this torus. All
+nonzero-flux maxima lie below it. For the opposite sign, an `N_f=0` frozen
+component has the smallest shift. This sign-reversal control distinguishes
+the perturbative selection from a hard-coded preference for zero flux.
+
+## 2. Constructing controlled nonzero flux
+
+Starting from the checkerboard ice configuration, choose a straight
+noncontractible loop along one cubic axis. Occupations alternate along that
+loop. Flipping the whole loop changes one incoming and one outgoing link at
+each visited vertex, so every three-of-six constraint survives. Depending on
+the transverse parity, the loop changes the signed electric flux by `+1` or
+`-1`.
+
+The runner derives that sign by evaluating the flux before and after each
+candidate loop. It inserts the requested number of same-sign loops, verifies
+the resulting full flux triple, and rejects any construction that changes a
+vertex degree. Local square moves then sample within the assigned sector
+without changing the flux.
+
+The largest magnitude is `Phi=L/2`. Therefore the field density in the fit
+window obeys
+
+```text
+|Phi|/L^2 <= 1/(2L),
+```
+
+which decreases from `1/12` at `L=6` to `1/24` at `L=12`. The refinement is
+not a fixed large-background-field test.
+
+## 3. Symmetry-averaged Monte Carlo protocol
+
+For every `L` and every magnitude `Phi=1,...,L/2`, the protocol runs all six
+signed-axis sectors
+
+```text
+(+/-Phi,0,0), (0,+/-Phi,0), (0,0,+/-Phi).
+```
+
+Each chain starts from a shifted set of noncontractible flux lines, uses `500`
+thermal sweeps, and then takes `500` samples separated by two full
+checkerboard sweeps. Ten consecutive blocks per chain estimate uncertainty.
+The six nonzero-flux chains provide `3000` samples per magnitude. Three
+independent zero-flux replicas provide `1500` samples per volume.
+
+The largest signed-axis range is `3.375` times the estimated standard error
+of one chain. Pooling all signs and axes therefore removes a visible cubic
+orientation choice while retaining the between-chain variation in the block
+error. This is a sampling control, not a proof of large-volume ergodicity.
+
+The measured orbit means are:
+
+```text
+L=6:  169.2593, 169.1357, 168.2900, 166.8390
+L=8:  400.1993, 400.2510, 399.9897, 398.4503, 396.7370
+L=10: 780.5727, 779.6630, 779.6877, 778.8550, 778.0757, 776.4027
+L=12: 1347.9060, 1347.1087, 1346.7343, 1345.9627,
+      1345.5970, 1344.4800, 1343.5380.
+```
+
+Within each row, entries run from `Phi=0` through `Phi=L/2`. Individual small
+flux steps can fluctuate upward, as the `L=8, Phi=1` value does. The theorem
+does not require pointwise monotonicity. Its load-bearing test is the resolved
+quadratic coefficient at each volume and the common controlled model
+comparison.
+
+## 4. Extracting the electric stiffness
+
+The effective electric energy of a uniform topological flux is
+
+```text
+(U/2) L^3 (Phi/L^2)^2 = U Phi^2/(2L).
+```
+
+The microscopic first-order cost has the same volume and flux dependence.
+Equating coefficients gives `U=2c|delta V|`. No empirical value, photon speed,
+or target coefficient is used in the fit. The volume intercepts absorb only
+the extensive zero-flux flippability.
+
+The four `c_L` values are not assumed equal. Their range is `0.625`, or about
+`39.9%` of their mean; the runner requires this relative spread to stay below
+`50%`. The common weighted coefficient is more than twenty reported standard
+errors above zero. The unweighted coefficient differs from it by `6.8%`,
+inside the stated `25%` consistency bound.
+
+The quadratic-over-volume form is also discriminating. With the same four
+free intercepts and one common slope, its residual is less than half that of
+the nearest named control. A linear flux cost, an unscaled `Phi^2` cost, and a
+mere nonzero-sector offset do not describe the finite data as well.
+
+This establishes positive topological electric stiffness at first order in
+the stated protocol. It does not bound higher orders in `delta V` uniformly
+with volume. The primary spin-liquid analysis supplies the stronger phase
+stability argument; this runner supplies a direct executable coefficient and
+its scaling tests.
+
+## 5. Consequence for the photon bridge
+
+The direct parent established on the same carrier:
+
+- exact one-qubit Gauss-preserving square-ring dynamics;
+- the complete `L=2` zero-flux RK sector;
+- axial and off-axis transverse Coulomb covariance on `L=6,8,10,12`; and
+- positive magnetic stiffness from threaded magnetic flux.
+
+This source adds the complementary first-order electric term. In the
+quadratic long-wavelength Hamiltonian
+
+```text
+H_eff=(U/2)||E||^2+(K/2)||curl A||^2,
+```
+
+the expansion point has positive `K`, and the first derivative produces
+positive `U` into the tested side. Thus both are positive to first order. The
+cubic curl kernel then has one Gauss-null direction and two equal branches
+
+```text
+omega(k)^2=U K 4 sum_i sin^2(k_i/2).
+```
+
+The new content is the sign, scaling, and magnitude of `U` in a microscopic
+one-qubit model. The mode-count identity and positive magnetic term come from
+the parents. A direct real-time or imaginary-time many-body spectrum at
+finite `delta V` remains unexecuted.
+
+## 6. Program boundary and next target
+
+This result removes two candidate blockers at once:
+
+```text
+finite local dimension two is compatible with magnetic stiffness,
+finite local dimension two is compatible with positive electric stiffness.
+```
+
+It materially strengthens the light lane because the two coefficients needed
+for a linear photon now coexist on the same exact microscopic carrier. It is
+not merely another imposed Maxwell generator: the coefficient is a falsifiable
+statistic of the supplied qubit Hamiltonian and its topological sectors.
+
+The shortest remaining physics test is dynamical and thermodynamic. A
+sign-free quantum Monte Carlo calculation or controlled duality analysis at
+finite `delta V<0` should resolve a volume-stable linear transverse spectrum
+or the equivalent charge `1/R` response. Those are alternative diagnostics
+of the same phase obligation, not two separate walls.
+
+The physical-site compiler remains separate. Coarse cubic links and square
+ring terms must still be realized by one homogeneous nearest-neighbor rule on
+the framework's physical `Z^3` sites. Matter coupling, Admissibility
+selection, and empirical electromagnetic identification also remain open.
+
+No axiom edit follows. The ice sector, ring Hamiltonian, perturbation sign,
+and couplings are supplied model content. Admissibility does not select them,
+and Record is untouched.
+
+## 7. Prior-art and contribution boundary
+
+The cubic spin-half model and the first-order topological-sector strategy are
+from M. Hermele, M. P. A. Fisher, and L. Balents,
+[“Pyrochlore Photons: The U(1) Spin Liquid in a S=1/2 Three-Dimensional
+Frustrated Magnet”](https://arxiv.org/abs/cond-mat/0305401) (2004). That work
+states that `delta V<0` selects the zero-flux sector, measures the static
+spinon potential, and establishes the adjacent stable `U(1)` phase.
+
+The repo-specific contribution is an independent executable realization of
+the topological-stiffness route: complete all-flux component enumeration,
+exact unit-flux cost, `120` signed-axis and shifted-initialization chains, a
+shrinking field-density ladder, four independent positive coefficients, and
+a controlled common-scaling comparison that yields the displayed `U`
+coefficient. This does not claim priority for the model or method.
+
+## 8. Executable evidence
+
+The runner reports `TOTAL: PASS=11 FAIL=0`. It checks:
+
+- exact partition of all `9600` states into `937` reversible,
+  flux-preserving components;
+- unique maximal flippability of the zero-flux mobile component;
+- exact signed-axis and cubic degeneracy of the six unit-flux components;
+- the `delta V<0` selection and opposite-sign frozen-sector control;
+- exact Gauss and assigned-flux preservation in all `120` large-volume
+  chains;
+- a positive independently resolved `c_L` on every volume;
+- a bounded coefficient range and spread across `L=6,8,10,12`;
+- preference for `Phi^2/L` over four named controls with equal intercept
+  freedom;
+- a positive weighted common coefficient and derived `U/|delta V|`;
+- shrinking fitted field density with volume; and
+- a normalized signed-axis sampling-spread control.
+
+## No-Go Discipline Gate
+
+This is a positive first-order stiffness theorem with a deliberately
+unexecuted thermodynamic phase question. The gate prevents the remaining
+dynamic calculation from being inflated into several independent blockers or
+from being treated as a negative result.
+
+### N1 — Alternative route enumeration
+
+| Honesty | Route family | Outcome |
+|---|---|---|
+| **ATTEMPTED** | exact all-flux component graph | **Positive:** zero flux is uniquely most flippable and unit flux has exact positive cost. |
+| **ATTEMPTED** | signed-axis noncontractible-loop sectors | **Positive:** all `120` chains preserve exact Gauss charge and assigned flux. |
+| **ATTEMPTED** | four-volume `Phi^2/L` scaling | **Positive:** every `c_L` and the common coefficient are resolved above zero. |
+| **ATTEMPTED** | linear, unscaled-quadratic, and sector-step controls | **Discriminating:** all have larger common-fit residuals. |
+| **ATTEMPTED** | magnetic threaded-flux route | Direct parent supplies positive `K` on the same carrier. |
+| **IMPORTED** | static-charge `1/R` response and phase stability | Primary model result; not restated as runner output. |
+| **OPEN** | finite-`delta V` sign-free dynamical calculation | Would test the full phase and linear spectrum directly. |
+| **OPEN** | homogeneous physical-site compiler | Would realize the constrained link model under the framework's local rule. |
+| **OPEN** | matter coupling on the spin-half carrier | Would join mobile charge, current, and field work on this model. |
+
+These routes differ by sector observable, scaling law, or terminal obligation.
+The exact small graph and the four-volume Monte Carlo are independent
+resolutions, not duplicated descriptions of one number.
+
+### N2 — Wall-independence and collapse audit
+
+The finite-`delta V` spectrum, stable thermodynamic phase, and charge `1/R`
+response are diagnostics of one remaining phase obligation and collapse into
+`W1`.
+
+```text
+W1 = repo-native finite-delta-V thermodynamic and dynamical phase test,
+W2 = homogeneous nearest-neighbor physical-site compiler,
+W3 = mobile matter and exact backreaction on the spin-half carrier,
+W4 = Admissibility selection and empirical electromagnetic identification.
+```
+
+| Pair | Does either automatically close the other? | Independent? |
+|---|---:|---:|
+| W1, W2 | no | yes |
+| W1, W3 | no | yes |
+| W1, W4 | no | yes |
+| W2, W3 | no | yes |
+| W2, W4 | no | yes |
+| W3, W4 | no | yes |
+
+No impossibility is inferred from this wall set.
+
+### N3 — Hidden-condition scan
+
+The supplied cubic link graph, three-of-six sector, RK tuning, first-order
+`delta V` expansion, topological-flux normalization, finite even volumes,
+maximum `Phi=L/2`, fixed seeds, shifted initial flux lines, checkerboard local
+updates, sample counts, block estimator, and symmetry pooling are explicit.
+Large-volume ergodicity within a flux sector is not proved. The standard-error
+figures do not include an independent rigorous autocorrelation bound. The
+shrinking field density controls the field amplitude but does not interchange
+the `delta V` and thermodynamic limits. The supplied law is not attributed to
+the framework axioms.
+
+### N4 — Residual matching
+
+| Surface | Exact residual there | Match here |
+|---|---|---|
+| direct finite-qubit parent | positive magnetic stiffness but electric coefficient imported | **direct partial resolution:** positive first-order `U` is now computed |
+| finite-clock parent | controlled Maxwell tangent, full many-link phase open | **alternative carrier:** fixed local dimension two and topological-sector stiffness |
+| Maxwell-generator parent | supplied positive quadratic electric term | **microscopic coefficient match:** `U=2c|delta V|` in the stated normalization |
+| primary spin-liquid source | long-run phase and static-charge response | **independent finite protocol:** exact graph plus topological-flux scaling |
+| physical-role compiler parent | collective edge/face roles | **unmatched remainder:** ice constraint and ring term are not yet compiled |
+
+The computed first derivative is not mislabeled as the full finite-perturbation
+phase.
+
+### N5 — Rhetoric and resolution audit
+
+“Positive electric stiffness” means the positive coefficient of the
+first-order `Phi^2/L` topological energy on the stated finite protocol. It
+does not mean a uniform all-orders thermodynamic bound. “Resolved” uses the
+displayed block errors and controls; the unproved large-volume mixing caveat
+remains explicit. The derived `U` is a model coefficient, not an observed
+electromagnetic constant.
+
+The cached runner contains the five-resolution execution certificate:
+
+```text
+per_element: each noncontractible alternating loop and each local plaquette move are checked
+per_site: exact three-of-six Gauss charge is preserved in every signed-flux chain
+per_mode: electric topological flux has positive quadratic stiffness in the Maxwell normalization
+per_block: all 9600 L=2 states and signed-axis Monte Carlo orbits on L=6 through L=12 are checked
+lattice_wide: finite-volume electric stiffness is resolved; a thermodynamic phase proof is not executed
+```
+
+### N6 — Partial-closure paths and primitive boundary
+
+No axiom or approved primitive is added. `W1` is a supplied-model phase
+calculation. It can be approached by sign-free quantum Monte Carlo, a
+continuous-time RK/master-equation method, or a controlled duality bound.
+`W2` is a compiler construction, and `W3` can reuse the gauge-matter energy
+accounting of the light parents only after the carrier map is explicit. `W4`
+is the selection and physical-identification boundary. None requires turning
+this measured coefficient into an axiom.
+
+### N7 — Steelman
+
+A hostile reviewer should reject a claim that four finite volumes and
+first-order perturbation theory prove the stable photon phase. The local
+Markov chain may have unmeasured mixing time, the block error is not a
+rigorous autocorrelation theorem, and the `delta V` radius need not be uniform
+in `L`. These objections are correct and define `W1`.
+
+They do not erase the exact `L=2` sign result or the fact that every larger
+volume independently gives positive curvature with a common scaling law that
+beats the named controls. The appropriate conclusion is the bounded
+first-order stiffness theorem, not either a complete phase proof or a
+negative verdict.
+
+### N8 — Cross-cycle echo
+
+The direct parent stopped at static RK correlations and positive magnetic
+stiffness. This source attacks its named missing electric coefficient with a
+new topological observable, exact all-flux enumeration, symmetry-related
+chains, volume scaling, and alternative-law controls. It is not an algebraic
+restatement of the parent. The earlier finite-clock route supplied a tangent
+by payload refinement; this route holds the local payload at one qubit and
+measures the stiffness emerging from constrained many-body sectors.
+
+**Gate result:** PASS. Six executed or imported route families are separated,
+three further routes remain open, dependent phase diagnostics are collapsed
+into one wall, and the first-order boundary is explicit.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- the exact move graph omits a state, crosses flux sectors, or is not
+  reversible with geometric multiplicity;
+- the zero-flux mobile component is not the unique maximizer of mean
+  flippability;
+- any signed unit-flux component differs in size, mean, or first-order cost;
+- any constructed noncontractible loop changes a vertex Gauss charge or has
+  the wrong signed flux;
+- any Monte Carlo chain leaves its assigned sector;
+- any fitted `c_L` is nonpositive or unresolved at the stated threshold;
+- the four-volume coefficient loses significance or exceeds the stated
+  relative spread;
+- `Phi^2/L` fails to beat any named equal-intercept control by the stated
+  residual factor;
+- the weighted and unweighted common coefficients disagree outside the
+  stated bound;
+- the field-density window fails to shrink; or
+- the signed-axis spread exceeds four estimated single-chain standard
+  errors.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=11 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15821,
- "node_count": 5576,
+ "edge_count": 15824,
+ "node_count": 5577,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17405,6 +17405,10 @@
   "spin_half_cubic_ice_exact_rk_coulomb_correlations_and_finite_qubit_photon_phase_bridge_bounded_theorem_note_2026-09-03": {
    "deps_hash": "66cfd875c50b",
    "out_degree": 5
+  },
+  "spin_half_cubic_ice_positive_topological_electric_stiffness_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "8a779a3f11ac",
+   "out_degree": 3
   },
   "spin_statistics_berezin_determinant_narrow_theorem_note_2026-05-10": {
    "deps_hash": "e3b0c44298fc",

--- a/logs/runner-cache/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.txt
@@ -1,0 +1,39 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py
+runner_sha256: 54cecc6ee35910254cc56d2b7378234651260334795d0ee35614f0924c030189
+input_fingerprint_sha256: 73a3ca589c3a301eb50e7e83e7eb2c875ae122fcd8c4f0062684c4ca03732b23
+timeout_sec: 120
+exit_code: 0
+elapsed_sec: 67.68
+status: ok
+----- stdout -----
+[PASS] 01 the exact L=2 move graph partitions all ice states into flux-preserving reversible components
+[PASS] 02 the unique most-flippable L=2 mobile component is the zero-electric-flux sector
+[PASS] 03 all six unit-flux L=2 sectors have one exact cubic- and inversion-degenerate energy cost
+[PASS] 04 negative delta V selects zero flux while the opposite sign provides a frozen-sector control
+[PASS] 05 every large-volume chain preserves exact Gauss charge and its constructed signed electric flux
+[PASS] 06 each volume independently resolves a positive quadratic topological-flux stiffness
+[PASS] 07 the Phi-squared-over-L coefficient remains finite and size-stable across four volumes
+[PASS] 08 the common Phi-squared-over-L law beats linear, unscaled-quadratic, and sector-step controls
+[PASS] 09 the fitted first-order energy gives a positive electric coefficient U/abs(delta V)=2c
+[PASS] 10 the fitted flux window becomes a shrinking field-density probe under volume refinement
+[PASS] 11 signed-axis means agree within four single-chain standard errors at every nonzero flux
+diagnostic exact graph: states=9600 components=937 mobile=177 zero_mean=8.00000000 unit_mean=6.48275862 unit_cost=1.51724138
+diagnostic L=6 orbit means: Phi=0:169.25933+/-0.22926[spread=1.56000] Phi=1:169.13567+/-0.18239[spread=0.75800] Phi=2:168.29000+/-0.17892[spread=1.04400] Phi=3:166.83900+/-0.14016[spread=0.71600]
+diagnostic L=6 stiffness: c=1.674857 error=0.141886 rms=0.062454
+diagnostic L=8 orbit means: Phi=0:400.19933+/-0.31140[spread=0.78600] Phi=1:400.25100+/-0.23909[spread=0.96200] Phi=2:399.98967+/-0.19734[spread=0.82000] Phi=3:398.45033+/-0.25743[spread=0.83200] Phi=4:396.73700+/-0.23988[spread=1.63400]
+diagnostic L=8 stiffness: c=1.884728 error=0.151700 rms=0.243210
+diagnostic L=10 orbit means: Phi=0:780.57267+/-0.50483[spread=0.82400] Phi=1:779.66300+/-0.32250[spread=1.76600] Phi=2:779.68767+/-0.27822[spread=1.38200] Phi=3:778.85500+/-0.36130[spread=2.75000] Phi=4:778.07567+/-0.33339[spread=1.91800] Phi=5:776.40267+/-0.32817[spread=1.76000]
+diagnostic L=10 stiffness: c=1.449046 error=0.157112 rms=0.249820
+diagnostic L=12 orbit means: Phi=0:1347.90600+/-0.80753[spread=4.51000] Phi=1:1347.10867+/-0.46500[spread=2.02800] Phi=2:1346.73433+/-0.46033[spread=2.95400] Phi=3:1345.96267+/-0.44679[spread=2.58400] Phi=4:1345.59700+/-0.45825[spread=2.61200] Phi=5:1344.48000+/-0.38563[spread=3.18800] Phi=6:1343.53800+/-0.45634[spread=2.98800]
+diagnostic L=12 stiffness: c=1.260166 error=0.173252 rms=0.298188
+diagnostic common scaling: c=1.591937+/-0.077393 unweighted_c=1.483284 weighted_rms=0.297855 relative_c_spread=0.398521 U/abs(deltaV)=3.183873 rss=1.734259 controls=Phi:3.623267,Phi/L:4.413888,Phi^2:4.410875,sector_step:27.987299 max_normalized_chain_spread=3.374985
+per_element: each noncontractible alternating loop and each local plaquette move are checked
+per_site: exact three-of-six Gauss charge is preserved in every signed-flux chain
+per_mode: electric topological flux has positive quadratic stiffness in the Maxwell normalization
+per_block: all 9600 L=2 states and signed-axis Monte Carlo orbits on L=6 through L=12 are checked
+lattice_wide: finite-volume electric stiffness is resolved; a thermodynamic phase proof is not executed
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py
+++ b/scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Topological electric stiffness in the spin-half cubic-ice model."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict, deque
+from dataclasses import dataclass
+
+import numpy as np
+
+from spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03 import (
+    CubicIceSampler,
+    decode_small,
+    electric_flux,
+    enumerate_small_ice_sector,
+    flippable_count,
+    initial_ice,
+    small_flip_destinations,
+    vertex_degrees,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py",
+    "scripts/u1_role_compiled_yee_maxwell_time_selection_fork_2026_09_03.py",
+)
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@dataclass(frozen=True)
+class ExactComponent:
+    flux: tuple[int, int, int]
+    size: int
+    total_flippability: int
+    minimum_flippability: int
+    maximum_flippability: int
+
+    @property
+    def mean_flippability(self) -> float:
+        return self.total_flippability / self.size
+
+
+def exact_components() -> tuple[tuple[int, ...], tuple[ExactComponent, ...], bool]:
+    states = enumerate_small_ice_sector()
+    state_set = set(states)
+    destinations = {
+        state: tuple(small_flip_destinations(decode_small(state)))
+        for state in states
+    }
+    move_consistency = True
+    for state, targets in destinations.items():
+        state_flux = electric_flux(decode_small(state))
+        target_counts = Counter(targets)
+        for target, multiplicity in target_counts.items():
+            move_consistency = move_consistency and bool(
+                target in state_set
+                and electric_flux(decode_small(target)) == state_flux
+                and Counter(destinations[target])[state] == multiplicity
+            )
+
+    seen: set[int] = set()
+    components: list[ExactComponent] = []
+    for start in states:
+        if start in seen:
+            continue
+        queue = deque([start])
+        seen.add(start)
+        members: list[int] = []
+        while queue:
+            state = queue.popleft()
+            members.append(state)
+            for target in destinations[state]:
+                if target not in seen:
+                    seen.add(target)
+                    queue.append(target)
+        fluxes = {electric_flux(decode_small(state)) for state in members}
+        if len(fluxes) != 1:
+            raise AssertionError(f"component crosses flux sectors: {fluxes}")
+        flippabilities = [len(destinations[state]) for state in members]
+        components.append(
+            ExactComponent(
+                flux=next(iter(fluxes)),
+                size=len(members),
+                total_flippability=sum(flippabilities),
+                minimum_flippability=min(flippabilities),
+                maximum_flippability=max(flippabilities),
+            )
+        )
+    return states, tuple(components), move_consistency
+
+
+def insert_flux_lines(
+    occupation: np.ndarray,
+    axis: int,
+    signed_flux: int,
+    line_offset: int = 0,
+) -> np.ndarray:
+    result = occupation.copy()
+    if signed_flux == 0:
+        return result
+    length = result.shape[0]
+    sign = 1 if signed_flux > 0 else -1
+    needed = abs(signed_flux)
+    transverse = [index for index in range(3) if index != axis]
+    inserted = 0
+    positions = [
+        (first, second)
+        for first in range(length)
+        for second in range(length)
+    ]
+    shift = line_offset % len(positions)
+    positions = positions[shift:] + positions[:shift]
+    for first, second in positions:
+        if inserted == needed:
+            break
+        candidate = result.copy()
+        line = [slice(None), slice(None), slice(None), axis]
+        line[transverse[0]] = first
+        line[transverse[1]] = second
+        before = electric_flux(result)
+        candidate[tuple(line)] ^= 1
+        after = electric_flux(candidate)
+        delta = after[axis] - before[axis]
+        if delta == sign:
+            result = candidate
+            inserted += 1
+    if inserted != needed:
+        raise ValueError(
+            f"could insert only {inserted} of {needed} requested flux lines"
+        )
+    expected = tuple(signed_flux if index == axis else 0 for index in range(3))
+    if electric_flux(result) != expected:
+        raise AssertionError(
+            f"wrong inserted flux: {electric_flux(result)} != {expected}"
+        )
+    if not np.all(vertex_degrees(result) == 3):
+        raise AssertionError("noncontractible alternating loops changed Gauss charge")
+    return result
+
+
+@dataclass(frozen=True)
+class FluxChain:
+    axis: int
+    signed_flux: int
+    mean: float
+    error: float
+    block_means: tuple[float, ...]
+    sector_ok: bool
+
+
+def run_flux_chain(
+    length: int,
+    axis: int,
+    signed_flux: int,
+    seed: int,
+    *,
+    thermal_sweeps: int = 500,
+    sample_count: int = 500,
+    sweep_stride: int = 2,
+    block_count: int = 10,
+) -> FluxChain:
+    sampler = CubicIceSampler(length, seed)
+    sampler.occupation = insert_flux_lines(
+        initial_ice(length), axis, signed_flux, line_offset=seed
+    )
+    expected_flux = tuple(
+        signed_flux if index == axis else 0 for index in range(3)
+    )
+    for _ in range(thermal_sweeps):
+        sampler.sweep()
+    values: list[float] = []
+    for _ in range(sample_count):
+        for _ in range(sweep_stride):
+            sampler.sweep()
+        values.append(float(flippable_count(sampler.occupation)))
+
+    data = np.asarray(values, dtype=float)
+    usable = (len(data) // block_count) * block_count
+    blocks = data[:usable].reshape(block_count, -1).mean(axis=1)
+    mean = float(np.mean(blocks))
+    error = float(np.std(blocks, ddof=1) / np.sqrt(block_count))
+    sector_ok = bool(
+        np.all(vertex_degrees(sampler.occupation) == 3)
+        and electric_flux(sampler.occupation) == expected_flux
+    )
+    return FluxChain(
+        axis=axis,
+        signed_flux=signed_flux,
+        mean=mean,
+        error=error,
+        block_means=tuple(float(value) for value in blocks),
+        sector_ok=sector_ok,
+    )
+
+
+@dataclass(frozen=True)
+class FluxOrbitAverage:
+    length: int
+    flux_magnitude: int
+    mean: float
+    error: float
+    chain_spread: float
+    chain_count: int
+    sector_ok: bool
+
+
+def run_flux_orbit(length: int, flux_magnitude: int) -> FluxOrbitAverage:
+    chains: list[FluxChain] = []
+    if flux_magnitude == 0:
+        specifications = [(0, 0, replica) for replica in range(3)]
+    else:
+        specifications = [
+            (axis, sign * flux_magnitude, 0)
+            for axis in range(3)
+            for sign in (-1, 1)
+        ]
+    for axis, signed_flux, replica in specifications:
+        seed = (
+            903_000
+            + 10_000 * length
+            + 100 * flux_magnitude
+            + 10 * axis
+            + (1 if signed_flux > 0 else 0)
+            + 3 * replica
+        )
+        chains.append(run_flux_chain(length, axis, signed_flux, seed))
+
+    blocks = np.asarray(
+        [value for chain in chains for value in chain.block_means],
+        dtype=float,
+    )
+    chain_means = np.asarray([chain.mean for chain in chains], dtype=float)
+    return FluxOrbitAverage(
+        length=length,
+        flux_magnitude=flux_magnitude,
+        mean=float(np.mean(blocks)),
+        error=float(np.std(blocks, ddof=1) / np.sqrt(len(blocks))),
+        chain_spread=float(np.max(chain_means) - np.min(chain_means)),
+        chain_count=len(chains),
+        sector_ok=all(chain.sector_ok for chain in chains),
+    )
+
+
+@dataclass(frozen=True)
+class LinearFit:
+    intercept: float
+    slope: float
+    slope_error: float
+    rms: float
+
+
+def weighted_linear_fit(
+    x_values: np.ndarray,
+    y_values: np.ndarray,
+    errors: np.ndarray,
+) -> LinearFit:
+    design = np.column_stack((np.ones_like(x_values), x_values))
+    weights = 1.0 / np.maximum(errors, 1.0e-12) ** 2
+    normal = design.T @ (weights[:, None] * design)
+    covariance = np.linalg.inv(normal)
+    coefficients = covariance @ (design.T @ (weights * y_values))
+    prediction = design @ coefficients
+    return LinearFit(
+        intercept=float(coefficients[0]),
+        slope=float(coefficients[1]),
+        slope_error=float(np.sqrt(covariance[1, 1])),
+        rms=float(np.sqrt(np.mean((y_values - prediction) ** 2))),
+    )
+
+
+def common_slope_rss(
+    lengths: np.ndarray,
+    predictor: np.ndarray,
+    values: np.ndarray,
+) -> tuple[float, float]:
+    unique_lengths = sorted(set(int(value) for value in lengths))
+    intercept_columns = np.column_stack(
+        [lengths == length for length in unique_lengths]
+    ).astype(float)
+    design = np.column_stack((intercept_columns, predictor))
+    coefficients, *_ = np.linalg.lstsq(design, values, rcond=None)
+    residual = values - design @ coefficients
+    return float(coefficients[-1]), float(residual @ residual)
+
+
+def weighted_common_slope(
+    lengths: np.ndarray,
+    predictor: np.ndarray,
+    values: np.ndarray,
+    errors: np.ndarray,
+) -> tuple[float, float, float]:
+    unique_lengths = sorted(set(int(value) for value in lengths))
+    intercept_columns = np.column_stack(
+        [lengths == length for length in unique_lengths]
+    ).astype(float)
+    design = np.column_stack((intercept_columns, predictor))
+    weights = 1.0 / np.maximum(errors, 1.0e-12) ** 2
+    normal = design.T @ (weights[:, None] * design)
+    covariance = np.linalg.inv(normal)
+    coefficients = covariance @ (design.T @ (weights * values))
+    residual = values - design @ coefficients
+    return (
+        float(coefficients[-1]),
+        float(np.sqrt(covariance[-1, -1])),
+        float(np.sqrt(np.mean(residual**2))),
+    )
+
+
+def main() -> int:
+    checks = Checks()
+
+    states, components, moves_ok = exact_components()
+    checks.check(
+        len(states) == 9600
+        and len(components) == 937
+        and sum(component.size for component in components) == len(states)
+        and moves_ok,
+        "the exact L=2 move graph partitions all ice states into flux-preserving reversible components",
+    )
+
+    mobile_components = [component for component in components if component.size > 1]
+    zero_mobile = [
+        component
+        for component in mobile_components
+        if component.flux == (0, 0, 0)
+    ]
+    maximum_mean = max(
+        component.mean_flippability for component in mobile_components
+    )
+    checks.check(
+        len(zero_mobile) == 1
+        and zero_mobile[0].size == 864
+        and zero_mobile[0].total_flippability == 864 * 8
+        and sum(
+            abs(component.mean_flippability - maximum_mean) < 1.0e-14
+            for component in mobile_components
+        )
+        == 1,
+        "the unique most-flippable L=2 mobile component is the zero-electric-flux sector",
+    )
+
+    unit_flux = [
+        component
+        for component in mobile_components
+        if sum(value * value for value in component.flux) == 1
+    ]
+    checks.check(
+        len(unit_flux) == 6
+        and all(component.size == 464 for component in unit_flux)
+        and all(
+            component.total_flippability * 29 == 188 * component.size
+            for component in unit_flux
+        )
+        and all(
+            abs(
+                zero_mobile[0].mean_flippability
+                - component.mean_flippability
+                - 44.0 / 29.0
+            )
+            < 1.0e-14
+            for component in unit_flux
+        ),
+        "all six unit-flux L=2 sectors have one exact cubic- and inversion-degenerate energy cost",
+    )
+
+    maximum_by_flux: dict[tuple[int, int, int], float] = defaultdict(float)
+    for component in components:
+        maximum_by_flux[component.flux] = max(
+            maximum_by_flux[component.flux], component.mean_flippability
+        )
+    checks.check(
+        all(
+            value < zero_mobile[0].mean_flippability
+            for flux, value in maximum_by_flux.items()
+            if flux != (0, 0, 0)
+        )
+        and any(component.size == 1 for component in components),
+        "negative delta V selects zero flux while the opposite sign provides a frozen-sector control",
+    )
+
+    orbit_results: dict[int, list[FluxOrbitAverage]] = {}
+    for length in (6, 8, 10, 12):
+        orbit_results[length] = [
+            run_flux_orbit(length, flux)
+            for flux in range(length // 2 + 1)
+        ]
+    checks.check(
+        all(
+            result.sector_ok
+            for results in orbit_results.values()
+            for result in results
+        ),
+        "every large-volume chain preserves exact Gauss charge and its constructed signed electric flux",
+    )
+
+    per_length_fits: dict[int, LinearFit] = {}
+    for length, results in orbit_results.items():
+        fluxes = np.asarray(
+            [result.flux_magnitude for result in results], dtype=float
+        )
+        values = np.asarray([result.mean for result in results], dtype=float)
+        errors = np.asarray([result.error for result in results], dtype=float)
+        per_length_fits[length] = weighted_linear_fit(
+            fluxes**2 / length, values, errors
+        )
+    stiffness_coefficients = np.asarray(
+        [-fit.slope for fit in per_length_fits.values()], dtype=float
+    )
+    stiffness_errors = np.asarray(
+        [fit.slope_error for fit in per_length_fits.values()], dtype=float
+    )
+    checks.check(
+        np.all(stiffness_coefficients > 0.0)
+        and np.all(stiffness_coefficients > 3.0 * stiffness_errors),
+        "each volume independently resolves a positive quadratic topological-flux stiffness",
+    )
+    checks.check(
+        np.ptp(stiffness_coefficients) / np.mean(stiffness_coefficients) < 0.5,
+        "the Phi-squared-over-L coefficient remains finite and size-stable across four volumes",
+    )
+
+    lengths = []
+    fluxes = []
+    values = []
+    errors = []
+    for length, results in orbit_results.items():
+        for result in results:
+            lengths.append(float(length))
+            fluxes.append(float(result.flux_magnitude))
+            values.append(result.mean)
+            errors.append(result.error)
+    length_array = np.asarray(lengths)
+    flux_array = np.asarray(fluxes)
+    value_array = np.asarray(values)
+    error_array = np.asarray(errors)
+    predictor = flux_array**2 / length_array
+    weighted_slope, weighted_slope_error, weighted_rms = weighted_common_slope(
+        length_array, predictor, value_array, error_array
+    )
+    quadratic_slope, quadratic_rss = common_slope_rss(
+        length_array, predictor, value_array
+    )
+    controls = {
+        "Phi": common_slope_rss(length_array, flux_array, value_array)[1],
+        "Phi/L": common_slope_rss(
+            length_array, flux_array / length_array, value_array
+        )[1],
+        "Phi^2": common_slope_rss(
+            length_array, flux_array**2, value_array
+        )[1],
+        "sector_step": common_slope_rss(
+            length_array, (flux_array > 0).astype(float), value_array
+        )[1],
+    }
+    checks.check(
+        quadratic_slope < 0.0
+        and quadratic_rss < 0.75 * min(controls.values()),
+        "the common Phi-squared-over-L law beats linear, unscaled-quadratic, and sector-step controls",
+    )
+
+    collapse_stiffness = -quadratic_slope
+    weighted_stiffness = -weighted_slope
+    common_stiffness_spread = float(np.ptp(stiffness_coefficients))
+    relative_stiffness_spread = float(
+        common_stiffness_spread / np.mean(stiffness_coefficients)
+    )
+    checks.check(
+        collapse_stiffness > 0.0
+        and relative_stiffness_spread < 0.5
+        and weighted_stiffness > 5.0 * weighted_slope_error
+        and abs(weighted_stiffness - collapse_stiffness) / weighted_stiffness
+        < 0.25,
+        "the fitted first-order energy gives a positive electric coefficient U/abs(delta V)=2c",
+    )
+
+    maximum_flux_density = max(
+        result.flux_magnitude / result.length**2
+        for results in orbit_results.values()
+        for result in results
+    )
+    terminal_flux_density = [
+        results[-1].flux_magnitude / length**2
+        for length, results in orbit_results.items()
+    ]
+    checks.check(
+        maximum_flux_density <= 1.0 / 12.0
+        and all(
+            terminal_flux_density[index + 1] < terminal_flux_density[index]
+            for index in range(len(terminal_flux_density) - 1)
+        ),
+        "the fitted flux window becomes a shrinking field-density probe under volume refinement",
+    )
+
+    maximum_normalized_chain_spread = max(
+        result.chain_spread / (result.error * np.sqrt(result.chain_count))
+        for results in orbit_results.values()
+        for result in results
+        if result.flux_magnitude > 0
+    )
+    checks.check(
+        maximum_normalized_chain_spread < 4.0,
+        "signed-axis means agree within four single-chain standard errors at every nonzero flux",
+    )
+
+    print(
+        "diagnostic exact graph:",
+        f"states={len(states)}",
+        f"components={len(components)}",
+        f"mobile={len(mobile_components)}",
+        f"zero_mean={zero_mobile[0].mean_flippability:.8f}",
+        f"unit_mean={unit_flux[0].mean_flippability:.8f}",
+        f"unit_cost={44.0 / 29.0:.8f}",
+    )
+    for length, results in orbit_results.items():
+        print(
+            f"diagnostic L={length} orbit means:",
+            " ".join(
+                f"Phi={result.flux_magnitude}:{result.mean:.5f}"
+                f"+/-{result.error:.5f}"
+                f"[spread={result.chain_spread:.5f}]"
+                for result in results
+            ),
+        )
+        fit = per_length_fits[length]
+        print(
+            f"diagnostic L={length} stiffness:",
+            f"c={-fit.slope:.6f}",
+            f"error={fit.slope_error:.6f}",
+            f"rms={fit.rms:.6f}",
+        )
+    print(
+        "diagnostic common scaling:",
+        f"c={weighted_stiffness:.6f}+/-{weighted_slope_error:.6f}",
+        f"unweighted_c={collapse_stiffness:.6f}",
+        f"weighted_rms={weighted_rms:.6f}",
+        f"relative_c_spread={relative_stiffness_spread:.6f}",
+        f"U/abs(deltaV)={2.0 * weighted_stiffness:.6f}",
+        f"rss={quadratic_rss:.6f}",
+        "controls=" + ",".join(
+            f"{name}:{value:.6f}" for name, value in controls.items()
+        ),
+        f"max_normalized_chain_spread={maximum_normalized_chain_spread:.6f}",
+    )
+    print(
+        "per_element: each noncontractible alternating loop and each local plaquette move are checked"
+    )
+    print(
+        "per_site: exact three-of-six Gauss charge is preserved in every signed-flux chain"
+    )
+    print(
+        "per_mode: electric topological flux has positive quadratic stiffness in the Maxwell normalization"
+    )
+    print(
+        "per_block: all 9600 L=2 states and signed-axis Monte Carlo orbits on L=6 through L=12 are checked"
+    )
+    print(
+        "lattice_wide: finite-volume electric stiffness is resolved; a thermodynamic phase proof is not executed"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- exhaust all 9600 L=2 ice states into 937 reversible topological-flux components
- prove the zero-flux mobile component is uniquely most flippable and derive the exact sixfold unit-flux cost 44/29
- run 120 signed-axis, shifted-initialization chains on L=6,8,10,12
- resolve a positive first-order electric stiffness at every volume
- obtain a common weighted coefficient c=1.591937 +/- 0.077393, hence U/abs(delta V)=3.183873 +/- 0.154786
- show the Phi-squared-over-L law beats linear, unscaled-quadratic, and sector-step controls

## Verification

- runner: TOTAL: PASS=11 FAIL=0
- identity-pinned cache: fresh and reproducible
- staged claim typing: pass
- repository invariants: pass, zero link violations
- strict audit lint: zero errors
- vocabulary lint: zero violations

## Boundary

This is a bounded finite-volume, first-order stiffness theorem. It does not claim a uniform finite-delta-V thermodynamic phase, a direct many-body photon spectrum, a physical-site compiler, or any axiom or audit-status change.