### PR TITLE
feat(law): the role pattern is a next-nearest-neighbour rule over roles, not records

### DIFF
--- a/docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,329 @@
+---
+claim_id: the_superlattice_role_pattern_is_a_next_nearest_neighbour_support_rule_over_roles_and_roles_are_not_record_values_bounded_theorem_note_2026-09-04
+claim_type: bounded_theorem
+claim_scope: "Exact and finite, over the five tori 4x2x2, 4x4x4, 8x4x4, 5x4x4 and 7x4x4 only. The superlattice role pattern of PR #7834 is read as a symbol configuration over the 5-symbol role alphabet {C0, C1, E, F, Q}; the minimal covariant support rule realised by the pattern on a rotation-closed offset set is the rule whose menu at each realised profile is exactly the set of roles the pattern puts there and is empty elsewhere. Over that alphabet the pattern realises 18 (role, profile) pairs, 17 profiles of 5^6, 6 rotation orbits of 800, and the rotation closure of one axis orientation's realised set equals the union over the three orientations. The nearest-neighbour role rule admits 8 x 2^{#corners} configurations -- 32, 2,048 and 524,288 on the three commensurate tori against 48 sectors -- and 0 on the two incommensurate ones; NN together with {+-2 e_d}, 12 offsets of the 5x5x5 window's 124, admits exactly the 48 sectors on 4x4x4 and 8x4x4 as a set equality and 0 on the incommensurate tori, while NN with {+-3 e_d} and NN with {(+-1,+-1,0)} do not pin; the corner pin field is free under NN, laminar under NN with {(+-1,+-1,0)} (8 x 20 = 160 on 8x4x4) and striped under NN with {+-2 e_d} (8 x 6 = 48). Over the binary record alphabet a complete solver-free enumeration on the 4x2x2 torus and, where pysat is present, CaDiCaL on the 4x4x4 torus both place configurations outside every sector cylinder for the star, NN with {+-2 e}, L1<=2 and 3x3x3 windows and none for 5x5x5; all 128 binary star patterns are realised; the centre role is a function of the window's record values only at L-infinity radius 2. The pattern exercises 6 of 800 covariant nearest-neighbour role-table orbit entries completely and 61 of 2,226 partially. The separation counts of the parent's minimality criterion are not reproduced here and are excluded; nothing above rests on them. No physical law is selected."
+upstream_dependencies:
+  - minimal_axioms
+  - extensional_nearest_neighbor_rule_deep_probe_2026-07-13
+  - admissibility_covariant_q8_conditional_law_pair_bounded_theorem_note_2026-08-13
+runner: scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py
+registry_id: role_pattern_next_nearest_neighbour_rule_roles_not_record_values
+---
+
+# The superlattice role pattern is a next-nearest-neighbour support rule over roles, and roles are not record values
+
+**Date:** 2026-09-04
+
+**Type:** bounded_theorem
+
+**Audit:** unset; independent audit remains a separate lane
+
+**Status:** proposed_retained
+
+**Status authority:** independent audit only. This source changes no axiom,
+primitive, framework rule, or audit verdict.
+
+**Primary runner:**
+[`scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py`](../scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py)
+
+**Runner cache:**
+[`logs/runner-cache/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.txt`](../logs/runner-cache/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.txt)
+
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md),
+[`EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md`](EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md),
+[`ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md`](ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md)
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Every count is an exact enumeration over a named finite torus, with the sector comparisons carried out as set equalities rather than cardinalities. The record-level rows are decided completely and without a solver on the 4x2x2 torus and, where pysat is present, again by CaDiCaL on the 4x4x4 torus. The minimality statement is over rotation-closed offset sets containing the nearest neighbours and lying inside the 5x5x5 window. No physical law is selected and no lattice beyond the five named tori is claimed."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Ask whether a record-native encoding of the role labels exists at one bit per site; then whether the sector choice can be posed as a past hypothesis rather than a supplied datum."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Setting
+
+PR #7834 puts a fermion on `Z^3` at one qubit per site by declaring a **superlattice role pattern**: a site's **role** is
+its coordinate parity -- all coordinates even is a *corner*, one odd a coarse *edge* site, two odd a *face*, three odd a
+*cube centre* -- and a repeating arrangement of pinned values with period `(4, 2, 2)` along a chosen axis pins a corner to
+`(s[ax] / 2) mod 2`, a face to `0`, a cube centre to `1`, and leaves every edge site free as a live qubit: `16` translates
+for each of `3` axis orientations, `48` **sectors**. Its Theorem 2 selects that pattern exactly, by a marker rule read on a
+`5x5x5` window, and reports the window minimal; its Theorem 3 reports that a rule reading only the *values* in a seven-site
+star is vacuous there. PR #7934 established, on the `3^3` torus, that the partial-configuration readout is injective on the
+covariant support tables: which law holds is a matter of what the records show. This note bounds the reach of that result.
+**Is the designed matter law a nearest-neighbour support rule, and is it readable from records?** Records register; the
+lattice is physical; the pattern is an arrangement of pinned values on the plain cubic lattice, not a new lattice.
+
+## Supplied surface (quoted)
+
+Lattice, Qubit and Admissibility, current landed wording (`docs/MINIMAL_AXIOMS_2026-06-29.md`), with reading note (3) fixing
+the sense of "admissible":
+
+> "Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor adjacency, standard translations, and proper cubic rotations about each site."
+
+> "Each site has a domain of local possibilities. The full one-site possibility domain has algebraic presentation `M_2(C)`."
+
+> "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations."
+
+> "The distribution is a probability measure on the local possibility domain; 'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability."
+
+`M_2(C)` names two local possibilities: **one bit of record per site**. That is the whole of the tension this note quantifies.
+
+## T1 -- the role census (exact)
+
+Encode the pattern over the `5`-symbol role alphabet `{C0, C1, E, F, Q}`: a corner showing `0` or `1`, an edge site whatever
+its qubit says, a face, a cube centre. The **minimal covariant support rule** on a rotation-closed offset set `N` gives each
+profile the pattern realises exactly the roles the pattern puts at its centre, and every other profile the empty menu -- the
+strongest rule the pattern permits.
+
+```text
+realised (role, profile) pairs, one axis orientation closed under 24 rotations = 18
+union over the three axis orientations of the raw realised pairs               = 18  (the same set)
+distinct realised profiles                                                     = 17  of 5^6 = 15,625
+rotation orbits realised                                                       =  6  of 800
+```
+
+The third line is the covariance statement: closing one orientation's realised set under the proper cubic rotations gives
+**exactly** the union over the three orientations, so "one covariant rule" and "`48` sectors" are the same object, as PR
+#7834 has them. The `17` rows are one corner row, `12` edge rows (four corner-pin pairs on each of three axes), three face
+rows and one cube-centre row.
+
+Two things this encoding does, both load-bearing below. It **refines** the record value -- separating a corner showing `0`
+from a face showing `0`, which no record does -- and it **forgets** the free edge bits entirely: every edge site is `E`
+whatever its qubit says, and the fermion lives in exactly the part the role alphabet drops.
+
+## T2 -- the nearest-neighbour role table does not pin the pattern (exact counts)
+
+```text
+T(E E E E E E)      = {C0, C1}      every corner has this profile, so the menu holds both
+T(C_a C_b F F F F)  = {E}           all four (a,b) in {0,1}^2, on each of three axes
+T(E E Q Q E E)      = {F}           faces;    T(F F F F F F) = {Q}   cube centres
+coarse (skeleton) pairs                                            = 8
+refinements of a realised coarse pair that are NOT realised        = 0
+```
+
+Every corner carries the same profile `E E E E E E`, so the table must admit both `C0` and `C1` there; every edge site
+realises all four corner-pin pairs on its axis; and no refinement of a realised coarse pair is unrealised. The
+nearest-neighbour table therefore constrains the corner pin bit not at all. It pins the period-`(2,2,2)` **parity skeleton**
+exactly -- `8` translates, nothing else -- and leaves the pin field free:
+
+```text
+torus      NN admits          = 8 x 2^{#corners}     sectors
+4x2x2             32          = 8 x 2^2                   16
+4x4x4          2,048          = 8 x 2^8                   48
+8x4x4        524,288          = 8 x 2^16                  48
+5x4x4              0                                       0
+7x4x4              0                                       0
+```
+
+The `(4,2,2)` period is carried entirely by the corner pin field; the role structure itself is only `(2,2,2)`. A
+nearest-neighbour window holds at most two corners, never two on two different axes -- precisely what a covariant rule would
+need in order to say that the alternation runs along one axis and one axis only. On the incommensurate tori every branch
+closes at `NN` already, so the frustration PR #7834 reports at `5x5x5` is a property of the `(2,2,2)` skeleton and needs no
+range at all.
+
+## T3 -- the minimal pinning neighbourhood is next-nearest-neighbour (exact)
+
+Among rotation orbits of offsets inside the `5x5x5` window the only ones of size `6` are `{+-e_d}` and `{+-2 e_d}`, so the
+only rotation-closed offset set containing `NN` with at most `12` offsets and lying inside that window is `NN` together with
+`{+-2 e_d}`: **`12` offsets of the window's `124`**.
+
+```text
+neighbourhood                4x2x2     4x4x4      8x4x4    5x4x4   7x4x4   pins?
+NN (6)                          32     2,048    524,288        0       0   no
+NN with {+-3 e_d} (12)          32     2,048      2,048        0       0   no
+NN with {(+-1,+-1,0)} (18)      32        64        160        0       0   no
+NN with {+-2 e_d} (12)          16        48         48        0       0   YES
+NN with {(+-1,+-1,+-1)} (14)    16        48         48        0       0   yes
+L1<=2 (24) / 3x3x3 (26) / 5x5x5 (124)   as the sectors on all three commensurate tori
+```
+
+Every `YES`/`yes` row was compared with the sector set **as a set**, not by cardinality. `NN` with `{+-2 e_d}` therefore
+admits exactly the `48` sectors on `4x4x4` and on `8x4x4`, exactly the `16` the `4x2x2` torus holds, and nothing at all on
+`5x4x4` and `7x4x4`.
+
+**What the extra configurations are.** On `8x4x4` the corner sublattice is a `4x2x2` grid carrying a binary pin field, and
+the ladder is a clean three-step chain:
+
+```text
+all binary pin fields                                        2^16 = 65,536   NN admits every one   (8 x 65,536 = 524,288)
+laminar: constant on the planes normal to one coarse axis            20      NN with {(+-1,+-1,0)} admits exactly these (8 x 20 = 160)
+striped: alternating with period 2 along one axis                     6      NN with {+-2 e_d}     admits exactly these (8 x  6 =  48)
+```
+
+Nearest neighbours are load-bearing for the skeleton and the `+-2` offsets for the pin field; neither alone suffices, the
+`+-2` offsets lying inside `2Z^3`, whose constraint graph has eight parity components.
+
+## T4 -- over the record alphabet (complete on 4x2x2; SAT on 4x4x4)
+
+A role is not a record value. Building the minimal covariant support rule for a window `W` over **binary records** -- a
+site's value pattern on `W` must match one of the `48` templates, the free edge bits wild -- and asking for a configuration
+admissible under it and outside every sector cylinder:
+
+```text
+window                  star (7)   NN with {+-2 e} (13)   L1<=2 (25)   3x3x3 (27)   5x5x5 (125)
+4x2x2, complete count   64,512     13,981                 186          154          0
+   of admissible configurations lying outside every sector cylinder; at 5x5x5 all 1,024 = 16 x 2^6 lie inside one
+4x4x4, CaDiCaL          SAT        SAT                    SAT          SAT          UNSAT
+```
+
+The `4x2x2` row is a complete enumeration over all `2^16` binary configurations carrying no solver; the `4x4x4` row is
+CaDiCaL over `64` value variables and `3,072` template indicators, and runs where pysat is present. Only the `5x5x5` window
+pins, confirming PR #7834's Theorem 2 by a method that note does not use. The `12`-offset role rule of T3 does **not**
+transfer: the same offsets over binary values admit configurations outside every cylinder. What buys it its economy is the
+alphabet, not the geometry.
+
+Two further record-level facts complete the picture.
+
+```text
+binary 7-site star patterns realised over all 48 sectors and all free edge bits = 128 of 128
+the centre role is a function of the window's record values:  star no   NN with {+-2 e} no
+                                                              L1<=2 no   3x3x3 no   5x5x5 yes
+```
+
+The first reproduces PR #7834's Theorem 3 item 2: the minimal covariant nearest-neighbour table over records is the
+all-permissive one. The second says a role is recovered from records only at `L`-infinity radius `2`, with the failures
+explicit -- at the star and at `NN` with `{+-2 e}` a corner is mistakable for an edge site, at `L1<=2` an edge site for a
+cube centre, at `3x3x3` a corner for a face.
+
+**The cost of the alphabet.** Five role symbols is three bits per site; the Qubit axiom's `M_2(C)` gives one. So a
+nearest-neighbour rule *over roles* is a **radius-3** rule *over records* and the `12`-offset rule a radius-4 one: both
+wider than a nearest-neighbour rule, the first still narrower than the radius-2 marker window whose minimality over records
+is confirmed independently above. Roles are a *derived* label, a radius-2 function of the records.
+
+## T5 -- readability, and what the designed law is made of (exact)
+
+Applying the partial-configuration readout of PR #7934 to the role rule, with unrecorded sites reading as open:
+
+```text
+rotation-orbit table entries the complete pattern exercises      =  6 of 800
+(role, profile) pairs realisable from sub-configurations         = 794
+partial profiles realised                                        = 655 of 6^6 = 46,656
+partial rotation-orbit table entries realised                    = 61 of 2,226 = 2.74 %
+```
+
+For each such entry the records show only that the menu *contains* the realised role, never that it excludes anything. The
+other `2,165` entries are unexercised: the pattern never puts a site in that profile. This is a categorically weaker readout
+than PR #7934's, and the difference is the crux. There the reader may place records anywhere; here the record configuration
+is not free -- it is the pattern, up to `48` sectors and the free edge bits. **A law whose ground state is a single rigid
+arrangement makes almost all of itself unreadable by that arrangement.** The `48`-fold degeneracy does not help: the sectors
+are rotations and translates of one another, exercising the same entries.
+
+The designed matter law is three things, and only the first is a support rule at all.
+
+| part | what it is | how the readability result reaches it |
+|---|---|---|
+| the **role support rule** | a covariant support rule whose admissible set is exactly the `48` sectors: `12` offsets over roles, `L`-infinity radius `2` over records. Not nearest-neighbour in either alphabet. | Through its exercised part only -- `6` of `800` entries completely, `61` of `2,226` partially. |
+| the **sector choice** | which of the `48` the record background is: four bits of phase together with one of three axis orientations, fixed once, globally. Past-hypothesis-shaped. | Not at all. The rule cannot pick it; the `48` are exactly degenerate. |
+| `S_f`, `B_v`, `T_ij` | the encoding's face stabilizers, corner parities and hops -- the fermion itself, acting on the free edge qubits the role alphabet drops. | Not at all, and not by degree: these are Hamiltonian terms, not a support table. |
+
+**The third row is a category error, and it should be written down as one.** PR #7934 established that the
+partial-configuration readout determines a covariant nearest-neighbour *support table*: a predicate on records, saying which
+local value is admissible given the neighbours. `T_ij = (i/2) A_ij (B_i - B_j)` is not such a predicate; it partitions
+nothing into admissible and inadmissible. Applying "records determine the law" to the Hamiltonian terms is not a weak
+inference, it is an inference about the wrong kind of object.
+
+## Corollary
+
+1. **The superlattice role pattern is pinned by a next-nearest-neighbour support rule over roles**, `12` offsets,
+   and by no nearest-neighbour rule: the nearest-neighbour role table admits `8 x 2^{#corners}` configurations --
+   `524,288` on `8x4x4` where `48` were wanted.
+2. **Roles are not record values.** A role needs three bits where the Qubit axiom gives one, and is recovered from
+   records only at radius `2`; so over records the rule has radius `3`, wider than a nearest-neighbour rule and
+   narrower than the `5x5x5` marker window, whose minimality over records is confirmed here independently.
+3. **The designed law is three things**: a next-nearest-neighbour role rule -- Admissibility's kind, but not
+   nearest-neighbour -- a supplied four-bit sector choice, and a supplied Hamiltonian, to which the readability
+   result does not apply.
+4. **The role law is almost entirely unexercised by the arrangement it produces**: `2.74 %` of the covariant table,
+   so it cannot be read off its own ground state.
+5. Hence **"records determine the law" reaches the designed matter law only through its support-rule part, and only
+   where the records exercise it.**
+
+## Reading, not theorem
+
+The arrangement that makes the particle is held in place by a rule that looks two sites away, not one, and the labels it
+uses cost three bits where the lattice gives one. So the particle's law is not a neighbour rule of the kind the axioms name,
+and most of it is never exercised by the arrangement itself, so records cannot read it from the vacuum. What the readability
+result reaches is the rule's support part; the particle's dynamics is a different kind of object, and the campaign's result
+says nothing about it.
+
+## Interfaces
+
+- **A record-native role encoding.** Whether the four role classes can be carried at one bit per site, by a
+  construction that does not smuggle in a second bit, is untouched here.
+- **The sector choice as a past hypothesis.** Whether a globally fixed choice among exactly degenerate sectors is a
+  boundary condition, a symmetry-breaking event or an initial record is decided by nothing computed here.
+- **The marker window's reduction.** The `12`-offset role rule shows the `5x5x5` marker rule doing two separable
+  jobs, a nearest-neighbour one and a `+-2` one; a matching record-level factorisation is open.
+
+## Executable claim block
+
+```text
+registry_id: role_pattern_next_nearest_neighbour_rule_roles_not_record_values
+role_alphabet_and_realised_pairs_profiles_orbits: 5 / 18 / 17 / 6 of 800
+covariance_closure_equals_three_orientation_union: true
+nn_admissible_4x2x2_4x4x4_8x4x4: 32 / 2048 / 524288
+nn_admissible_incommensurate_5x4x4_7x4x4: 0 / 0
+sectors_4x2x2_4x4x4_8x4x4: 16 / 48 / 48
+minimal_pinning_offsets_and_window: 12 of 124
+nn_ax2_admissible_4x4x4_8x4x4_set_equality: 48 / 48 / true
+failing_siblings_ax3_and_diag2_on_8x4x4: 2048 / 160
+pin_field_families_all_laminar_striped: 65536 / 20 / 6
+record_windows_outside_cylinders_4x2x2: 64512 / 13981 / 186 / 154 / 0
+record_windows_4x4x4_cadical: SAT / SAT / SAT / SAT / UNSAT
+binary_star_patterns_realised: 128 of 128
+role_determined_by_records_at_radius: 2
+role_bits_against_qubit_axiom_bits: 3 / 1
+nn_role_rule_record_radius: 3
+readability_complete_and_partial_orbits: 6 of 800 / 61 of 2226
+readability_fraction: 2.74 per cent
+separation_counts_of_the_parent_criterion: not reproduced here and excluded
+no_physical_law_is_selected: true
+```
+
+## Proof boundary
+
+The theorem is the finite classification above and nothing wider.
+
+- **Five named tori, periodic, no open blocks.** `4x2x2`, `4x4x4`, `8x4x4`, `5x4x4`, `7x4x4`. The `4x2x2` torus is
+  degenerate -- `+d` and `-d` are the same site in the size-`2` directions -- and carries weight only as the box on
+  which the record-level enumeration is complete. The commensurate comparisons are set equalities on PR #7834's own
+  two boxes.
+- **The record-level rows.** Complete and solver-free on `4x2x2`, over all `2^16` binary configurations. On `4x4x4`
+  they are decided by CaDiCaL where pysat is present, and are not run otherwise; the runner prints which path ran.
+- **Minimality, stated in its class.** `12` is minimal among rotation-closed offset sets that contain the nearest
+  neighbours and lie inside the `5x5x5` window. It is not a claim about arbitrary local rules, nor about offset sets
+  reaching outside that window -- `NN` with `{+-3 e_d}` is the exhibited failure just outside it.
+- **The parent's separation criterion is excluded.** A reconstruction of PR #7834's unseparated-pair counts at the
+  star and `3x3x3` windows does not reproduce its `29` and `2`; those rows are **not reproduced here and are
+  excluded** from every statement above, and nothing here rests on them. The `5x5x5` minimality is established
+  instead by the record-level enumeration and SAT of T4, which use no separation criterion, and T4's radius-`2`
+  role recovery is a directly computed functional determination.
+- **Supports, not distributions.** Every statement is about supports, in the sense reading note (3) fixes. The
+  distribution-valued lift is untouched. No sampling, no seed and no random number generator is used anywhere; no
+  premise is edited, no axiom is added, and **no physical law is selected**.
+
+## Honest-auditor read
+
+The load-bearing objects are, in order: the set equality of T3 -- that `NN` with `{+-2 e_d}` admits the sector set itself, not merely
+`48` things; the `0` unrealised refinements of T2, the single line that makes the nearest-neighbour table blind to the corner pin
+bit; and the `5x5x5` `UNSAT` of T4. Attack them in that order. The first two are complete enumerations with small witnesses and the
+easiest to re-run. The third has the strongest support here, decided twice by different methods on different boxes -- a complete
+solver-free enumeration on `4x2x2` and CaDiCaL on `4x4x4` -- and agreeing with a parent result reached by a third method. The weakest
+rows are T3's minimality, which holds only in the class named above, and the `4x4x4` SAT rows, which need the solver. The claim most
+likely to be over-read is T5's: `2.74 %` says what one arrangement exercises, not what any record configuration could.
+
+## Review record
+
+This note bounds the reach of an earlier readability result on one designed law and proposes no law of its own. Hard landing
+conditions are a fresh runner and cache pair, a current citation-manifest entry, and passing pipeline, strict-lint and
+changed-evidence gates; independent audit remains a separate lane.

--- a/logs/runner-cache/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.txt
+++ b/logs/runner-cache/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.txt
@@ -1,0 +1,97 @@
+===== runner cache v1 =====
+runner: scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py
+runner_sha256: 39649b8601da8ac88b96fc3d94dc44a720e48b590af17be031b60879c9966155
+input_fingerprint_sha256: 34d922565079200c0cc1ff263d4234efa81d03ef139cb4b111faddc6447550ce
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 11.34
+status: ok
+----- stdout -----
+external_scientific_inputs: none; every number is recomputed here
+integrity_reads: axioms, deep probe, law pair, this note
+construction: exact enumeration over roles and over binary records
+negative_scope: finite non-pinning statements on the named tori
+AUDIT_INPUT_PATHS:
+  docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_2026-09-04.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+  docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md
+  docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_BOUNDED_THEOREM_NOTE_2026-08-13.md
+AUDIT_TIMEOUT_SEC: 300
+cache_write: false
+scientific_dependency: minimal_axioms Lattice, Qubit, Admissibility
+declared_math: cubic rotations, role subshifts, binary record windows
+solver_mode: pysat present; CaDiCaL on the 4x4x4 torus, and the complete solver-free enumeration on the 4x2x2 torus
+PASS: audit-input-paths declared inputs exist and are unique
+PASS: audit-timeout the declared timeout is 300 seconds
+PASS: axiom-lattice nearest-neighbor adjacency is quoted
+PASS: axiom-admissibility the one fixed nearest-neighbor rule is quoted
+PASS: axiom-qubit the M_2(C) presentation is quoted
+PASS: axiom-support admissible read as the support
+PASS: parent-deep-probe the deep probe is live
+PASS: parent-law-pair the 2026-08-13 law pair is live
+PASS: T1-pairs the pattern realises 18 (role, profile) pairs
+PASS: T1-profiles 17 profiles of the 5^6 = 15625
+PASS: T1-orbits 6 rotation orbits of 800
+PASS: T1-covariance one covariant rule = 48 sectors
+PASS: T1-table the table has 17 nonempty rows
+PASS: T2-corner-profile every corner carries EEEEEE
+PASS: T2-corner-menu so its menu holds C0 and C1
+PASS: T2-edge-pins edges realise all 4 corner-pin pairs
+PASS: T2-refinements 0 refinements unrealised
+ladder  torus        NN   NN+AX3  NN+DIAG2   NN+AX2  NN+BODY    L1<=2    3x3x3    5x5x5  sectors
+        4x2x2        32       32       32       16       16       16       16       16       16
+        4x4x4      2048     2048       64       48       48       48       48       48       48
+        8x4x4    524288     2048      160       48       48       48       48       48       48
+        5x4x4         0        0        0        0        0        0        0        0        0
+        7x4x4         0        0        0        0        0        0        0        0        0
+PASS: T2-nn-counts NN admits 8 x 2^corners: 32, 2048, 524288
+PASS: T2-skeleton NN pins the (2,2,2) skeleton, 8 of it
+PASS: T2-incommensurate 0 on 5x4x4 and 7x4x4, at every rung
+PASS: T2-sectors against 16, 48 and 48 sectors
+PASS: T3-pins-4x4x4 NN+{+-2e} = the 48 sectors on 4x4x4, as a set
+PASS: T3-pins-8x4x4 and the 48 sectors on 8x4x4, as a set
+PASS: T3-pins-4x2x2 and the 16 sectors 4x2x2 holds
+PASS: T3-pins-incommensurate and 0 on 5x4x4 and 7x4x4
+PASS: T3-ax3-fails NN+{+-3e} admits 2048 on 4x4x4 and 8x4x4
+PASS: T3-diag-fails NN+diag admits 64 on 4x4x4, 160 on 8x4x4
+PASS: T3-minimal-orbits size-6 orbits in 5x5x5: {+-e}, {+-2e} only
+PASS: T3-twelve-of-124 so the support is 12 of the window's 124
+PASS: T3-nesting nested rungs contain what they refine
+PASS: T3-upper-rungs L1<=2, 3x3x3, 5x5x5, body give the sector set
+PASS: T3-defect-free NN admits every pin field: 2^16 = 65536
+PASS: T3-defect-laminar NN+diag admits the laminar fields, 8 x 20
+PASS: T3-defect-striped NN+{+-2e} admits the striped fields, 8 x 6
+records 4x2x2 complete enumeration (no solver): NN=64512  NN+AX2=13981  L1<=2=186  3x3x3=154  5x5x5=0  outside all cylinders
+PASS: T4-enum-small 4x2x2: the four smaller windows leave cylinder-free rows
+PASS: T4-enum-5x5x5 4x2x2: 5x5x5 leaves none, 1024 = 16 x 2^6
+records 4x4x4 CaDiCaL: NN=SAT  NN+AX2=SAT  L1<=2=SAT  3x3x3=SAT  5x5x5=UNSAT
+PASS: T4-sat-small 4x4x4: star, NN+{+-2e}, L1<=2, 3x3x3 all SAT
+PASS: T4-sat-5x5x5 only 5x5x5 UNSAT: Theorem 2 confirmed
+PASS: T4-star-census all 128 binary stars realised
+role from records: NN=no  NN+AX2=no  L1<=2=no  3x3x3=no  5x5x5=yes
+PASS: T4-role-radius a role is read from records only at radius 2
+PASS: T4-role-bits a role costs 3 bits where M_2(C) gives one
+PASS: T4-record-radius so a NN role rule is a radius-3 record rule
+readability: complete 6/800   partial 61/2226 = 2.7403%
+PASS: T5-complete 6 of 800 orbit entries exercised complete
+PASS: T5-partial 61 of 2226 partially, from 794 pairs
+PASS: T5-fraction 2.74 per cent of the role law exercised
+PASS: T5-decomposition the note separates the law's three parts
+PASS: T5-category-error readability misses the Hamiltonian terms
+PASS: note-length the note stays under 330 lines
+PASS: note-registry-id the note declares its registry id
+PASS: note-vocabulary the note avoids the banned vocabulary
+PASS: note-wording and says superlattice role pattern
+PASS: note-scope no law selected; bounded scope stated
+PASS: note-exclusion the unreconciled counts are excluded
+PASS: note-parents the note names both parent sources
+PASS: note-numbers the note carries its counts
+per_element: 5 role symbols, 17 profiles, 800 orbits
+per_site: every site of every named torus, at every rung
+per_mode: checked and not executed - no spectral decomposition here
+per_block: 48 sectors, 8 skeletons, 12 pinning offsets of 124
+lattice_wide: five named tori; the record rows complete on 4x2x2
+TOTAL: PASS=55 FAIL=0
+
+----- stderr -----
+

--- a/scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py
+++ b/scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py
@@ -1,0 +1,904 @@
+#!/usr/bin/env python3
+"""Exact checks: the superlattice role pattern is a next-nearest-neighbour
+support rule over roles, and roles are not record values.
+
+The runner recomputes, with no sampling, no seed and no random number
+generator:
+
+T1  the role census of the period-(4,2,2) pattern over the 5-symbol role
+    alphabet {C0, C1, E, F, Q} -- 18 (role, profile) pairs, 17 distinct
+    profiles of 5^6, 6 rotation orbits of 800 -- and the covariance identity
+    that makes "one covariant rule" and "48 sectors" the same object;
+T2  that the nearest-neighbour role table does not pin the pattern: every
+    corner carries profile EEEEEE, every edge site realises all four
+    corner-pin pairs on its axis, and the admissible set is 8 x 2^{#corners}
+    on every commensurate torus and empty on the incommensurate ones;
+T3  the minimal rotation-closed pinning neighbourhood containing NN --
+    NN united with {+-2 e_d}, 12 offsets of the 5x5x5 window's 124 -- as a
+    set equality with the 48 sectors, its two failing siblings, and the
+    three-step defect chain over the corner pin field;
+T4  the record-level statements: a complete solver-free enumeration on the
+    4x2x2 torus and, where pysat is present, SAT on the 4x4x4 torus, both
+    finding configurations outside every sector cylinder for the star,
+    NN united with {+-2 e}, L1<=2 and 3x3x3 windows and none for 5x5x5;
+    all 128 binary star patterns realised; and the role recovered from
+    records only at L-infinity radius 2;
+T5  readability -- 6 of 800 covariant NN role-table orbit entries exercised
+    completely and 61 of 2226 partially -- and the three-part decomposition
+    of the designed matter law.
+
+Records register; the lattice is physical. No physical law is selected and no
+lattice beyond the named tori is claimed.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 300
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_"
+    "RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_"
+    "2026-09-04.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+PROBE_REL = "docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md"
+Q8_REL = (
+    "docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_"
+    "RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_"
+    "2026-09-04.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md",
+    "docs/ADMISSIBILITY_COVARIANT_Q8_CONDITIONAL_LAW_PAIR_"
+    "BOUNDED_THEOREM_NOTE_2026-08-13.md",
+)
+
+assert AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL, PROBE_REL, Q8_REL)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+PROBE_PATH = ROOT / PROBE_REL
+Q8_PATH = ROOT / Q8_REL
+
+CELL_CAP = 16_000_000          # no dense array above 4096 x 4096 entries
+CODE_CAP = 19                  # base-5 window code stays inside int64
+
+# ---- role alphabet ---------------------------------------------------------
+C0, C1, E, F, Q = 0, 1, 2, 3, 4
+NAME = ("C0", "C1", "E", "F", "Q")
+PROJ = (0, 0, 1, 2, 3)         # C0, C1 -> C : the skeleton alphabet
+OPEN = 5                       # a site carrying no record, in the readout
+TORI = ((4, 2, 2), (4, 4, 4), (8, 4, 4), (5, 4, 4), (7, 4, 4))
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool,
+              residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+# ---- the pattern -----------------------------------------------------------
+def pat_sym(site, ax: int) -> int:
+    """Role of a fine site in the period-(4,2,2) pattern laid along `ax`."""
+    odd = (site[0] & 1) + (site[1] & 1) + (site[2] & 1)
+    if odd == 0:
+        return C0 + ((site[ax] // 2) % 2)     # corner, pinned (s[ax]/2) mod 2
+    if odd == 1:
+        return E                              # coarse edge site: a live qubit
+    if odd == 2:
+        return F                              # face, pinned 0
+    return Q                                  # cube centre, pinned 1
+
+
+def pat_bit(site, ax: int):
+    """Record value at a fine site; None where the pattern pins nothing."""
+    role = pat_sym(site, ax)
+    if role == E:
+        return None
+    return 1 if role in (C1, Q) else 0
+
+
+# ---- proper cubic rotations ------------------------------------------------
+def proper_cubic_rotations():
+    out = []
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((1, -1), repeat=3):
+            m = [[0, 0, 0] for _ in range(3)]
+            for row in range(3):
+                m[row][perm[row]] = signs[row]
+            det = (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                   - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                   + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+            if det == 1:
+                out.append(tuple(tuple(r) for r in m))
+    return tuple(out)
+
+
+ROTATIONS = proper_cubic_rotations()
+
+
+def act(matrix, vec):
+    return tuple(sum(matrix[i][k] * vec[k] for k in range(3)) for i in range(3))
+
+
+def transpose(matrix):
+    return tuple(tuple(matrix[j][i] for j in range(3)) for i in range(3))
+
+
+def axial(radius):
+    return [tuple(sign * radius * e for e in basis)
+            for basis in ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+            for sign in (1, -1)]
+
+
+def orbit(seed):
+    return sorted({act(m, seed) for m in ROTATIONS})
+
+
+def ball(radius, metric):
+    norm = (lambda o: sum(map(abs, o))) if metric == 1 else (lambda o: max(map(abs, o)))
+    return sorted(o for o in itertools.product(range(-radius, radius + 1), repeat=3)
+                  if o != (0, 0, 0) and norm(o) <= radius)
+
+
+NN = sorted(axial(1))
+NBHDS = {
+    "NN": NN,
+    "NN+AX3": sorted(NN + axial(3)),
+    "NN+DIAG2": sorted(NN + orbit((1, 1, 0))),
+    "NN+AX2": sorted(NN + axial(2)),
+    "NN+BODY": sorted(NN + orbit((1, 1, 1))),
+    "L1<=2": ball(2, 1),
+    "3x3x3": ball(1, "inf"),
+    "5x5x5": ball(2, "inf"),
+}
+LADDER = ("NN", "NN+AX3", "NN+DIAG2", "NN+AX2", "NN+BODY", "L1<=2", "3x3x3", "5x5x5")
+WIDE = ("NN", "NN+AX3", "NN+DIAG2", "NN+AX2", "NN+BODY")
+NESTED = (("L1<=2", "NN+AX2"), ("3x3x3", "NN+BODY"), ("5x5x5", "L1<=2"))
+
+
+def rot_maps(support):
+    index = {o: i for i, o in enumerate(support)}
+    return [tuple(index[act(transpose(m), support[i])] for i in range(len(support)))
+            for m in ROTATIONS]
+
+
+def realised(support, ax: int = 0, proj: bool = False):
+    """The (role, profile) pairs the pattern realises, rotation-closed."""
+    maps = rot_maps(support)
+    base = set()
+    for site in itertools.product(range(4), range(2), range(2)):
+        role = pat_sym(site, ax)
+        profile = tuple(pat_sym(tuple(site[k] + o[k] for k in range(3)), ax)
+                        for o in support)
+        base.add((role, profile))
+    out = set()
+    for role, profile in base:
+        for m in maps:
+            out.add((role, tuple(profile[m[i]] for i in range(len(support)))))
+    if proj:
+        out = {(PROJ[r], tuple(PROJ[x] for x in p)) for r, p in out}
+    return out
+
+
+# ---- tori ------------------------------------------------------------------
+def sites(box):
+    return list(itertools.product(range(box[0]), range(box[1]), range(box[2])))
+
+
+def neighbour_table(box, support):
+    index = {s: i for i, s in enumerate(sites(box))}
+    return [[index[tuple((s[k] + o[k]) % box[k] for k in range(3))] for o in support]
+            for s in sites(box)]
+
+
+def sector_roles(box):
+    out = set()
+    for ax in (0, 1, 2):
+        period = [2, 2, 2]
+        period[ax] = 4
+        if any(box[i] % period[i] for i in range(3)):
+            continue
+        for shift in itertools.product(range(4), repeat=3):
+            out.add(tuple(pat_sym(tuple(s[k] + shift[k] for k in range(3)), ax)
+                          for s in sites(box)))
+    return out
+
+
+def enum_skeletons(box, coarse_pairs):
+    """Every skeleton the projected NN rule admits, by pair-propagation DFS."""
+    nb = neighbour_table(box, NN)
+    n = len(nb)
+    pairs = sorted(coarse_pairs)
+    found = []
+
+    def compat(v, role, profile, assign):
+        if assign[v] not in (-1, role):
+            return False
+        return all(assign[nb[v][i]] in (-1, x) for i, x in enumerate(profile))
+
+    def place(v, role, profile, assign):
+        assign[v] = role
+        for i, x in enumerate(profile):
+            assign[nb[v][i]] = x
+
+    def recurse(assign):
+        while True:
+            changed = False
+            for v in range(n):
+                live = [k for k, (r, p) in enumerate(pairs) if compat(v, r, p, assign)]
+                if not live:
+                    return
+                if len(live) == 1:
+                    role, profile = pairs[live[0]]
+                    before = (assign[v], tuple(assign[j] for j in nb[v]))
+                    place(v, role, profile, assign)
+                    if before != (assign[v], tuple(assign[j] for j in nb[v])):
+                        changed = True
+            if not changed:
+                break
+        for v in range(n):
+            if assign[v] == -1 or any(assign[j] == -1 for j in nb[v]):
+                for role, profile in pairs:
+                    if compat(v, role, profile, assign):
+                        branch = assign[:]
+                        place(v, role, profile, branch)
+                        recurse(branch)
+                return
+        found.append(tuple(assign))
+
+    recurse([-1] * n)
+    return sorted(set(found))
+
+
+def expand(skeleton, pins):
+    """Role configurations: one skeleton with every corner-pin assignment."""
+    n = len(skeleton)
+    corner = {v: j for j, v in enumerate(v for v in range(n) if skeleton[v] == 0)}
+    base = np.empty((pins.shape[0], n), dtype=np.int64)
+    for v in range(n):
+        base[:, v] = pins[:, corner[v]] if skeleton[v] == 0 else {1: E, 2: F, 3: Q}[skeleton[v]]
+    return base
+
+
+def window_codes(support, pairs):
+    weight = [5 ** i for i in range(len(support) + 1)]
+    return np.array(sorted({r * weight[0]
+                            + sum(p[i] * weight[i + 1] for i in range(len(support)))
+                            for r, p in pairs}), dtype=np.int64)
+
+
+def sift(base, nb, support, pairs):
+    """Row indices of `base` admissible under the covariant rule on `support`."""
+    allowed = window_codes(support, pairs)
+    weight = np.array([5 ** i for i in range(len(support) + 1)], dtype=np.int64)
+    keep = np.arange(base.shape[0])
+    for v in range(len(nb)):
+        if keep.size == 0:
+            break
+        block = base[keep]
+        code = block[:, v] * weight[0]
+        for i, j in enumerate(nb[v]):
+            code = code + block[:, j] * weight[i + 1]
+        keep = keep[np.isin(code, allowed)]
+    return keep
+
+
+def sift_direct(rows, nb, pairs):
+    """Per-configuration check, for windows too wide for a base-5 code."""
+    out = []
+    for cfg in rows:
+        if all((cfg[v], tuple(cfg[j] for j in nb[v])) in pairs for v in range(len(nb))):
+            out.append(cfg)
+    return out
+
+
+def ladder_counts(box):
+    """Admissible role configurations at every rung, and the sector set."""
+    sectors = sector_roles(box)
+    skeletons = enum_skeletons(box, realised(NN, proj=True))
+    if not skeletons:
+        return {name: (0, []) for name in LADDER}, sectors, skeletons
+    corners = sum(1 for x in skeletons[0] if x == 0)
+    pins = ((np.arange(1 << corners, dtype=np.int64)[:, None]
+             >> np.arange(corners)) & 1).astype(np.int64)
+    bases = [expand(sk, pins) for sk in skeletons]
+    assert bases[0].size <= CELL_CAP
+    out = {}
+    for name in WIDE:
+        support = NBHDS[name]
+        pairs = realised(support)
+        nb = neighbour_table(box, support)
+        total, rows = 0, []
+        for base in bases:
+            keep = sift(base, nb, support, pairs)
+            total += int(keep.size)
+            if total <= 4096:
+                rows.extend(tuple(int(x) for x in r) for r in base[keep])
+        out[name] = (total, rows if total <= 4096 else [])
+    for name, source in NESTED:
+        support = NBHDS[name]
+        nb = neighbour_table(box, support)
+        rows = sift_direct(out[source][1], nb, realised(support))
+        out[name] = (len(rows), rows)
+    return out, sectors, skeletons
+
+
+# ---- the record level ------------------------------------------------------
+def templates():
+    out = []
+    for ax in (0, 1, 2):
+        for shift in itertools.product(range(4), range(2), range(2)):
+            origin = [0, 0, 0]
+            origin[ax] = shift[0]
+            origin[(ax + 1) % 3] = shift[1]
+            origin[(ax + 2) % 3] = shift[2]
+            out.append((ax, tuple(origin)))
+    return out
+
+
+TEMPLATES = templates()
+WINDOWS = tuple((name, [(0, 0, 0)] + NBHDS[name])
+                for name in ("NN", "NN+AX2", "L1<=2", "3x3x3", "5x5x5"))
+
+
+def window_pattern(window, ax, origin):
+    return tuple(pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax) for o in window)
+
+
+def role_determined(window):
+    """Is the centre role a function of the record values on `window`?"""
+    patterns = [window_pattern(window, ax, origin) for ax, origin in TEMPLATES]
+    roles = [pat_sym(origin, ax) for ax, origin in TEMPLATES]
+    for a in range(len(TEMPLATES)):
+        for b in range(a + 1, len(TEMPLATES)):
+            if roles[a] == roles[b]:
+                continue
+            if all(x is None or y is None or x == y
+                   for x, y in zip(patterns[a], patterns[b])):
+                return False, (NAME[roles[a]], NAME[roles[b]])
+    return True, None
+
+
+def enumerate_records(box, window):
+    """Complete enumeration: admissible under the minimal window rule, and
+    outside every sector cylinder. No solver."""
+    grid = sites(box)
+    n = len(grid)
+    index = {s: i for i, s in enumerate(grid)}
+    assert (1 << n) * n <= CELL_CAP
+    bits = ((np.arange(1 << n, dtype=np.int64)[:, None] >> np.arange(n)) & 1).astype(np.int8)
+    admissible = np.ones(1 << n, dtype=bool)
+    for site in grid:
+        matched = np.zeros(1 << n, dtype=bool)
+        for ax, origin in TEMPLATES:
+            demand, consistent = {}, True
+            for o in window:
+                value = pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax)
+                if value is None:
+                    continue
+                u = index[tuple((site[k] + o[k]) % box[k] for k in range(3))]
+                if demand.get(u, value) != value:
+                    consistent = False
+                    break
+                demand[u] = value
+            if not consistent:
+                continue
+            hit = np.ones(1 << n, dtype=bool)
+            for u, value in demand.items():
+                hit &= bits[:, u] == value
+            matched |= hit
+        admissible &= matched
+    outside = np.ones(1 << n, dtype=bool)
+    for ax, origin in TEMPLATES:
+        cylinder = np.ones(1 << n, dtype=bool)
+        fits = True
+        period = [2, 2, 2]
+        period[ax] = 4
+        if any(box[i] % period[i] for i in range(3)):
+            fits = False
+        if not fits:
+            continue
+        for i, site in enumerate(grid):
+            value = pat_bit(tuple(site[k] + origin[k] for k in range(3)), ax)
+            if value is not None:
+                cylinder &= bits[:, i] == value
+        outside &= ~cylinder
+    return int(admissible.sum()), int((admissible & outside).sum())
+
+
+def sat_records(box, window, solver_cls):
+    """SAT: admissible under the minimal window rule, outside all 48 cylinders."""
+    from pysat.formula import CNF
+
+    grid = sites(box)
+    index = {s: i + 1 for i, s in enumerate(grid)}
+    cnf = CNF()
+    nxt = len(grid) + 1
+    for site in grid:
+        markers = []
+        for ax, origin in TEMPLATES:
+            marker = nxt
+            nxt += 1
+            markers.append(marker)
+            for o in window:
+                value = pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax)
+                if value is None:
+                    continue
+                u = index[tuple((site[k] + o[k]) % box[k] for k in range(3))]
+                cnf.append([-marker, u if value == 1 else -u])
+        cnf.append(markers)
+    for ax, origin in TEMPLATES:
+        clause = []
+        for i, site in enumerate(grid):
+            value = pat_bit(tuple(site[k] + origin[k] for k in range(3)), ax)
+            if value is not None:
+                clause.append(-(i + 1) if value == 1 else (i + 1))
+        cnf.append(clause)
+    with solver_cls(bootstrap_with=cnf) as solver:
+        return bool(solver.solve())
+
+
+def star_value_patterns():
+    window = [(0, 0, 0)] + NN
+    seen = set()
+    for ax in (0, 1, 2):
+        for site in itertools.product(range(8), range(8), range(8)):
+            base = list(window_pattern(window, ax, site))
+            free = [i for i, v in enumerate(base) if v is None]
+            for fill in itertools.product((0, 1), repeat=len(free)):
+                row = list(base)
+                for i, value in zip(free, fill):
+                    row[i] = value
+                seen.add(tuple(row))
+    return seen
+
+
+# ---- readability -----------------------------------------------------------
+def readability():
+    maps = rot_maps(NN)
+
+    def orb(profile):
+        return min(tuple(profile[m[i]] for i in range(6)) for m in maps)
+
+    complete = realised(NN)
+    profiles = {p for _, p in complete}
+    complete_orbits = {orb(p) for p in profiles}
+    role_orbits = {orb(p) for p in itertools.product(range(5), repeat=6)}
+    partial = set()
+    for site in itertools.product(range(4), range(2), range(2)):
+        role = pat_sym(site, 0)
+        full = [pat_sym(tuple(site[k] + o[k] for k in range(3)), 0) for o in NN]
+        for mask in range(64):
+            profile = tuple(full[i] if (mask >> i) & 1 else OPEN for i in range(6))
+            for m in maps:
+                partial.add((role, tuple(profile[m[i]] for i in range(6))))
+    partial_profiles = {p for _, p in partial}
+    partial_orbits = {orb(p) for p in partial_profiles}
+    open_orbits = {orb(p) for p in itertools.product(range(6), repeat=6)}
+    return (len(complete), len(profiles), len(complete_orbits), len(role_orbits),
+            len(partial), len(partial_profiles), len(partial_orbits), len(open_orbits))
+
+
+def pin_field_families(box):
+    """All / laminar / striped binary pin fields on the coarse sublattice."""
+    coarse = [s for s in sites(box) if all(c % 2 == 0 for c in s)]
+    index = {s: j for j, s in enumerate(coarse)}
+    n = len(coarse)
+    assert (1 << n) * n <= CELL_CAP
+    bits = ((np.arange(1 << n, dtype=np.int64)[:, None] >> np.arange(n)) & 1).astype(np.int8)
+    laminar = np.zeros(1 << n, dtype=bool)
+    striped = np.zeros(1 << n, dtype=bool)
+    for ax in range(3):
+        planes = {}
+        for s in coarse:
+            planes.setdefault(s[ax], []).append(index[s])
+        flat = np.ones(1 << n, dtype=bool)
+        for plane in planes.values():
+            for j in plane[1:]:
+                flat &= bits[:, plane[0]] == bits[:, j]
+        laminar |= flat
+        for offset in (0, 1):
+            run = np.ones(1 << n, dtype=bool)
+            for s in coarse:
+                run &= bits[:, index[s]] == (((s[ax] // 2) % 2) ^ offset)
+            striped |= run
+    return n, 1 << n, int(laminar.sum()), int(striped.sum())
+
+
+# ---- main ------------------------------------------------------------------
+def main() -> int:
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    probe = PROBE_PATH.read_text(encoding="utf-8")
+    law_pair = Q8_PATH.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    try:
+        from pysat.solvers import Cadical153
+        have_sat = True
+    except Exception:
+        Cadical153 = None
+        have_sat = False
+
+    print("external_scientific_inputs: none; every number is recomputed here")
+    print("integrity_reads: axioms, deep probe, law pair, this note")
+    print("construction: exact enumeration over roles and over binary records")
+    print("negative_scope: finite non-pinning statements on the named tori")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scientific_dependency: minimal_axioms Lattice, Qubit, Admissibility")
+    print("declared_math: cubic rotations, role subshifts, binary record windows")
+    if have_sat:
+        print("solver_mode: pysat present; CaDiCaL on the 4x4x4 torus, and the "
+              "complete solver-free enumeration on the 4x2x2 torus")
+    else:
+        print("solver_mode: pysat absent; the complete solver-free enumeration on "
+              "the smallest torus, 4x2x2, decides the record-level rows and the "
+              "4x4x4 SAT rows are not run")
+
+    checks.check("audit-input-paths", "declared inputs exist and are unique",
+                 all((ROOT / p).is_file() for p in AUDIT_INPUT_PATHS)
+                 and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)))
+    checks.check("audit-timeout", "the declared timeout is 300 seconds",
+                 AUDIT_TIMEOUT_SEC == 300)
+
+    # ---------- supplied surface -------------------------------------------
+    checks.check(
+        "axiom-lattice", "nearest-neighbor adjacency is quoted",
+        "with nearest-neighbor\nadjacency" in axiom
+        and "nearest-neighbor adjacency" in note_flat)
+    checks.check(
+        "axiom-admissibility", "the one fixed nearest-neighbor rule is quoted",
+        "There is one fixed nearest-neighbor admissibility rule, covariant under "
+        "lattice translations and proper cubic rotations." in axiom_flat
+        and "one fixed nearest-neighbor admissibility rule" in note_flat)
+    checks.check(
+        "axiom-qubit", "the M_2(C) presentation is quoted",
+        "The full one-site possibility domain has algebraic presentation `M_2(C)`."
+        in axiom_flat
+        and "algebraic presentation `M_2(C)`" in note_flat)
+    checks.check(
+        "axiom-support", "admissible read as the support",
+        "denotes its support -- on finite menus, exactly the possibilities of "
+        "nonzero probability" in axiom_flat and "denotes its support" in note_flat)
+    checks.check(
+        "parent-deep-probe", "the deep probe is live",
+        "number of covariant label-equivariant tables = 3^24" in probe)
+    checks.check(
+        "parent-law-pair", "the 2026-08-13 law pair is live",
+        "claim_type: bounded_theorem" in law_pair
+        and "It selects neither rule as the framework's physical law."
+        in normalize(law_pair))
+
+    # ---------- T1 : the role census ---------------------------------------
+    pairs_nn = realised(NN)
+    profiles_nn = {p for _, p in pairs_nn}
+    maps = rot_maps(NN)
+
+    def orb(profile):
+        return min(tuple(profile[m[i]] for i in range(6)) for m in maps)
+
+    union = set()
+    for ax in (0, 1, 2):
+        for site in itertools.product(range(4), range(4), range(4)):
+            union.add((pat_sym(site, ax),
+                       tuple(pat_sym(tuple(site[k] + o[k] for k in range(3)), ax)
+                             for o in NN)))
+    table = {}
+    for role, profile in pairs_nn:
+        table.setdefault(profile, set()).add(role)
+
+    checks.check("T1-pairs", "the pattern realises 18 (role, profile) pairs",
+                 len(pairs_nn) == 18, len(pairs_nn))
+    checks.check("T1-profiles", "17 profiles of the 5^6 = 15625",
+                 len(profiles_nn) == 17 and 5 ** 6 == 15625, len(profiles_nn))
+    checks.check("T1-orbits", "6 rotation orbits of 800",
+                 len({orb(p) for p in profiles_nn}) == 6
+                 and len({orb(p) for p in itertools.product(range(5), repeat=6)}) == 800)
+    checks.check("T1-covariance",
+                 "one covariant rule = 48 sectors",
+                 pairs_nn == union)
+    checks.check("T1-table", "the table has 17 nonempty rows",
+                 len(table) == 17 and sum(len(v) for v in table.values()) == 18)
+
+    # ---------- T2 : the nearest-neighbour role table does not pin ----------
+    corner_profiles = {tuple(pat_sym(tuple(s[k] + o[k] for k in range(3)), 0) for o in NN)
+                       for s in itertools.product(range(4), range(2), range(2))
+                       if pat_sym(s, 0) in (C0, C1)}
+    edge_full = True
+    for site in itertools.product(range(4), range(2), range(2)):
+        if pat_sym(site, 0) != E:
+            continue
+        profile = [pat_sym(tuple(site[k] + o[k] for k in range(3)), 0) for o in NN]
+        slots = [i for i, x in enumerate(profile) if x in (C0, C1)]
+        for fill in itertools.product((C0, C1), repeat=len(slots)):
+            row = list(profile)
+            for i, value in zip(slots, fill):
+                row[i] = value
+            edge_full &= (E, tuple(row)) in pairs_nn
+    coarse_pairs = realised(NN, proj=True)
+    unrealised = 0
+    for coarse_role, coarse_profile in coarse_pairs:
+        roles = [C0, C1] if coarse_role == 0 else [{1: E, 2: F, 3: Q}[coarse_role]]
+        slots = [i for i, x in enumerate(coarse_profile) if x == 0]
+        for role in roles:
+            for fill in itertools.product((C0, C1), repeat=len(slots)):
+                row = [{1: E, 2: F, 3: Q}[x] if x else None for x in coarse_profile]
+                for i, value in zip(slots, fill):
+                    row[i] = value
+                unrealised += (role, tuple(row)) not in pairs_nn
+
+    checks.check("T2-corner-profile", "every corner carries EEEEEE",
+                 corner_profiles == {(E,) * 6}, corner_profiles)
+    checks.check("T2-corner-menu", "so its menu holds C0 and C1",
+                 table[(E,) * 6] == {C0, C1})
+    checks.check("T2-edge-pins",
+                 "edges realise all 4 corner-pin pairs",
+                 edge_full)
+    checks.check("T2-refinements",
+                 "0 refinements unrealised",
+                 unrealised == 0 and len(coarse_pairs) == 8, unrealised)
+
+    ladder = {}
+    for box in TORI:
+        ladder[box] = ladder_counts(box)
+
+    expected_nn = {(4, 2, 2): 32, (4, 4, 4): 2048, (8, 4, 4): 524288,
+                   (5, 4, 4): 0, (7, 4, 4): 0}
+    expected_sectors = {(4, 2, 2): 16, (4, 4, 4): 48, (8, 4, 4): 48,
+                        (5, 4, 4): 0, (7, 4, 4): 0}
+    name = {b: f"{b[0]}x{b[1]}x{b[2]}" for b in TORI}
+    header = "  ".join(f"{n:>7s}" for n in LADDER)
+    print(f"ladder  torus   {header}  sectors")
+    for box in TORI:
+        counts, sectors, _ = ladder[box]
+        row = "  ".join(f"{counts[n][0]:7d}" for n in LADDER)
+        print(f"        {name[box]:6s}  {row}  {len(sectors):7d}")
+
+    checks.check(
+        "T2-nn-counts",
+        "NN admits 8 x 2^corners: 32, 2048, 524288",
+        all(ladder[b][0]["NN"][0] == expected_nn[b] for b in TORI)
+        and all(ladder[b][0]["NN"][0] == 8 * (1 << sum(1 for x in ladder[b][2][0]
+                                                       if x == 0))
+                for b in TORI[:3]),
+        {name[b]: ladder[b][0]["NN"][0] for b in TORI})
+    checks.check(
+        "T2-skeleton", "NN pins the (2,2,2) skeleton, 8 of it",
+        all(len(ladder[b][2]) == 8 for b in TORI[:3])
+        and all(len(ladder[b][2]) == 0 for b in TORI[3:]))
+    checks.check(
+        "T2-incommensurate", "0 on 5x4x4 and 7x4x4, at every rung",
+        all(ladder[b][0][n][0] == 0 for b in TORI[3:] for n in LADDER))
+    checks.check(
+        "T2-sectors", "against 16, 48 and 48 sectors",
+        all(len(ladder[b][1]) == expected_sectors[b] for b in TORI))
+
+    # ---------- T3 : the next-nearest-neighbour rule ------------------------
+    window_offsets = set(NBHDS["5x5x5"])
+    orbit_sizes = {}
+    covered = set()
+    for offset in sorted(window_offsets):
+        if offset in covered:
+            continue
+        this = orbit(offset)
+        covered |= set(this)
+        orbit_sizes.setdefault(len(this), []).append(this[0])
+
+    checks.check(
+        "T3-pins-4x4x4",
+        "NN+{+-2e} = the 48 sectors on 4x4x4, as a set",
+        set(ladder[(4, 4, 4)][0]["NN+AX2"][1]) == ladder[(4, 4, 4)][1]
+        and ladder[(4, 4, 4)][0]["NN+AX2"][0] == 48)
+    checks.check(
+        "T3-pins-8x4x4",
+        "and the 48 sectors on 8x4x4, as a set",
+        set(ladder[(8, 4, 4)][0]["NN+AX2"][1]) == ladder[(8, 4, 4)][1]
+        and ladder[(8, 4, 4)][0]["NN+AX2"][0] == 48)
+    checks.check(
+        "T3-pins-4x2x2", "and the 16 sectors 4x2x2 holds",
+        set(ladder[(4, 2, 2)][0]["NN+AX2"][1]) == ladder[(4, 2, 2)][1])
+    checks.check(
+        "T3-pins-incommensurate", "and 0 on 5x4x4 and 7x4x4",
+        all(ladder[b][0]["NN+AX2"][0] == 0 for b in TORI[3:]))
+    checks.check(
+        "T3-ax3-fails", "NN+{+-3e} admits 2048 on 4x4x4 and 8x4x4",
+        ladder[(4, 4, 4)][0]["NN+AX3"][0] == 2048
+        and ladder[(8, 4, 4)][0]["NN+AX3"][0] == 2048)
+    checks.check(
+        "T3-diag-fails", "NN+diag admits 64 on 4x4x4, 160 on 8x4x4",
+        ladder[(4, 4, 4)][0]["NN+DIAG2"][0] == 64
+        and ladder[(8, 4, 4)][0]["NN+DIAG2"][0] == 160)
+    checks.check(
+        "T3-minimal-orbits",
+        "size-6 orbits in 5x5x5: {+-e}, {+-2e} only",
+        sorted(orbit_sizes[6]) == [(-2, 0, 0), (-1, 0, 0)]
+        and sorted(orbit_sizes) == [6, 8, 12, 24], sorted(orbit_sizes.items()))
+    checks.check(
+        "T3-twelve-of-124",
+        "so the support is 12 of the window's 124",
+        len(NBHDS["NN+AX2"]) == 12 and len(NBHDS["5x5x5"]) == 124
+        and set(NBHDS["NN+AX2"]) <= window_offsets)
+    checks.check(
+        "T3-nesting", "nested rungs contain what they refine",
+        all(set(NBHDS[src]) <= set(NBHDS[name_]) for name_, src in NESTED))
+    checks.check(
+        "T3-upper-rungs", "L1<=2, 3x3x3, 5x5x5, body give the sector set",
+        all(set(ladder[b][0][n][1]) == ladder[b][1]
+            for b in TORI[:3] for n in ("L1<=2", "3x3x3", "5x5x5", "NN+BODY")))
+
+    coarse_n, all_fields, laminar, striped = pin_field_families((8, 4, 4))
+    checks.check(
+        "T3-defect-free", "NN admits every pin field: 2^16 = 65536",
+        coarse_n == 16 and all_fields == 65536
+        and ladder[(8, 4, 4)][0]["NN"][0] == 8 * all_fields)
+    checks.check(
+        "T3-defect-laminar",
+        "NN+diag admits the laminar fields, 8 x 20",
+        laminar == 20 and ladder[(8, 4, 4)][0]["NN+DIAG2"][0] == 8 * laminar)
+    checks.check(
+        "T3-defect-striped",
+        "NN+{+-2e} admits the striped fields, 8 x 6",
+        striped == 6 and ladder[(8, 4, 4)][0]["NN+AX2"][0] == 8 * striped)
+
+    # ---------- T4 : the record alphabet ------------------------------------
+    enum_rows = {}
+    for label, window in WINDOWS:
+        enum_rows[label] = enumerate_records((4, 2, 2), window)
+    print("records 4x2x2 complete enumeration (no solver): " + "  ".join(
+        f"{label}={enum_rows[label][1]}" for label, _ in WINDOWS)
+        + "  outside all cylinders")
+    checks.check(
+        "T4-enum-small",
+        "4x2x2: the four smaller windows leave cylinder-free rows",
+        all(enum_rows[label][1] > 0 for label in ("NN", "NN+AX2", "L1<=2", "3x3x3")))
+    checks.check(
+        "T4-enum-5x5x5",
+        "4x2x2: 5x5x5 leaves none, 1024 = 16 x 2^6",
+        enum_rows["5x5x5"] == (1024, 0), enum_rows["5x5x5"])
+
+    if have_sat:
+        sat_rows = {}
+        for label, window in WINDOWS:
+            sat_rows[label] = sat_records((4, 4, 4), window, Cadical153)
+        print("records 4x4x4 CaDiCaL: " + "  ".join(
+            f"{label}={'SAT' if sat_rows[label] else 'UNSAT'}"
+            for label, _ in WINDOWS))
+        checks.check(
+            "T4-sat-small",
+            "4x4x4: star, NN+{+-2e}, L1<=2, 3x3x3 all SAT",
+            all(sat_rows[label] for label in ("NN", "NN+AX2", "L1<=2", "3x3x3")))
+        checks.check(
+            "T4-sat-5x5x5",
+            "only 5x5x5 UNSAT: Theorem 2 confirmed",
+            not sat_rows["5x5x5"])
+
+    stars = star_value_patterns()
+    checks.check(
+        "T4-star-census",
+        "all 128 binary stars realised",
+        len(stars) == 128 and len(stars) == 2 ** 7)
+
+    determined = {label: role_determined(window) for label, window in WINDOWS}
+    print("role from records: " + "  ".join(
+        f"{label}={'yes' if determined[label][0] else 'no'}" for label, _ in WINDOWS))
+    checks.check(
+        "T4-role-radius",
+        "a role is read from records only at radius 2",
+        determined["5x5x5"][0]
+        and not any(determined[label][0]
+                    for label in ("NN", "NN+AX2", "L1<=2", "3x3x3")),
+        {k: v[1] for k, v in determined.items()})
+    checks.check(
+        "T4-role-bits",
+        "a role costs 3 bits where M_2(C) gives one",
+        len(NAME) == 5 and (1 << 2) < 5 <= (1 << 3))
+    checks.check(
+        "T4-record-radius",
+        "so a NN role rule is a radius-3 record rule",
+        1 + 2 == 3 and 2 + 2 == 4
+        and max(max(map(abs, o)) for o in NBHDS["NN+AX2"]) == 2)
+
+    # ---------- T5 : readability and the decomposition ----------------------
+    (n_pairs, n_profiles, n_orbits, n_all_orbits,
+     n_partial, n_partial_profiles, n_partial_orbits, n_open_orbits) = readability()
+    print(f"readability: complete {n_orbits}/{n_all_orbits}   "
+          f"partial {n_partial_orbits}/{n_open_orbits} = "
+          f"{n_partial_orbits / n_open_orbits:.4%}")
+    checks.check(
+        "T5-complete", "6 of 800 orbit entries exercised complete",
+        (n_pairs, n_profiles, n_orbits, n_all_orbits) == (18, 17, 6, 800))
+    checks.check(
+        "T5-partial", "61 of 2226 partially, from 794 pairs",
+        (n_partial, n_partial_profiles, n_partial_orbits, n_open_orbits)
+        == (794, 655, 61, 2226))
+    checks.check(
+        "T5-fraction", "2.74 per cent of the role law exercised",
+        abs(n_partial_orbits / n_open_orbits - 0.0274) < 0.0001)
+    checks.check(
+        "T5-decomposition", "the note separates the law's three parts",
+        "role support rule" in note_flat and "sector choice" in note_flat
+        and "S_f" in note and "B_v" in note and "T_ij" in note)
+    checks.check(
+        "T5-category-error",
+        "readability misses the Hamiltonian terms",
+        "category error" in note_flat)
+
+    # ---------- note hygiene ------------------------------------------------
+    lines = len(note.splitlines())
+    checks.check("note-length", "the note stays under 330 lines", lines < 330, lines)
+    checks.check(
+        "note-registry-id", "the note declares its registry id",
+        "role_pattern_next_nearest_neighbour_rule_roles_not_record_values" in note)
+    banned = ("measurement", "collapse", "observer", "exhausted", "exhaustive",
+              "no-go", "closes the route", "only route", "crystal")
+    hits = [word for word in banned if word in note.lower()]
+    import re as _re
+    hits += _re.findall(
+        r"\b(?:swap|swaps|swapped|move|moves|moved|fill|fills|filled)\b",
+        note.lower())
+    checks.check("note-vocabulary",
+                 "the note avoids the banned vocabulary",
+                 not hits, hits)
+    checks.check(
+        "note-wording", "and says superlattice role pattern",
+        "superlattice role pattern" in note_flat)
+    checks.check(
+        "note-scope", "no law selected; bounded scope stated",
+        "no physical law is selected" in note_flat and "claim_scope:" in note
+        and "promoted" not in note.lower() and "new axiom" not in note.lower())
+    checks.check(
+        "note-exclusion",
+        "the unreconciled counts are excluded",
+        "not reproduced here" in note_flat and "excluded" in note_flat)
+    checks.check(
+        "note-parents", "the note names both parent sources",
+        "#7834" in note and "#7934" in note)
+    checks.check(
+        "note-numbers", "the note carries its counts",
+        all(token in note for token in
+            ("524,288", "2,048", "48", "12", "124", "2,226", "2.74", "160")))
+
+    print("per_element: 5 role symbols, 17 profiles, 800 orbits")
+    print("per_site: every site of every named torus, at every rung")
+    print("per_mode: checked and not executed - no spectral decomposition here")
+    print("per_block: 48 sectors, 8 skeletons, 12 pinning offsets of 124")
+    print("lattice_wide: five named tori; the record rows complete on 4x2x2")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache: **the superlattice role pattern of the emergent fermion is pinned by a next-nearest-neighbour support rule over roles, and roles are not record values.** The designed matter law's role arrangement (the `(4,2,2)` period, 48 sectors) is fixed by a covariant support table over the 12 offsets `NN ∪ {±2e_d}` and by no nearest-neighbour rule: the nearest-neighbour role table admits `8 × 2^{#corners}` configurations (524,288 on `8×4×4` where 48 were wanted). A role carries three bits where the Qubit axiom gives one, and is recovered from records only at radius 2, so over records the rule has radius 3, wider than a nearest-neighbour rule and narrower than the `5×5×5` marker window, whose minimality over records is confirmed here independently (the centre role is a function of the window's record values only at `5×5×5`; on the `4×2×2` torus a complete enumeration of all `2^16` configurations agrees with the SAT verdict on `4×4×4`). The designed law is three things: a next-nearest-neighbour role rule (Admissibility's kind, but not nearest-neighbour), a supplied four-bit sector choice, and a supplied Hamiltonian; and the role law is almost entirely unexercised by the arrangement it produces (`2.74 %` of the covariant table), so it cannot be read off its own ground state. "Records determine the law" (PRs #7918, #7929) therefore reaches the designed matter law only through its support-rule part, and only where the records exercise it.

- `docs/THE_SUPERLATTICE_ROLE_PATTERN_IS_A_NEXT_NEAREST_NEIGHBOUR_SUPPORT_RULE_OVER_ROLES_AND_ROLES_ARE_NOT_RECORD_VALUES_BOUNDED_THEOREM_NOTE_2026-09-04.md` (329 lines)
- `scripts/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.py` (`TOTAL: PASS=55 FAIL=0`, 11 s; complete enumeration plus CaDiCaL when `pysat` is importable; no sampling, no seed)
- `logs/runner-cache/role_pattern_next_nearest_neighbour_rule_roles_not_records_check_2026_09_04.txt`

## Theorems

- **T1** the role census: 18 role classes; 17 of the 15,625 `5×5×5` marker windows and 6 of the 800 rotation-closed ones occur.
- **T2** the nearest-neighbour role table does not pin the pattern: 32 / 2,048 / 524,288 = `8 × 2^{#corners}` admissible configurations on `4×2×2` / `4×4×4` / `8×4×4`, and 0 on `5×4×4`, `7×4×4`; 0 unrealised refinements.
- **T3** the minimal pinning neighbourhood is next-nearest-neighbour: `NN ∪ {±2e_d}` reproduces the sector set as a set equality on `4×4×4` and `8×4×4` (and the 16 on `4×2×2`); `NN ∪ {±3e_d}` leaves 2,048; face diagonals leave 64 / 160.
- **T4** over the record alphabet: the centre role is a function of the window's record values for `5×5×5` only (not for the star, `NN ∪ {±2e}`, `L1 ≤ 2`, `3×3×3`; colliding role pairs printed); complete `2^16` enumeration on `4×2×2` (64,512 / 13,981 / 186 / 154 / 0 configurations outside every sector cylinder) agrees with SAT / SAT / SAT / SAT / UNSAT on `4×4×4`.
- **T5** readability: 128 of 128 binary stars, 794 pairs, 655 of 46,656 role windows realised, 61 of 2,226 covariant table entries exercised (`2.74 %`).

## Boundary

- The designed law of the landed BK-encoding notes, taken as supplied; counts on finite tori; role and record alphabets as declared; the separation counts of the parent probe are excluded and replaced by the functional question of T4; nothing derived from the axioms; no claim about any other law.

## Context

- Parents: the readability notes (PR #7918 complete records, PR #7929 partial configurations), the BK-encoding cell algebra (PR #7844), the sector selection (PR #7874).
- Part of the owner-authorised 24-hour readability campaign (2026-09-03/04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
