### PR TITLE
science(light): retain finite-detuning Maxwell stiffness

### DIFF
--- a/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_PROJECTOR_MAXWELL_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_PROJECTOR_MAXWELL_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,502 @@
+# Spin-Half Cubic Ice Retains Maxwell Electric-Flux Stiffness at Two Finite Detunings
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct first-order parent:**
+[`SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Finite-qubit photon parent:**
+[`SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Physical-role compiler boundary:**
+[`U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md`](U1_ROLE_ENCODED_DOUBLED_INCIDENCE_NEAREST_NEIGHBOR_GAUGE_LAW_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py`](../scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.txt`](../logs/runner-cache/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.txt)
+
+## Result up front
+
+The one-qubit cubic-ice Hamiltonian retains a positive Maxwell-scaled electric
+flux cost at two finite distances from its Rokhsar-Kivelson (RK) point. This is
+a finite-population, finite-imaginary-time projector result on the mobile
+components reached by the declared starts; it is not a thermodynamic-limit or
+real-time-spectrum theorem.
+
+Set the ring amplitude to one and write
+
+```text
+H(V)=-sum_p (|clockwise><counterclockwise|+h.c.)+V N_f,
+delta V=V-1.
+```
+
+Every basis state has exactly three occupied links at every cubic vertex.
+`N_f` counts alternating square plaquettes. The calculation projects the
+lowest positive-amplitude state in fixed electric-flux components at
+
+```text
+V=0.95 and V=0.90.
+```
+
+All integer flux magnitudes `Phi=0,...,L/2` are calculated on `L=4,6,8`.
+The `Phi=0,L/2` endpoints are also calculated on `L=10`. Fitting
+
+```text
+E_L(Phi)-E_L(0)=(U_L/2) Phi^2/L
+```
+
+gives the controlled volume ladder
+
+| `V` | `U_4` | `U_6` | `U_8` | `U_10` | mean `U/|delta V|` |
+|---:|---:|---:|---:|---:|---:|
+| 0.95 | 0.162431 | 0.158859 | 0.161363 | 0.167899 | 3.252761 |
+| 0.90 | 0.323246 | 0.316443 | 0.321798 | 0.322970 | 3.211140 |
+
+The `L=8` values in this table use the doubled-population, nonlocal-start
+control. The corresponding `256`-walker full curves agree within the declared
+`15%` population threshold. The relative spread over `L=4,6,8,10` is about
+`5.6%` at `V=0.95` and `2.1%` at `V=0.90`.
+
+The direct parent obtained at first order
+
+```text
+U/|delta V|=3.183873 +/- 0.154786.
+```
+
+The two finite-detuning means differ from its central value by only about
+`2.2%` and `0.9%`. No perturbation series is used in the finite-detuning
+projection: within each finite graph, all powers of `delta V` enter the
+ground-state eigenvector.
+
+The joint flux-and-volume fit strongly favors `Phi^2/L`. Its residual sums of
+squares are
+
+```text
+V=0.95: 0.00014972,
+V=0.90: 0.00007401.
+```
+
+At both detunings the runner requires this to be less than `20%` of the best
+among four controls: linear in `|Phi|`, linear in `|Phi|/L`, unscaled
+`Phi^2`, and a nonzero-sector step. Separately on each complete `L=4,6,8`
+ladder, the quadratic law beats the linear-flux fit.
+
+This is direct positive movement on the finite-qubit photon-phase seam. The
+electric coefficient neither exists only as a derivative at the RK point nor
+collapses immediately at finite detuning. It remains bounded because the
+calculation does not establish the infinite-volume ground state, a finite
+interval of `V`, the magnetic stiffness at the same detunings, or a linear
+real-time photon pole.
+
+## 1. Exact positive projector
+
+On an `L^3` torus there are
+
+```text
+M=3 L^3
+```
+
+square-plaquette roots. Inside a fixed mobile component, the RK Hamiltonian is
+the graph Laplacian
+
+```text
+H_RK=D-A,
+```
+
+where `D_CC=N_f(C)` and `A` counts square flips. Therefore
+
+```text
+H(V)=H_RK+delta V N_f.
+```
+
+For `0<=V<=1`, define
+
+```text
+G=I-H(V)/M.
+```
+
+Its off-diagonal entry for each allowed square flip is `1/M`, and its diagonal
+entry is
+
+```text
+1-V N_f(C)/M >= 1-V >= 0.
+```
+
+Thus `G` is entrywise nonnegative at both tested detunings and has the same
+eigenvectors as `H`. On each connected component, its Perron vector is the
+lowest-energy positive-amplitude eigenvector of `H`.
+
+The column sum at configuration `C` is
+
+```text
+b(C)=1-delta V N_f(C)/M.
+```
+
+One exact importance-sampled step with constant trial state is:
+
+1. multiply the walker weight by `b(C)`;
+2. choose one of the `M` plaquettes uniformly;
+3. if it is flippable, execute the flip with probability `1/b(C)`;
+4. otherwise remain in `C`.
+
+The flip probability for each allowed destination is exactly `1/(M b(C))`.
+The remaining probability is the normalized diagonal of `G`. Fixed-population
+systematic resampling is performed after a declared number of these exact
+steps; the approximation is in the finite walker population and projection
+time, not in a Trotterized Hamiltonian.
+
+## 2. Mixed estimator
+
+For the constant trial state, the row sum of the Hamiltonian is
+
+```text
+E_local(C)=V N_f(C)-N_f(C)=delta V N_f(C).
+```
+
+If `psi_0` is the positive ground vector in the component, symmetry of `H`
+gives
+
+```text
+E_0
+ = <1|H|psi_0>/<1|psi_0>
+ = delta V sum_C N_f(C) psi_0(C) / sum_C psi_0(C).
+```
+
+The projector population samples the last ratio. The reported energy is
+therefore the mixed estimator
+
+```text
+E_0=delta V <N_f>_mixed.
+```
+
+This identity is independently checked on the complete `L=2` component
+graphs. Exact sparse diagonalization gives
+
+| `V` | `Phi` | exact `E_0` |
+|---:|---:|---:|
+| 0.95 | 0 | -0.402736506 |
+| 0.95 | 1 | -0.328353309 |
+| 0.90 | 0 | -0.810822412 |
+| 0.90 | 1 | -0.664101443 |
+
+For each row, direct eigenvector evaluation of the mixed estimator agrees to
+`1e-9`, and a `2048`-walker projector independently reproduces the exact
+energy inside its declared stochastic tolerance.
+
+## 3. Finite-volume protocol
+
+The primary `L=4,6,8` populations use:
+
+```text
+walkers                 256
+uniform-RK warmup       100 attempted sweeps
+projector burn          150 attempted sweeps
+projector samples       300, one per attempted sweep
+```
+
+One attempted sweep means `M` exact single-plaquette Green-function steps per
+walker. Ten time blocks supply the displayed internal sampling errors.
+
+The `L=10` endpoint populations use the same counts. The population control
+at `L=8` uses:
+
+```text
+walkers                 512
+uniform-RK warmup       150 attempted sweeps
+projector burn          250 attempted sweeps
+projector samples       500
+```
+
+It also changes the initialization. Instead of beginning only from the
+checkerboard ice state, it flips two oppositely oriented noncontractible lines
+whose net electric flux is zero, then adds the requested net-flux lines. This
+is a nonlocal start relative to the elementary square moves. Agreement does
+not prove that all disconnected mobile components have been found, but it is
+a direct initialization/component sensitivity control.
+
+Every population ends with exact three-of-six vertex degree and exact assigned
+electric flux for every walker. Incrementally maintained `N_f` is recomputed
+from scratch on the final population. The minimum resampling effective
+population stays above `90%` of nominal, and at least `25%` of the final
+walkers remain distinct at every `L>=4` run. These thresholds guard against a
+numerically positive answer produced by immediate population collapse.
+
+The largest inserted flux is `Phi=L/2`; hence the field density obeys
+
+```text
+Phi/L^2 <= 1/(2L).
+```
+
+The endpoint sequence is therefore a shrinking-field-density rather than a
+fixed strong-field test.
+
+## 4. What the scaling discriminates
+
+For a Maxwell electric term
+
+```text
+H_E=(U/2) sum_links E^2,
+```
+
+a uniform topological flux `Phi` spreads over an `L^2` cross-section. Its
+energy is
+
+```text
+(U/2) L^3 (Phi/L^2)^2 = U Phi^2/(2L).
+```
+
+That is the observed joint dependence on both flux and volume. A linear flux
+cost would indicate a different string-like response. An unscaled `Phi^2`
+cost would fail the volume normalization. A step would say only that sectors
+differ, not that they carry a stiffness. The fit compares all five using one
+through-origin coefficient per detuning.
+
+The primary `L=4,6,8` curves also allow the flux shape to be tested before
+combining volumes. Every fitted `U_L` is positive by more than six reported
+internal standard errors, and every quadratic residual is below one quarter
+of its same-volume linear control.
+
+The result is nonperturbative in the limited but important sense that `V=0.95`
+and `V=0.90` are diagonalized by power projection, not evaluated by truncating
+the derivative at `V=1`. It is not nonperturbative in the stronger sense of a
+rigorous infinite-volume construction.
+
+## 5. Program consequence
+
+The finite-qubit light chain now contains, on the same microscopic carrier:
+
+```text
+one occupation qubit per cubic link
+ -> exact three-of-six Gauss sector
+ -> local four-qubit square-ring Hamiltonian
+ -> RK Coulomb correlations and positive magnetic response
+ -> positive first-order electric stiffness
+ -> positive finite-detuning Phi^2/L electric stiffness.
+```
+
+The last arrow is new here. It removes the specific concern that the electric
+coefficient could be a derivative-only artifact that disappears as soon as
+one leaves the RK point.
+
+It does not close the whole photon phase. The next direct physics target is a
+finite-detuning dynamical observable: an imaginary-time transverse correlator
+whose lowest pole scales linearly with lattice momentum, or an independently
+resolved static-charge `1/R` potential. Those diagnose the same remaining
+phase wall and should not be counted as separate TOE obligations.
+
+The physical-site compiler remains independent. The role compiler realizes
+edge/face incidence with one neighbor-conditioned law, but this source does
+not compile the ice constraint and ring Hamiltonian into an orthogonal
+one-qubit-per-physical-site composite. Admissibility selection and the
+empirical electromagnetic dictionary also remain open.
+
+No axiom change is proposed. The Hamiltonian, detunings, component starts, and
+projection rule are supplied model content. The current Admissibility axiom
+does not select them.
+
+## 6. Prior-art and contribution boundary
+
+The spin-half cubic model, RK point, dual Maxwell description, first-order
+spinon potential, and stable adjacent `U(1)` phase are due to M. Hermele,
+M. P. A. Fisher, and L. Balents,
+[“Pyrochlore Photons: The U(1) Spin Liquid in a S=1/2 Three-Dimensional
+Frustrated Magnet”](https://arxiv.org/abs/cond-mat/0305401) (2004).
+
+This source makes no priority claim for the model, projector methods, or the
+phase. Its repo-specific contribution is the independently executable finite
+protocol: the exact positive Green function, four exact small-graph controls,
+all-flux ladders at three volumes, `L=10` shrinking-density endpoints, two
+finite detunings, nonlocal-start and doubled-population controls, and the
+five-way joint scaling comparison.
+
+## 7. Executable evidence
+
+The runner reports `TOTAL: PASS=12 FAIL=0`. It checks:
+
+- exactly `3L^3` four-link square moves on `L=2,4,6,8,10`;
+- three neutral noncontractible line-pair start controls;
+- the exact constant-trial mixed-estimator identity in four `L=2` cases;
+- projector agreement with all four exact `L=2` ground energies;
+- exact Gauss charge, assigned flux, and flippability accounting in every
+  final walker;
+- effective-population and distinct-final-state collapse controls;
+- resolved positive stiffness on each complete `L=4,6,8` flux ladder;
+- same-volume preference for quadratic over linear flux dependence;
+- positive shrinking-density `L=10` endpoints;
+- doubled-population, nonlocal-start agreement at `L=8`;
+- joint preference for `Phi^2/L` over four named controls; and
+- volume stability and agreement with the independent first-order
+  coefficient.
+
+## No-Go Discipline Gate
+
+This positive result leaves a deliberately bounded phase statement. The gate
+below prevents finite projector evidence from being promoted into a
+thermodynamic theorem or its remaining diagnostics from being multiplied into
+separate walls.
+
+### N1 — Alternative route enumeration
+
+| Route | Outcome |
+|---|---|
+| exact finite graph | **Positive control:** four `L=2` energies and mixed estimators agree exactly. |
+| first-order topological response | **Positive parent:** supplies `U/|delta V|=3.183873(154786)` at the RK boundary. |
+| finite-detuning positive projector | **Positive here:** two detunings and four volumes retain `Phi^2/L`. |
+| nonlocal start and population doubling | **Positive control:** `L=8` endpoint stiffness agrees within `15%`. |
+| static-charge potential | **Open direct diagnostic:** tests `1/R` at finite detuning. |
+| imaginary-time transverse spectrum | **Open direct diagnostic:** tests the linear photon pole. |
+| controlled duality/stability analysis | **Imported primary route:** supplies the adjacent stable phase, not new runner output. |
+| orthogonal physical-site compiler | **Open independent route:** compiles the coarse carrier into physical sites. |
+
+The static-charge and spectrum calculations are alternate diagnostics of one
+phase obligation, not independent reasons to discount the positive result.
+
+### N2 — Wall-independence and collapse audit
+
+After this calculation the live walls are
+
+```text
+W1 = thermodynamic and dynamical completion of the finite-detuning phase,
+W2 = homogeneous nearest-neighbor physical-site compiler,
+W3 = mobile matter and exact backreaction on the spin-half carrier,
+W4 = Admissibility selection and empirical electromagnetic identification.
+```
+
+`W1` contains the real-time pole, finite-volume-to-infinite-volume control,
+finite-detuning magnetic response, and static-charge potential. These are
+coupled phase diagnostics and are collapsed into one wall. `W2` does not prove
+phase stability. `W3` does not select the law. `W4` does not supply the
+microscopic spectrum. None automatically closes another.
+
+### N3 — Hidden-condition scan
+
+The cubic link graph, periodic even volumes, three-of-six sector, ring
+amplitude, two values of `V`, fixed mobile-component starts, flux range,
+walker counts, warmup, burn, sampling length, resampling rule, seeds, and fit
+models are supplied explicitly. The calculation assumes neither that local
+square moves connect every ice state nor that the sampled component is the
+global minimum among all mobile components. Internal block errors are not a
+rigorous population-control or autocorrelation theorem.
+
+The physical lattice law does not follow from the projector. Record formation,
+measurement, electromagnetic calibration, and a continuum limit are absent.
+
+### N4 — Residual matching
+
+| Surface | Residual there | Match here |
+|---|---|---|
+| first-order parent | finite-detuning persistence unexecuted | **direct partial resolution:** two finite detunings retain the coefficient and scaling |
+| finite-qubit parent | stable phase imported, direct dynamics open | **strengthened but not closed:** finite-detuning electric tower is computed |
+| primary spin-liquid result | stable adjacent phase and universal description | **independent bounded numerical match:** no replacement of its thermodynamic argument |
+| role compiler | edge/face incidence but no ice-ring orthogonal composite | **unmatched:** no compiler claim here |
+| minimal axioms | dynamics and law values not selected | **unmatched:** supplied Hamiltonian remains supplied |
+
+The theorem survives if either open-PR parent loses status: its formulas and
+runner inputs are explicit on this stack. Their status is not imported as an
+audit premise.
+
+### N5 — Rhetoric and resolution audit
+
+“Retains stiffness” means the displayed positive `Phi^2/L` coefficient in the
+declared finite projector protocol. “Finite detuning” means exactly `V=0.95`
+and `V=0.90`, not an interval. “Nonperturbative” refers only to projection of
+the complete finite Hamiltonian rather than truncation in `delta V`.
+“Maxwell” names the discriminating topological energy law, not an empirical
+identification with laboratory electromagnetism.
+
+The five-resolution certificate says:
+
+```text
+per_element: every accepted square flip is checked;
+per_site: every final walker preserves Gauss charge;
+per_mode: the electric topological-flux tower is fitted;
+per_block: exact L=2 and projector L=4,6,8,10 are combined;
+lattice_wide: finite-volume stiffness is resolved, a thermodynamic phase is not.
+```
+
+### N6 — Partial-closure paths and primitive boundary
+
+No axiom or approved primitive is added. Positive continuations are:
+
+- measure the lowest imaginary-time transverse pole across `L` at finite
+  detuning;
+- measure the finite-detuning charge potential with source separation and
+  volume controls;
+- add a finite-detuning magnetic twist response on the same projector;
+- sample additional nonlocal starts and larger populations/volumes; or
+- build the orthogonal spatial composite for the ice constraint and ring
+  term.
+
+The kinetic-isotropy primitive does not select this Hamiltonian, its detuning,
+or its time interpretation.
+
+### N7 — Steelman
+
+A hostile reviewer can correctly object that fixed-population stochastic
+reconfiguration has population bias, finite projection time, and unproved
+autocorrelation control. They can also object that one family of mobile starts
+does not classify every disconnected ice component. These objections prevent
+a thermodynamic phase theorem.
+
+They do not erase the four exact small-graph controls, the positive coefficient
+on every full finite ladder, the shrinking-field endpoint at `L=10`, or the
+agreement under a doubled population and nonlocal initialization. The proper
+claim is the bounded finite-detuning stiffness result, not either full phase
+closure or no progress.
+
+### N8 — Cross-cycle echo
+
+The direct parent measured the first derivative of the topological energy at
+the RK point and named finite detuning as the next shortest physics test. This
+source executes that test with a different method and two nonzero detunings.
+The older finite-clock route supplies another microscopic carrier but not this
+spin-half many-body projection. The physical-role compiler names the separate
+site-realization wall and is not silently reused as a phase theorem.
+
+**Gate result:** PASS. Eight route families are separated, dependent phase
+diagnostics are collapsed, the finite-population and component boundaries are
+explicit, and the positive finite-detuning result is preserved without a
+thermodynamic or empirical overclaim.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- `G=I-H/M` has a negative entry at either tested `V`;
+- the sampled transition probabilities differ from normalized columns of
+  `G`;
+- the constant-trial mixed estimator differs from exact diagonalization on
+  `L=2`;
+- any local update changes a vertex charge or assigned electric flux;
+- incrementally maintained and recomputed `N_f` disagree;
+- any complete `L=4,6,8` curve has unresolved or nonpositive `U_L`;
+- the quadratic curve fails the declared same-volume linear control;
+- either `L=10` endpoint loses positive stiffness;
+- the doubled-population/nonlocal-start `L=8` result disagrees beyond `15%`;
+- `Phi^2/L` fails the declared joint model comparison;
+- the volume spread or first-order comparison exceeds `20%`; or
+- effective population or final-state diversity crosses its collapse bound.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=12 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15824,
- "node_count": 5577,
+ "edge_count": 15828,
+ "node_count": 5578,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17405,6 +17405,10 @@
   "spin_half_cubic_ice_exact_rk_coulomb_correlations_and_finite_qubit_photon_phase_bridge_bounded_theorem_note_2026-09-03": {
    "deps_hash": "66cfd875c50b",
    "out_degree": 5
+  },
+  "spin_half_cubic_ice_finite_detuning_projector_maxwell_stiffness_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "864f3fd41e7e",
+   "out_degree": 4
   },
   "spin_half_cubic_ice_positive_topological_electric_stiffness_bounded_theorem_note_2026-09-03": {
    "deps_hash": "8a779a3f11ac",

--- a/logs/runner-cache/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py
+runner_sha256: 8becfe5e91a731e38bc056b69044f03f8c40ced504641ba6893f3410893c1706
+input_fingerprint_sha256: 3c58cd9e3a66fa268a03c885c7305ba4d1c4a505800468e4342a58d8e4625766
+timeout_sec: 480
+exit_code: 0
+elapsed_sec: 266.42
+status: ok
+----- stdout -----
+[PASS] 01 the L=2,4,6,8,10 projector geometries contain exactly 3L^3 four-link square moves
+[PASS] 02 opposite noncontractible line pairs provide three nonlocal zero-flux initialization controls
+[PASS] 03 the exact L=2 eigenvectors satisfy the constant-trial mixed-estimator identity in both flux sectors
+[PASS] 04 the stochastic projector reproduces four exact L=2 ground energies at V=0.95 and V=0.90
+[PASS] 05 every projector population preserves exact local flippability, three-of-six Gauss charge, and assigned flux
+[PASS] 06 all populations retain effective weight and final-state diversity above the declared collapse controls
+[PASS] 07 every L=4,6,8 finite-detuning flux ladder has resolved positive electric stiffness
+[PASS] 08 Phi^2/L beats a linear-in-|Phi| curve separately on every full flux ladder
+[PASS] 09 the shrinking-density L=10 endpoints independently retain positive stiffness
+[PASS] 10 doubled L=8 populations reproduce the positive endpoint stiffness within fifteen percent
+[PASS] 11 the joint L=4,6,8,10 data prefer Maxwell Phi^2/L scaling over four named controls
+[PASS] 12 the volume ladder is stable and remains near the independent first-order U/|delta V| coefficient
+EXACT V=0.95 Phi=0 E0=-0.402736506 projector=-0.402717719+/-0.000143474
+EXACT V=0.95 Phi=1 E0=-0.328353309 projector=-0.328269366+/-0.000095120
+EXACT V=0.90 Phi=0 E0=-0.810822412 projector=-0.810989837+/-0.000199869
+EXACT V=0.90 Phi=1 E0=-0.664101443 projector=-0.663706429+/-0.000116271
+CURVE V=0.95 L=4 U=0.162431+/-0.002836 rss_quad=0.00000758 rss_linear=0.00043585
+CURVE V=0.95 L=6 U=0.158859+/-0.003556 rss_quad=0.00000179 rss_linear=0.00096923
+CURVE V=0.95 L=8 U=0.158029+/-0.004098 rss_quad=0.00005171 rss_linear=0.00216498
+CURVE V=0.90 L=4 U=0.323246+/-0.005698 rss_quad=0.00000678 rss_linear=0.00149915
+CURVE V=0.90 L=6 U=0.316443+/-0.008214 rss_quad=0.00001294 rss_linear=0.00421991
+CURVE V=0.90 L=8 U=0.327441+/-0.007456 rss_quad=0.00000206 rss_linear=0.00875919
+POPULATION_CONTROL V=0.95 U_256=0.156557 U_512=0.161363+/-0.003361
+POPULATION_CONTROL V=0.90 U_256=0.327962 U_512=0.321798+/-0.006029
+DATA V=0.95 U_L=4:0.162431,6:0.158859,8:0.161363,10:0.167899 U/|deltaV|=3.252761 global_rss=0.00014972
+MODEL_CONTROL V=0.95 rss=quadratic_over_length:0.00014972,linear:0.00482474,linear_over_length:0.01507353,quadratic:0.00423395,step:0.04087815
+DATA V=0.90 U_L=4:0.323246,6:0.316443,8:0.321798,10:0.322970 U/|deltaV|=3.211140 global_rss=0.00007401
+MODEL_CONTROL V=0.90 rss=quadratic_over_length:0.00007401,linear:0.01707266,linear_over_length:0.05625386,quadratic:0.01900005,step:0.15655303
+CERTIFICATE: exact_stoquastic_green_function=True constant_trial_mixed_estimator=True finite_population=True finite_imaginary_time=True thermodynamic_limit=False real_time_spectrum=False
+RESOLUTION: per_element=every accepted square flip; per_site=all final walkers preserve Gauss; per_mode=electric topological flux; per_block=exact L2 plus projector L4,6,8,10; lattice_wide=finite-volume finite-detuning stiffness, not a thermodynamic phase proof
+TOTAL: PASS=12 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py
+++ b/scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py
@@ -1,0 +1,888 @@
+#!/usr/bin/env python3
+"""Finite-delta-V projector Monte Carlo for the spin-half cubic-ice model.
+
+The Hamiltonian is
+
+    H(V) = - sum_p (|clockwise><counterclockwise| + h.c.) + V N_f
+
+inside a fixed three-of-six ice and electric-flux sector.  At V=1 it is the
+Rokhsar-Kivelson graph Laplacian.  For V<1 it is stoquastic.  The runner uses
+the exact positive Green function G=I-H/M, where M=3L^3 is the number of
+oriented square roots, together with fixed-population stochastic
+reconfiguration.  A constant trial state makes the mixed estimator simply
+(V-1)<N_f>.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numba import njit
+from scipy import sparse
+from scipy.sparse.linalg import eigsh
+
+from spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03 import (
+    build_small_rk_orbit,
+    decode_small,
+    electric_flux,
+    initial_ice,
+    small_flip_destinations,
+    vertex_degrees,
+)
+from spin_half_cubic_ice_topological_electric_stiffness_2026_09_03 import (
+    insert_flux_lines,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py",
+)
+
+AUDIT_TIMEOUT_SEC = 480
+
+
+ORIENTATIONS = ((0, 1), (0, 2), (1, 2))
+
+
+@dataclass(frozen=True)
+class Geometry:
+    length: int
+    plaquette_links: np.ndarray
+    affected_plaquettes: np.ndarray
+    affected_counts: np.ndarray
+
+    @property
+    def link_count(self) -> int:
+        return 3 * self.length**3
+
+    @property
+    def plaquette_count(self) -> int:
+        return 3 * self.length**3
+
+
+def link_index(length: int, coordinate: tuple[int, int, int], axis: int) -> int:
+    return int(np.ravel_multi_index((*coordinate, axis), (length, length, length, 3)))
+
+
+def build_geometry(length: int) -> Geometry:
+    plaquettes: list[tuple[int, int, int, int]] = []
+    for first_axis, second_axis in ORIENTATIONS:
+        for root in np.ndindex(length, length, length):
+            first_neighbor = list(root)
+            first_neighbor[first_axis] = (first_neighbor[first_axis] + 1) % length
+            second_neighbor = list(root)
+            second_neighbor[second_axis] = (second_neighbor[second_axis] + 1) % length
+            plaquettes.append(
+                (
+                    link_index(length, root, first_axis),
+                    link_index(length, tuple(first_neighbor), second_axis),
+                    link_index(length, tuple(second_neighbor), first_axis),
+                    link_index(length, root, second_axis),
+                )
+            )
+    plaquette_links = np.asarray(plaquettes, dtype=np.int32)
+    link_to_plaquettes: list[list[int]] = [[] for _ in range(3 * length**3)]
+    for plaquette, links in enumerate(plaquettes):
+        for link in links:
+            link_to_plaquettes[link].append(plaquette)
+    affected: list[tuple[int, ...]] = []
+    for links in plaquettes:
+        affected.append(
+            tuple(
+                sorted(
+                    {
+                        neighbor
+                        for link in links
+                        for neighbor in link_to_plaquettes[link]
+                    }
+                )
+            )
+        )
+    width = max(len(values) for values in affected)
+    padded = np.full((len(affected), width), -1, dtype=np.int32)
+    counts = np.empty(len(affected), dtype=np.int32)
+    for row, values in enumerate(affected):
+        counts[row] = len(values)
+        padded[row, : len(values)] = values
+    return Geometry(
+        length=length,
+        plaquette_links=plaquette_links,
+        affected_plaquettes=padded,
+        affected_counts=counts,
+    )
+
+
+def neutral_flux_pair_start(length: int, axis: int, offset: int) -> np.ndarray:
+    """Flip two oppositely oriented winding lines while keeping net flux zero."""
+    result = initial_ice(length)
+    transverse = [index for index in range(3) if index != axis]
+    positions = [
+        (first, second)
+        for first in range(length)
+        for second in range(length)
+    ]
+    shift = offset % len(positions)
+    positions = positions[shift:] + positions[:shift]
+    used: set[tuple[int, int]] = set()
+    for desired in (1, -1):
+        found = False
+        for first, second in positions:
+            if (first, second) in used:
+                continue
+            candidate = result.copy()
+            line = [slice(None), slice(None), slice(None), axis]
+            line[transverse[0]] = first
+            line[transverse[1]] = second
+            before = electric_flux(result)[axis]
+            candidate[tuple(line)] ^= 1
+            after = electric_flux(candidate)[axis]
+            if after - before == desired:
+                result = candidate
+                used.add((first, second))
+                found = True
+                break
+        if not found:
+            raise ValueError("could not build a neutral opposite winding-line pair")
+    if electric_flux(result) != (0, 0, 0):
+        raise AssertionError("neutral line pair changed total flux")
+    if not np.all(vertex_degrees(result) == 3):
+        raise AssertionError("neutral line pair changed Gauss charge")
+    return result
+
+
+@njit(cache=True)
+def is_flippable(state: np.ndarray, links: np.ndarray) -> bool:
+    first_low = state[links[0]]
+    second_high = state[links[1]]
+    first_high = state[links[2]]
+    second_low = state[links[3]]
+    return (
+        first_low == first_high
+        and second_low == second_high
+        and first_low != second_low
+    )
+
+
+@njit(cache=True)
+def count_flippable(state: np.ndarray, plaquette_links: np.ndarray) -> int:
+    count = 0
+    for plaquette in range(plaquette_links.shape[0]):
+        if is_flippable(state, plaquette_links[plaquette]):
+            count += 1
+    return count
+
+
+@njit(cache=True)
+def flip_and_update_count(
+    state: np.ndarray,
+    plaquette: int,
+    current_count: int,
+    plaquette_links: np.ndarray,
+    affected_plaquettes: np.ndarray,
+    affected_counts: np.ndarray,
+) -> int:
+    before = 0
+    for slot in range(affected_counts[plaquette]):
+        neighbor = affected_plaquettes[plaquette, slot]
+        if is_flippable(state, plaquette_links[neighbor]):
+            before += 1
+    for link in plaquette_links[plaquette]:
+        state[link] ^= np.uint8(1)
+    after = 0
+    for slot in range(affected_counts[plaquette]):
+        neighbor = affected_plaquettes[plaquette, slot]
+        if is_flippable(state, plaquette_links[neighbor]):
+            after += 1
+    return current_count + after - before
+
+
+@njit(cache=True)
+def systematic_resample(
+    states: np.ndarray,
+    flippable_counts: np.ndarray,
+    log_weights: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    population = states.shape[0]
+    maximum = np.max(log_weights)
+    weights = np.exp(log_weights - maximum)
+    total = np.sum(weights)
+    cumulative = np.cumsum(weights / total)
+    offset = np.random.random() / population
+    output_states = np.empty_like(states)
+    output_counts = np.empty_like(flippable_counts)
+    source = 0
+    for destination in range(population):
+        position = offset + destination / population
+        while source + 1 < population and cumulative[source] < position:
+            source += 1
+        output_states[destination] = states[source]
+        output_counts[destination] = flippable_counts[source]
+    return output_states, output_counts
+
+
+@njit(cache=True)
+def run_population_core(
+    start_state: np.ndarray,
+    plaquette_links: np.ndarray,
+    affected_plaquettes: np.ndarray,
+    affected_counts: np.ndarray,
+    delta_v: float,
+    population: int,
+    classical_sweeps: int,
+    burn_sweeps: int,
+    sample_sweeps: int,
+    resample_interval: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    np.random.seed(seed)
+    plaquette_count = plaquette_links.shape[0]
+    link_count = start_state.shape[0]
+    states = np.empty((population, link_count), dtype=np.uint8)
+    flippable_counts = np.empty(population, dtype=np.int32)
+    for walker in range(population):
+        states[walker] = start_state
+        flippable_counts[walker] = count_flippable(
+            states[walker], plaquette_links
+        )
+
+    # Symmetric random-plaquette dynamics has the uniform RK distribution.
+    # Independent walkers are decorrelated before projector branching begins.
+    for _ in range(classical_sweeps * plaquette_count):
+        for walker in range(population):
+            plaquette = np.random.randint(plaquette_count)
+            if is_flippable(states[walker], plaquette_links[plaquette]):
+                flippable_counts[walker] = flip_and_update_count(
+                    states[walker],
+                    plaquette,
+                    flippable_counts[walker],
+                    plaquette_links,
+                    affected_plaquettes,
+                    affected_counts,
+                )
+
+    total_steps = (burn_sweeps + sample_sweeps) * plaquette_count
+    first_sample_step = burn_sweeps * plaquette_count
+    sample_interval = plaquette_count
+    samples = np.empty(sample_sweeps, dtype=np.float64)
+    effective_populations = np.empty(sample_sweeps, dtype=np.float64)
+    count_checks = np.empty(sample_sweeps, dtype=np.int32)
+    sample_index = 0
+    log_weights = np.zeros(population, dtype=np.float64)
+    minimum_effective_population = float(population)
+
+    for step in range(total_steps):
+        for walker in range(population):
+            count = flippable_counts[walker]
+            branch = 1.0 - delta_v * count / plaquette_count
+            log_weights[walker] += np.log(branch)
+            plaquette = np.random.randint(plaquette_count)
+            if (
+                is_flippable(states[walker], plaquette_links[plaquette])
+                and np.random.random() < 1.0 / branch
+            ):
+                flippable_counts[walker] = flip_and_update_count(
+                    states[walker],
+                    plaquette,
+                    count,
+                    plaquette_links,
+                    affected_plaquettes,
+                    affected_counts,
+                )
+
+        if (step + 1) % resample_interval == 0:
+            maximum = np.max(log_weights)
+            weights = np.exp(log_weights - maximum)
+            effective_population = np.sum(weights) ** 2 / np.sum(weights**2)
+            minimum_effective_population = min(
+                minimum_effective_population, effective_population
+            )
+            states, flippable_counts = systematic_resample(
+                states, flippable_counts, log_weights
+            )
+            log_weights[:] = 0.0
+        else:
+            effective_population = float(population)
+
+        if step + 1 >= first_sample_step and (
+            step + 1 - first_sample_step
+        ) % sample_interval == 0:
+            maximum = np.max(log_weights)
+            weights = np.exp(log_weights - maximum)
+            samples[sample_index] = np.sum(
+                weights * flippable_counts
+            ) / np.sum(weights)
+            current_effective_population = (
+                np.sum(weights) ** 2 / np.sum(weights**2)
+            )
+            minimum_effective_population = min(
+                minimum_effective_population, current_effective_population
+            )
+            effective_populations[sample_index] = minimum_effective_population
+            walker = sample_index % population
+            count_checks[sample_index] = (
+                count_flippable(states[walker], plaquette_links)
+                - flippable_counts[walker]
+            )
+            sample_index += 1
+
+    return (
+        samples,
+        effective_populations,
+        count_checks,
+        states,
+        flippable_counts,
+    )
+
+
+@dataclass(frozen=True)
+class ProjectorResult:
+    length: int
+    flux: int
+    delta_v: float
+    energy: float
+    energy_error: float
+    flippability: float
+    flippability_error: float
+    minimum_effective_population_fraction: float
+    count_consistent: bool
+    sector_consistent: bool
+    final_unique_fraction: float
+
+
+def blocked_mean_and_error(
+    values: np.ndarray, block_count: int = 10
+) -> tuple[float, float]:
+    usable = (len(values) // block_count) * block_count
+    blocks = values[:usable].reshape(block_count, -1).mean(axis=1)
+    return float(np.mean(blocks)), float(
+        np.std(blocks, ddof=1) / np.sqrt(block_count)
+    )
+
+
+def run_population(
+    length: int,
+    flux: int,
+    delta_v: float,
+    *,
+    population: int,
+    classical_sweeps: int,
+    burn_sweeps: int,
+    sample_sweeps: int,
+    seed: int,
+    start_family: int = 0,
+) -> ProjectorResult:
+    geometry = build_geometry(length)
+    if start_family == 0:
+        base_occupation = initial_ice(length)
+    else:
+        base_occupation = neutral_flux_pair_start(
+            length, (start_family - 1) % 3, seed
+        )
+    occupation = insert_flux_lines(
+        base_occupation, 0, flux, line_offset=seed
+    )
+    expected_flux = (flux, 0, 0)
+    if not np.all(vertex_degrees(occupation) == 3):
+        raise AssertionError("projector start leaves the ice sector")
+    if electric_flux(occupation) != expected_flux:
+        raise AssertionError("projector start has the wrong electric flux")
+    (
+        samples,
+        effective_populations,
+        count_checks,
+        final_states,
+        final_counts,
+    ) = run_population_core(
+        occupation.ravel(),
+        geometry.plaquette_links,
+        geometry.affected_plaquettes,
+        geometry.affected_counts,
+        delta_v,
+        population,
+        classical_sweeps,
+        burn_sweeps,
+        sample_sweeps,
+        max(16, geometry.plaquette_count // 8),
+        seed,
+    )
+    mean, error = blocked_mean_and_error(samples)
+    sector_consistent = True
+    for state in final_states:
+        final_occupation = state.reshape((length, length, length, 3))
+        sector_consistent = sector_consistent and bool(
+            np.all(vertex_degrees(final_occupation) == 3)
+            and electric_flux(final_occupation) == expected_flux
+        )
+    packed = np.packbits(final_states, axis=1)
+    final_unique_fraction = np.unique(packed, axis=0).shape[0] / population
+    return ProjectorResult(
+        length=length,
+        flux=flux,
+        delta_v=delta_v,
+        energy=delta_v * mean,
+        energy_error=abs(delta_v) * error,
+        flippability=mean,
+        flippability_error=error,
+        minimum_effective_population_fraction=float(
+            np.min(effective_populations) / population
+        ),
+        count_consistent=bool(
+            np.all(count_checks == 0)
+            and all(
+                count_flippable(state, geometry.plaquette_links) == count
+                for state, count in zip(final_states, final_counts, strict=True)
+            )
+        ),
+        sector_consistent=sector_consistent,
+        final_unique_fraction=float(final_unique_fraction),
+    )
+
+
+def exact_small_energy(delta_v: float, flux: int) -> tuple[float, float]:
+    start = insert_flux_lines(initial_ice(2), 0, flux)
+    orbit = build_small_rk_orbit(start)
+    flippabilities = np.asarray(
+        [len(small_flip_destinations(decode_small(state))) for state in orbit.states],
+        dtype=float,
+    )
+    hamiltonian = orbit.hamiltonian + sparse.diags(delta_v * flippabilities)
+    values, vectors = eigsh(
+        hamiltonian,
+        k=1,
+        which="SA",
+        v0=np.linspace(1.0, 2.0, len(orbit.states)),
+        tol=1.0e-12,
+    )
+    vector = vectors[:, 0]
+    if np.sum(vector) < 0:
+        vector = -vector
+    mixed = delta_v * float(np.dot(vector, flippabilities) / np.sum(vector))
+    return float(values[0]), mixed
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@dataclass(frozen=True)
+class FluxCurveFit:
+    length: int
+    delta_v: float
+    electric_stiffness: float
+    electric_stiffness_error: float
+    quadratic_rss: float
+    linear_rss: float
+
+
+def fit_flux_curve(results: list[ProjectorResult]) -> FluxCurveFit:
+    ordered = sorted(results, key=lambda result: result.flux)
+    if ordered[0].flux != 0:
+        raise ValueError("a flux curve needs a zero-flux reference")
+    reference = ordered[0]
+    nonzero = ordered[1:]
+    predictor = np.asarray(
+        [result.flux**2 / result.length for result in nonzero], dtype=float
+    )
+    differences = np.asarray(
+        [result.energy - reference.energy for result in nonzero], dtype=float
+    )
+    errors = np.asarray(
+        [
+            np.hypot(result.energy_error, reference.energy_error)
+            for result in nonzero
+        ],
+        dtype=float,
+    )
+    weights = 1.0 / np.maximum(errors, 1.0e-12) ** 2
+    slope = float(np.sum(weights * predictor * differences) / np.sum(weights * predictor**2))
+    slope_error = float(np.sqrt(1.0 / np.sum(weights * predictor**2)))
+    quadratic_rss = float(np.sum((differences - slope * predictor) ** 2))
+    linear_predictor = np.asarray(
+        [float(result.flux) for result in nonzero], dtype=float
+    )
+    linear_slope = float(
+        np.dot(linear_predictor, differences)
+        / np.dot(linear_predictor, linear_predictor)
+    )
+    linear_rss = float(
+        np.sum((differences - linear_slope * linear_predictor) ** 2)
+    )
+    return FluxCurveFit(
+        length=reference.length,
+        delta_v=reference.delta_v,
+        electric_stiffness=2.0 * slope,
+        electric_stiffness_error=2.0 * slope_error,
+        quadratic_rss=quadratic_rss,
+        linear_rss=linear_rss,
+    )
+
+
+def endpoint_stiffness(
+    zero: ProjectorResult, endpoint: ProjectorResult
+) -> tuple[float, float]:
+    predictor = endpoint.flux**2 / endpoint.length
+    stiffness = 2.0 * (endpoint.energy - zero.energy) / predictor
+    error = 2.0 * np.hypot(
+        endpoint.energy_error, zero.energy_error
+    ) / predictor
+    return float(stiffness), float(error)
+
+
+def model_rss(
+    curves: dict[int, list[ProjectorResult]],
+    predictor_kind: str,
+) -> tuple[float, float]:
+    predictors: list[float] = []
+    differences: list[float] = []
+    for length, results in curves.items():
+        ordered = sorted(results, key=lambda result: result.flux)
+        reference = ordered[0].energy
+        for result in ordered[1:]:
+            flux = float(result.flux)
+            if predictor_kind == "quadratic_over_length":
+                predictor = flux**2 / length
+            elif predictor_kind == "linear":
+                predictor = flux
+            elif predictor_kind == "linear_over_length":
+                predictor = flux / length
+            elif predictor_kind == "quadratic":
+                predictor = flux**2
+            elif predictor_kind == "step":
+                predictor = 1.0
+            else:
+                raise ValueError(predictor_kind)
+            predictors.append(predictor)
+            differences.append(result.energy - reference)
+    x_values = np.asarray(predictors, dtype=float)
+    y_values = np.asarray(differences, dtype=float)
+    slope = float(np.dot(x_values, y_values) / np.dot(x_values, x_values))
+    residual = y_values - slope * x_values
+    return slope, float(np.dot(residual, residual))
+
+
+def main() -> int:
+    checks = Checks()
+    detunings = (-0.05, -0.10)
+
+    geometry_ok = True
+    for length in (2, 4, 6, 8, 10):
+        geometry = build_geometry(length)
+        geometry_ok = geometry_ok and bool(
+            geometry.plaquette_links.shape == (3 * length**3, 4)
+            and np.all(geometry.affected_counts > 0)
+            and np.all(geometry.affected_counts <= geometry.affected_plaquettes.shape[1])
+            and all(len(set(int(link) for link in links)) == 4 for links in geometry.plaquette_links)
+        )
+    checks.check(
+        geometry_ok,
+        "the L=2,4,6,8,10 projector geometries contain exactly 3L^3 four-link square moves",
+    )
+    neutral_starts_ok = all(
+        np.all(vertex_degrees(neutral_flux_pair_start(8, axis, axis)) == 3)
+        and electric_flux(neutral_flux_pair_start(8, axis, axis)) == (0, 0, 0)
+        for axis in range(3)
+    )
+    checks.check(
+        neutral_starts_ok,
+        "opposite noncontractible line pairs provide three nonlocal zero-flux initialization controls",
+    )
+
+    exact_controls: list[tuple[float, int, float, float, ProjectorResult]] = []
+    for detuning_index, delta_v in enumerate(detunings):
+        for flux in (0, 1):
+            exact, exact_mixed = exact_small_energy(delta_v, flux)
+            projector = run_population(
+                2,
+                flux,
+                delta_v,
+                population=2048,
+                classical_sweeps=100,
+                burn_sweeps=200,
+                sample_sweeps=500,
+                seed=1_200_000 + 10_000 * detuning_index + flux,
+            )
+            exact_controls.append(
+                (delta_v, flux, exact, exact_mixed, projector)
+            )
+    checks.check(
+        all(abs(exact - mixed) < 1.0e-9 for _, _, exact, mixed, _ in exact_controls),
+        "the exact L=2 eigenvectors satisfy the constant-trial mixed-estimator identity in both flux sectors",
+    )
+    checks.check(
+        all(
+            abs(projector.energy - exact)
+            < max(8.0 * projector.energy_error, 0.004)
+            for _, _, exact, _, projector in exact_controls
+        ),
+        "the stochastic projector reproduces four exact L=2 ground energies at V=0.95 and V=0.90",
+    )
+
+    primary: dict[tuple[float, int], list[ProjectorResult]] = {}
+    all_projectors = [control[-1] for control in exact_controls]
+    for detuning_index, delta_v in enumerate(detunings):
+        for length in (4, 6, 8):
+            curve: list[ProjectorResult] = []
+            for flux in range(length // 2 + 1):
+                result = run_population(
+                    length,
+                    flux,
+                    delta_v,
+                    population=256,
+                    classical_sweeps=100,
+                    burn_sweeps=150,
+                    sample_sweeps=300,
+                    seed=(
+                        2_000_000
+                        + 100_000 * detuning_index
+                        + 100 * length
+                        + flux
+                    ),
+                )
+                curve.append(result)
+                all_projectors.append(result)
+            primary[(delta_v, length)] = curve
+
+    endpoint_ten: dict[float, tuple[ProjectorResult, ProjectorResult]] = {}
+    for detuning_index, delta_v in enumerate(detunings):
+        pair = tuple(
+            run_population(
+                10,
+                flux,
+                delta_v,
+                population=256,
+                classical_sweeps=100,
+                burn_sweeps=150,
+                sample_sweeps=300,
+                seed=2_500_000 + 100_000 * detuning_index + flux,
+            )
+            for flux in (0, 5)
+        )
+        endpoint_ten[delta_v] = pair
+        all_projectors.extend(pair)
+
+    checks.check(
+        all(
+            result.count_consistent and result.sector_consistent
+            for result in all_projectors
+        ),
+        "every projector population preserves exact local flippability, three-of-six Gauss charge, and assigned flux",
+    )
+    checks.check(
+        min(
+            result.minimum_effective_population_fraction
+            for result in all_projectors
+        )
+        > 0.90
+        and min(result.final_unique_fraction for result in all_projectors if result.length >= 4)
+        > 0.25,
+        "all populations retain effective weight and final-state diversity above the declared collapse controls",
+    )
+
+    curve_fits = [
+        fit_flux_curve(primary[(delta_v, length)])
+        for delta_v in detunings
+        for length in (4, 6, 8)
+    ]
+    checks.check(
+        all(
+            fit.electric_stiffness > 6.0 * fit.electric_stiffness_error
+            for fit in curve_fits
+        ),
+        "every L=4,6,8 finite-detuning flux ladder has resolved positive electric stiffness",
+    )
+    checks.check(
+        all(
+            fit.quadratic_rss < 0.25 * fit.linear_rss
+            for fit in curve_fits
+        ),
+        "Phi^2/L beats a linear-in-|Phi| curve separately on every full flux ladder",
+    )
+
+    endpoint_ten_fits = {
+        delta_v: endpoint_stiffness(*endpoint_ten[delta_v])
+        for delta_v in detunings
+    }
+    checks.check(
+        all(value > 6.0 * error for value, error in endpoint_ten_fits.values()),
+        "the shrinking-density L=10 endpoints independently retain positive stiffness",
+    )
+
+    controls: dict[float, tuple[ProjectorResult, ProjectorResult]] = {}
+    for detuning_index, delta_v in enumerate(detunings):
+        pair = tuple(
+            run_population(
+                8,
+                flux,
+                delta_v,
+                population=512,
+                classical_sweeps=150,
+                burn_sweeps=250,
+                sample_sweeps=500,
+                seed=3_000_000 + 100_000 * detuning_index + flux,
+                start_family=detuning_index + 1,
+            )
+            for flux in (0, 4)
+        )
+        controls[delta_v] = pair
+    control_fits = {
+        delta_v: endpoint_stiffness(*controls[delta_v])
+        for delta_v in detunings
+    }
+    primary_eight = {
+        delta_v: endpoint_stiffness(
+            primary[(delta_v, 8)][0], primary[(delta_v, 8)][-1]
+        )
+        for delta_v in detunings
+    }
+    checks.check(
+        all(
+            control > 6.0 * error
+            and abs(control - primary_eight[delta_v][0])
+            / (0.5 * (control + primary_eight[delta_v][0]))
+            < 0.15
+            for delta_v, (control, error) in control_fits.items()
+        ),
+        "doubled L=8 populations reproduce the positive endpoint stiffness within fifteen percent",
+    )
+
+    global_results: dict[float, dict[str, tuple[float, float]]] = {}
+    for delta_v in detunings:
+        curves = {
+            length: primary[(delta_v, length)] for length in (4, 6, 8)
+        }
+        curves[10] = list(endpoint_ten[delta_v])
+        global_results[delta_v] = {
+            kind: model_rss(curves, kind)
+            for kind in (
+                "quadratic_over_length",
+                "linear",
+                "linear_over_length",
+                "quadratic",
+                "step",
+            )
+        }
+    checks.check(
+        all(
+            global_results[delta_v]["quadratic_over_length"][1]
+            < 0.20
+            * min(
+                global_results[delta_v][kind][1]
+                for kind in (
+                    "linear",
+                    "linear_over_length",
+                    "quadratic",
+                    "step",
+                )
+            )
+            for delta_v in detunings
+        ),
+        "the joint L=4,6,8,10 data prefer Maxwell Phi^2/L scaling over four named controls",
+    )
+
+    first_order_normalized = 3.183873
+    volume_stiffness: dict[float, list[float]] = {}
+    for delta_v in detunings:
+        values = [
+            next(
+                fit.electric_stiffness
+                for fit in curve_fits
+                if fit.delta_v == delta_v and fit.length == length
+            )
+            for length in (4, 6)
+        ]
+        values.append(control_fits[delta_v][0])
+        values.append(endpoint_ten_fits[delta_v][0])
+        volume_stiffness[delta_v] = values
+    checks.check(
+        all(
+            (max(values) - min(values)) / np.mean(values) < 0.20
+            and abs(np.mean(values) / abs(delta_v) - first_order_normalized)
+            / first_order_normalized
+            < 0.20
+            for delta_v, values in volume_stiffness.items()
+        ),
+        "the volume ladder is stable and remains near the independent first-order U/|delta V| coefficient",
+    )
+
+    for delta_v, flux, exact, _, projector in exact_controls:
+        print(
+            "EXACT",
+            f"V={1.0 + delta_v:.2f}",
+            f"Phi={flux}",
+            f"E0={exact:.9f}",
+            f"projector={projector.energy:.9f}+/-{projector.energy_error:.9f}",
+        )
+    for fit in curve_fits:
+        print(
+            "CURVE",
+            f"V={1.0 + fit.delta_v:.2f}",
+            f"L={fit.length}",
+            f"U={fit.electric_stiffness:.6f}+/-{fit.electric_stiffness_error:.6f}",
+            f"rss_quad={fit.quadratic_rss:.8f}",
+            f"rss_linear={fit.linear_rss:.8f}",
+        )
+    for delta_v in detunings:
+        print(
+            "POPULATION_CONTROL",
+            f"V={1.0 + delta_v:.2f}",
+            f"U_256={primary_eight[delta_v][0]:.6f}",
+            f"U_512={control_fits[delta_v][0]:.6f}+/-{control_fits[delta_v][1]:.6f}",
+        )
+    for delta_v in detunings:
+        print(
+            "DATA",
+            f"V={1.0 + delta_v:.2f}",
+            "U_L="
+            + ",".join(
+                f"{length}:{value:.6f}"
+                for length, value in zip(
+                    (4, 6, 8, 10), volume_stiffness[delta_v], strict=True
+                )
+            ),
+            f"U/|deltaV|={np.mean(volume_stiffness[delta_v]) / abs(delta_v):.6f}",
+            f"global_rss={global_results[delta_v]['quadratic_over_length'][1]:.8f}",
+        )
+        print(
+            "MODEL_CONTROL",
+            f"V={1.0 + delta_v:.2f}",
+            "rss="
+            + ",".join(
+                f"{kind}:{global_results[delta_v][kind][1]:.8f}"
+                for kind in (
+                    "quadratic_over_length",
+                    "linear",
+                    "linear_over_length",
+                    "quadratic",
+                    "step",
+                )
+            ),
+        )
+    print(
+        "CERTIFICATE: exact_stoquastic_green_function=True constant_trial_mixed_estimator=True "
+        "finite_population=True finite_imaginary_time=True thermodynamic_limit=False "
+        "real_time_spectrum=False"
+    )
+    print(
+        "RESOLUTION: per_element=every accepted square flip; per_site=all final walkers preserve Gauss; "
+        "per_mode=electric topological flux; per_block=exact L2 plus projector L4,6,8,10; "
+        "lattice_wide=finite-volume finite-detuning stiffness, not a thermodynamic phase proof"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Extends the spin-half cubic-ice photon bridge beyond first order at the RK point with an exact-positive stoquastic projector calculation at two finite detunings.

- Uses the exact Green function `G = I - H/M` and the constant-trial mixed estimator, calibrated against complete `L=2` exact diagonalization in zero- and unit-flux components.
- Computes every integer flux magnitude through `L/2` on `L=4,6,8`, plus shrinking-density endpoints on `L=10`, at `V=0.95` and `V=0.90`.
- Finds positive, volume-stable `Phi^2/L` electric stiffness: mean `U/|delta V| = 3.252761` and `3.211140`, close to the parent first-order `3.183873`.
- Doubles the `L=8` population and changes to a nonlocal neutral winding-pair initialization; endpoint stiffness agrees within the declared 15% control.
- Joint Maxwell-scaling residuals are `0.00014972` and `0.00007401`, each below 20% of the best linear, unscaled-quadratic, or sector-step control.

## Verification

`python3 scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py`

`TOTAL: PASS=12 FAIL=0` in the identity-pinned cache, 266.42 seconds.

Targeted staged claim typing, cache freshness, citation graph, enforced repository invariants, strict audit lint, diff check, and vocabulary lint all pass. Strict lint reports only repository-baseline warnings/notices and zero errors.

## Boundary

Bounded finite-volume evidence on declared mobile components. Fixed finite populations and projection times remain; all disconnected components are not classified. This does not establish a thermodynamic phase, finite-detuning magnetic stiffness, real-time linear photon pole, physical-site compiler, law selection, or empirical electromagnetic identification. It changes no audit verdict, TOE score, axiom, or approved primitive.

Stacked on #7937.
