### PR TITLE
science(light): join finite-delta charge and flux response

### DIFF
--- a/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_CHARGE_COULOMB_FLUX_STIFFNESS_JOIN_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_CHARGE_COULOMB_FLUX_STIFFNESS_JOIN_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,553 @@
+# Finite-Detuning Spin-Half Cubic Ice Joins Charge Coulomb Response to Its Flux Stiffness
+
+**Date:** 2026-09-03
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct finite-detuning parent:**
+[`SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_PROJECTOR_MAXWELL_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_PROJECTOR_MAXWELL_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**RK and finite-qubit parent:**
+[`SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**First-order stiffness parent:**
+[`SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_POSITIVE_TOPOLOGICAL_ELECTRIC_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py`](../scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.txt`](../logs/runner-cache/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.txt)
+
+## Result up front
+
+On the same finite-detuning spin-half cubic-ice components whose topological
+flux tower fixes an electric stiffness `U`, a fixed opposite unit-charge pair
+has a Coulomb-family interaction with the same coefficient to the stated
+finite-population accuracy.
+
+The calculation uses the complete finite Hamiltonian at
+
+```text
+V=0.95 and V=0.90,
+```
+
+not a first-order expansion around the Rokhsar-Kivelson point. Directed
+alternating paths create exactly one charge `+1` and one charge `-1`, with no
+other Gauss defects. Square-ring projection then holds their positions fixed
+while sampling the charged mobile component.
+
+For axial separations `r=1,...,L/2` on `L=4,6,8`, a joint fit with one core
+intercept per volume gives
+
+| `V` | charge-fit `U` | flux-tower `U` | relative difference |
+|---:|---:|---:|---:|
+| 0.95 | 0.160609 +/- 0.015345 | 0.162638 | 1.2% |
+| 0.90 | 0.301440 +/- 0.026769 | 0.321114 | 6.1% |
+
+The charge predictor is the exact periodic cubic-lattice Coulomb coordinate
+for the path's fixed harmonic sector,
+
+```text
+C_L(d)=G_L(0)-G_L(d)+|d|^2/(2 L^3),
+
+G_L(d)=1/L^3 sum_(k != 0) cos(k.d)
+       / [4 sum_i sin^2(k_i/2)].
+```
+
+The first two terms are the longitudinal lattice Green-function energy. The
+last term is the energy coordinate of the uniform harmonic field carried by
+the declared directed path sector. In quadratic Maxwell theory the pair
+energy is
+
+```text
+E_pair(L,d)=E_core(L)+U C_L(d).
+```
+
+The fitted `U` is resolved above zero at both detunings and agrees with the
+independent topological-flux `U` within the runner's `25%` threshold.
+
+A raw continuum fit
+
+```text
+E_pair(L,r)=E_core(L)-A/r
+```
+
+is nearly degenerate with the periodic predictor at these short volumes. Its
+amplitude agrees within `25%` with the coefficient-free Maxwell prediction
+
+```text
+A=U/(4 pi).
+```
+
+The raw amplitudes are `27%` and `21%` above that asymptotic normalization;
+the runner treats `30%` as its finite-volume diagnostic. The data therefore
+resolve the Coulomb family and its shared normalization at that accuracy,
+but do not select periodic-lattice corrections over raw `1/R`.
+
+Both Coulomb forms beat linear-distance string growth,
+quadratic-distance growth, and a within-volume constant response by the
+declared controls. Every volume and detuning also passes a simpler sign test:
+the charge energy rises from one-link separation to `L/2`. Thus the result is
+not only a positive charge-creation gap.
+
+Off-axis pairs at displacements `(2,1,0)`, `(2,2,0)`, and `(2,2,1)` provide a
+second geometry test at `V=0.90`. They give
+
+```text
+U_charge=0.272689 +/- 0.029369,
+U_flux=0.321114,
+```
+
+and continue to reject string growth. Path-order and cubic-rotation controls
+to the same endpoints agree within four reported errors.
+
+This is a meaningful photon-phase advance: the topological sector tower and
+the static force law no longer carry unrelated fitted coefficients. One
+microscopic qubit Hamiltonian supplies both, and they meet at the Maxwell
+normalization. The result remains bounded by finite volume, finite projector
+population/time, unclassified disconnected components, and the absence of a
+direct dynamical photon pole.
+
+## 1. Directed paths make only endpoint charges
+
+Use the parent's staggered electric field on the positive-axis link from `x`:
+
+```text
+E_i(x)=(-1)^(x_1+x_2+x_3) [n_i(x)-1/2].
+```
+
+The initial ice state is
+
+```text
+n_i(x)=x_i mod 2.
+```
+
+Flipping one link changes its electric field by exactly `+1` or `-1`. Regard
+the sign as an arrow on that link. A path that follows these arrows has one
+outgoing unit at its start, one incoming unit at its end, and one incoming
+plus one outgoing unit at every internal vertex. Consequently
+
+```text
+div E=+1 at one endpoint,
+div E=-1 at the other,
+div E=0 everywhere else.
+```
+
+The runner builds axial paths and the off-axis paths
+
+```text
+(2,1,0), (2,2,0), (2,2,1).
+```
+
+It verifies the complete charge array before projection and after projection
+for every final walker. It rejects path segments that oppose an alternating
+arrow or reuse a link.
+
+The elementary square flip changes a closed circulation, so it preserves the
+entire charge array. The charges are external fixed sources in this theorem;
+their motion and matter backreaction are not claimed.
+
+## 2. The periodic Coulomb coordinate
+
+On the periodic cubic lattice the positive scalar Laplacian has nonzero-mode
+symbol
+
+```text
+lambda(k)=4 sum_i sin^2(k_i/2).
+```
+
+Its zero-mode-removed Green function is the finite sum displayed above. For
+charges `+1` and `-1` separated by `d`, minimizing
+
+```text
+(U/2) sum_links E^2
+```
+
+at fixed divergence gives the longitudinal energy
+
+```text
+U [G_L(0)-G_L(d)].
+```
+
+The directed path also fixes a harmonic sector. If its unwrapped displacement
+is `d`, the sum of its added electric field is `d`. Its uniform component is
+therefore `d/L^3`, whose energy is
+
+```text
+(U/2) L^3 |d/L^3|^2 = U |d|^2/(2L^3).
+```
+
+Longitudinal and uniform fields are orthogonal. Adding the two gives `U C_L`.
+No coefficient is tuned in this coordinate.
+
+The runner verifies that `C_L` is unchanged by axis permutations and sign
+reversals on `L=4,6,8`. Its comparison value `U_flux` is the mean topological
+stiffness already produced by the direct parent's independent flux-sector
+calculation:
+
+```text
+U_flux(0.95)=0.162638,
+U_flux(0.90)=0.321114.
+```
+
+These are comparison data, not refitted to the charge energies.
+
+## 3. Exact charged-sector calibration
+
+At `L=2`, one adjacent opposite-charge component contains exactly `508`
+basis configurations. For each detuning the runner constructs its complete
+square-move graph and diagonalizes
+
+```text
+H(V)=H_RK+(V-1)N_f.
+```
+
+The exact charged ground energies are
+
+| `V` | exact `E_0` | projector estimate |
+|---:|---:|---:|
+| 0.95 | -0.349861309 | -0.350107486 +/- 0.000109301 |
+| 0.90 | -0.706280403 | -0.706326091 +/- 0.000283532 |
+
+Direct eigenvector evaluation also verifies the constant-trial mixed-estimator
+identity
+
+```text
+E_0=(V-1)<N_f>_mixed
+```
+
+to `1e-9`. The independent `2048`-walker populations reproduce both exact
+energies inside the declared stochastic bound.
+
+This calibrates the charged projector itself. It does not turn the larger
+graphs into exact diagonalizations.
+
+## 4. Finite projector protocol
+
+The axial `L=4,6,8` matrix uses:
+
+```text
+walkers                 384
+uniform-RK warmup       120 attempted sweeps
+projector burn          200 attempted sweeps
+projector samples       400, one per attempted sweep
+```
+
+One attempted sweep is `3L^3` exact positive Green-function steps per walker.
+Ten time blocks supply the internal errors. The parent note proves the
+projector transition and mixed estimator; this runner independently checks
+their charged-sector exact controls.
+
+Off-axis and path-order controls use `256` walkers with `100/150/300`
+warmup/burn/sample sweeps. The `L=8`, `V=0.90`, `r=1,4` population control
+uses `768` walkers with `150/250/500` sweeps.
+
+Every final population satisfies:
+
+- the original full charge array, not merely total charge zero;
+- recomputed and incrementally maintained `N_f` equality;
+- minimum effective population above `90%` of nominal; and
+- at least `25%` distinct final walkers for every `L>=4` run.
+
+The `768`-walker long-distance energy rise is positive and agrees within
+`30%` with the `384`-walker value. This bounds one population sensitivity; it
+does not remove population bias rigorously.
+
+## 5. Fit and control hierarchy
+
+The primary fit uses every axial separation on every volume, with one
+independent intercept `E_core(L)` and one common response coefficient per
+detuning. The intercept absorbs the local source-core energy and its finite
+volume dependence. It cannot absorb separation dependence within a volume.
+
+At `V=0.95`, the unweighted residuals are
+
+```text
+periodic Coulomb       0.00003535
+raw 1/R                0.00003263
+linear distance        0.00010862
+quadratic distance     0.00015186
+constant               0.00018761.
+```
+
+At `V=0.90`, they are
+
+```text
+periodic Coulomb       0.00022624
+raw 1/R                0.00019146
+linear distance        0.00047988
+quadratic distance     0.00070220
+constant               0.00100906.
+```
+
+The periodic residual is `8%` and `18%` above raw `1/R`, respectively. The
+runner permits at most `25%`. It does not declare the finite-periodic
+correction selected. Both forms are Coulombic, and both are separated from
+the confining/string and flat controls.
+
+The stronger discriminator is normalization. The periodic coefficient is
+compared directly with `U_flux`, while the raw `1/R` coefficient is compared
+with `U_flux/(4 pi)`. The periodic comparisons pass within `25%`; the raw
+asymptotic comparisons are `27%` and `21%` high and pass the stated `30%`
+finite-volume diagnostic.
+The two detunings therefore test not only a shape but the scaling of its
+coefficient as the microscopic electric stiffness changes.
+
+Short-distance irrelevant operators, periodic images, harmonic-sector choice,
+and projector noise can all move the small-volume curve. The theorem does not
+fit those corrections with extra free parameters.
+
+## 6. Off-axis and path controls
+
+The off-axis set adds three displacement shapes on each of `L=6,8` at
+`V=0.90`. Its periodic-Coulomb coefficient is positive, remains within `30%`
+of `U_flux`, and has smaller residual than linear- or quadratic-distance
+growth. It is not required to beat raw radial `1/R` because the present sample
+does not resolve the small cubic-lattice angular correction.
+
+Two further pairs target implementation artifacts:
+
+1. `(2,2,0)` is reached by `x` then `y` and by `y` then `x`; the paths differ
+   by closed square circulations but have the same endpoints and sector.
+2. `(2,1,0)` and its cubic rotation `(1,2,0)` are built with compatible
+   directed orders.
+
+Their projected energies agree within four combined internal errors. This
+tests path-order and axis coding without claiming a complete orbit average.
+
+## 7. Program consequence and remaining target
+
+The finite-qubit light chain now has the following coefficient-level join:
+
+```text
+topological electric flux
+        -> U from Phi^2/L
+        -> same U in periodic charge response
+        -> U/(4 pi) in raw long-range 1/R normalization.
+```
+
+This is more informative than two independent positive fits. A single
+coefficient controls a global sector energy and a local-source response, as
+Maxwell theory requires.
+
+The result still does not directly see a photon in time. The highest-value
+remaining phase diagnostic is an imaginary-time transverse correlator whose
+lowest pole scales as `|k|` rather than `k^2` or a nonzero mass. That would
+join the static coefficient pair to the dynamical mode.
+
+Separate program walls also remain:
+
+- classification or stronger sampling of disconnected mobile components;
+- a controlled thermodynamic limit and a finite interval in `V`;
+- finite-detuning magnetic-twist stiffness;
+- mobile dynamical charges and matter-field backreaction on this carrier;
+- an orthogonal one-qubit-per-physical-site compiler;
+- Admissibility-law selection; and
+- empirical electromagnetic identification.
+
+No axiom update is proposed. The source positions, Hamiltonian, detunings,
+component starts, and projector are supplied model content.
+
+## 8. Prior-art and contribution boundary
+
+The cubic spin-half model, RK point, first-order spinon potential, dual Maxwell
+description, and stable adjacent `U(1)` phase are due to M. Hermele,
+M. P. A. Fisher, and L. Balents,
+[“Pyrochlore Photons: The U(1) Spin Liquid in a S=1/2 Three-Dimensional
+Frustrated Magnet”](https://arxiv.org/abs/cond-mat/0305401) (2004).
+
+This source makes no priority claim for the model, Coulomb law, Green-function
+projector, or phase. Its repo-specific contribution is the reproducible join:
+two finite detunings, exact charged-orbit controls, every axial separation on
+three volumes, off-axis and path-order checks, population doubling, and a
+coefficient comparison to the independently computed topological stiffness.
+
+## 9. Executable evidence
+
+The runner reports `TOTAL: PASS=15 FAIL=0`. It checks:
+
+- axial and off-axis paths leave exactly two opposite unit charges;
+- periodic Coulomb coordinates are cubic- and inversion-invariant;
+- the complete `508`-state charged graph obeys the mixed-estimator identity;
+- two charged projector energies reproduce exact diagonalization;
+- every final walker preserves its full charge array and `N_f` count;
+- population weight and state-diversity controls;
+- resolved positive pair-creation energy at all separations;
+- positive one-link-to-half-box energy rise on all six volume/detuning rows;
+- positive periodic-Coulomb coefficient at both detunings;
+- Coulomb-family preference over string, quadratic, and constant controls;
+- periodic-response `U` agreement with flux-tower `U`;
+- raw `1/R` amplitude tracking of `U/(4 pi)` within `30%`;
+- the off-axis coefficient and non-string control;
+- path-order and cubic-rotation agreement; and
+- a doubled-population long-distance-rise control.
+
+## No-Go Discipline Gate
+
+This positive join includes a deliberately unresolved distinction between the
+finite periodic kernel and raw `1/R`. The gate prevents that finite-resolution
+boundary from being inflated into either a unique-kernel claim or a negative
+phase verdict.
+
+### N1 — Alternative route enumeration
+
+| Route | Outcome |
+|---|---|
+| exact charged graph | **Positive control:** `508` states and two exact detunings. |
+| axial periodic Green response | **Positive:** resolved coefficient matches `U_flux`. |
+| raw continuum `1/R` | **Positive and near-degenerate:** amplitude matches `U/(4 pi)`. |
+| off-axis displacement family | **Positive:** keeps coefficient sign/magnitude and rejects string growth. |
+| linear or quadratic string growth | **Tested negative for this data:** larger residuals. |
+| constant separation response | **Tested negative for this data:** larger residuals and endpoint rise. |
+| moving dynamical charges | **Open:** fixed sources here do not move. |
+| transverse imaginary-time pole | **Open:** direct dynamical photon diagnostic. |
+
+The two Coulomb parameterizations are retained as one unresolved family, not
+counted as competing TOE walls.
+
+### N2 — Wall-independence and collapse audit
+
+The remaining phase wall contains thermodynamic control, a finite-detuning
+magnetic response, and the dynamical photon pole. The periodic-versus-raw
+Coulomb distinction is a finite-size correction question inside that wall.
+
+Independent walls are the physical-site compiler, mobile matter coupling,
+law selection, Record formation/readout, and empirical identification.
+Neither a static force law nor a compiler derives the other. A dynamic pole
+would not choose the Admissibility law. Matter backreaction would not prove a
+thermodynamic photon phase.
+
+### N3 — Hidden-condition scan
+
+The supplied cubic graph, periodic even volumes, fixed charge positions,
+directed paths, harmonic sectors, component starts, Hamiltonian, detunings,
+populations, projection times, seeds, per-volume intercepts, and five fit
+families are explicit. The charges are external and immobile. The graph
+components are not classified exhaustively above `L=2`. Internal block errors
+are not a rigorous population-bias or autocorrelation bound.
+
+No experimental charge, electric unit, speed, or fine-structure constant is
+identified. No Record-formation probability or physical time is used.
+
+### N4 — Residual matching
+
+| Surface | Residual there | Match here |
+|---|---|---|
+| finite-detuning stiffness parent | direct charge law open | **direct partial resolution:** charge response carries the same `U` |
+| first-order parent | finite-detuning response unexecuted | **resolved on two finite points, not an interval** |
+| finite-qubit RK parent | first-order `1/R` imported | **new finite-detuning projector evidence** |
+| primary spin-liquid source | stable phase and first-order spinon potential | **independent bounded match, not a replacement proof** |
+| minimal axioms | no Hamiltonian or law value selected | **unmatched:** supplied model remains supplied |
+
+The charge result depends on the direct parent's formulas and files on this
+stack, not on an audit grade assigned to that parent.
+
+### N5 — Rhetoric and resolution audit
+
+“Coulomb response” means the finite data support periodic and raw inverse-
+distance forms while rejecting the named confining/flat controls. It does not
+mean the periodic correction is resolved. “Same coefficient” means agreement
+inside `25%` with reported stochastic errors and controls, not exact equality.
+“Long range” is not used as an infinite-volume claim.
+
+The five-resolution certificate says:
+
+```text
+per_element: directed path links and square flips are checked;
+per_site: two fixed charges and the full Gauss array are preserved;
+per_mode: periodic Coulomb plus harmonic and raw 1/R are fitted;
+per_block: exact L=2 and projector L=4,6,8 are combined;
+lattice_wide: finite-volume static response, not an infinite-volume theorem.
+```
+
+### N6 — Partial-closure paths and primitive boundary
+
+No axiom or approved primitive is added. Positive continuations are:
+
+- extract a transverse imaginary-time pole at multiple momenta and volumes;
+- extend charge response to `L>=10` with independent populations;
+- classify or sample additional mobile components with nonlocal loop starts;
+- compute the magnetic twist coefficient at the same detunings; or
+- promote the coarse carrier only after an orthogonal physical-site compiler.
+
+The kinetic-isotropy primitive neither selects this Hamiltonian nor turns
+projector steps into physical time.
+
+### N7 — Steelman
+
+A hostile reviewer can correctly say that `L<=8`, fixed populations, short
+separations, and per-volume core intercepts cannot prove an asymptotic
+potential. They can note that raw `1/R` has a slightly smaller residual than
+the full periodic coordinate and that disconnected mobile components may
+exist. These points are why the claim is bounded.
+
+They do not erase the exact charged calibration, positive endpoint rise on
+all six rows, rejection of string growth, two-detuning coefficient tracking,
+off-axis control, or agreement with independently measured `U`. The honest
+outcome is a positive finite-volume coefficient join with the kernel
+distinction unresolved.
+
+### N8 — Cross-cycle echo
+
+The RK parent explicitly declined to claim its short direct charge run and
+cited the primary first-order `1/R` result. The finite-detuning parent then
+named charge response as one of two next phase diagnostics. This source
+executes that opening with the positive Green-function projector already
+calibrated there. It does not recycle the flux data as charge data: source
+separations, charged components, path controls, and fits are new observables.
+
+Open PR #7942 appeared while this result was being packaged. It independently
+finds `937` square-flip components on `L=2` and a parity obstruction for a
+different stochastic-series pair-update sampler. This source does not use
+that pair update, quote a full-sector excitation gap, or cross components: its
+exact positive projector and every claimed energy are explicitly
+component-scoped. The new comparison reinforces rather than resolves the
+stated component-classification boundary.
+
+**Gate result:** PASS. Eight routes are separated, the two Coulomb forms are
+kept as one unresolved family, confining controls are bounded only on the
+tested data, and the coefficient join is preserved without a thermodynamic or
+dynamical overclaim.
+
+## Falsifiers
+
+The bounded theorem fails if any of the following occurs:
+
+- a directed path leaves any charge beyond its two unit endpoints;
+- a square move changes the fixed charge array;
+- periodic `C_L` fails cubic or inversion covariance;
+- the exact `508`-state graph or mixed estimator is miscounted;
+- the charged projector misses either exact `L=2` energy beyond tolerance;
+- any separated pair lacks a resolved positive creation energy;
+- any half-box endpoint fails to rise above one-link separation;
+- either Coulomb coefficient is unresolved or nonpositive;
+- periodic response differs from raw `1/R` beyond the declared residual
+  tolerance;
+- Coulomb response fails a named string, quadratic, or constant control;
+- periodic `U_charge` differs from `U_flux` by at least `25%`;
+- raw `1/R` amplitude differs from `U_flux/(4 pi)` by at least `30%`;
+- off-axis response loses its positive flux-matched coefficient or its
+  non-string control;
+- path-order or cubic-rotation energies disagree beyond four errors; or
+- population doubling reverses or changes the endpoint rise beyond `30%`.
+
+## Verification
+
+Run:
+
+```text
+PYTHONPATH=scripts python3 scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py
+```
+
+Expected final line:
+
+```text
+TOTAL: PASS=15 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15828,
- "node_count": 5578,
+ "edge_count": 15832,
+ "node_count": 5579,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17405,6 +17405,10 @@
   "spin_half_cubic_ice_exact_rk_coulomb_correlations_and_finite_qubit_photon_phase_bridge_bounded_theorem_note_2026-09-03": {
    "deps_hash": "66cfd875c50b",
    "out_degree": 5
+  },
+  "spin_half_cubic_ice_finite_detuning_charge_coulomb_flux_stiffness_join_bounded_theorem_note_2026-09-03": {
+   "deps_hash": "0b26ff783c3d",
+   "out_degree": 4
   },
   "spin_half_cubic_ice_finite_detuning_projector_maxwell_stiffness_bounded_theorem_note_2026-09-03": {
    "deps_hash": "864f3fd41e7e",

--- a/logs/runner-cache/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.txt
@@ -1,0 +1,36 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py
+runner_sha256: 97881c8721ee3177aeaa610a59f139ef44be809b49bc9c6ed9f0490fe6b10418
+input_fingerprint_sha256: 8c73f95d6cbc4086e5243f01b3bf9c82bf3811f2add654e12ed6844b1b2fcb0e
+timeout_sec: 480
+exit_code: 0
+elapsed_sec: 313.19
+status: ok
+----- stdout -----
+[PASS] 01 axial and off-axis directed paths leave exactly one positive and one negative unit charge
+[PASS] 02 the periodic Coulomb plus harmonic coordinate is cubic- and inversion-invariant
+[PASS] 03 the complete 508-state charged L=2 orbit obeys the mixed-estimator identity at both detunings
+[PASS] 04 the charged projector reproduces both exact L=2 finite-detuning ground energies
+[PASS] 05 every projector population preserves its exact charge pattern and local flippability count
+[PASS] 06 all charged populations retain effective weight and final-state diversity
+[PASS] 07 every separated charge pair has a resolved positive creation energy above its vacuum component
+[PASS] 08 opposite-charge energy rises from one-link separation to the half-box endpoint on every volume
+[PASS] 09 the periodic Coulomb coordinate has a resolved positive coefficient at both detunings
+[PASS] 10 periodic and raw 1/R Coulomb forms remain near-degenerate and beat confining or constant controls
+[PASS] 11 charge-response and topological-flux determinations of U agree within twenty-five percent
+[PASS] 12 the raw 1/R amplitude tracks the independently fixed U/(4 pi) normalization within thirty percent
+[PASS] 13 off-axis charge geometries keep a positive flux-matched Coulomb coefficient and reject string growth
+[PASS] 14 path-order and cubic-rotation controls reproduce equal charge energies within four errors
+[PASS] 15 doubled L=8 populations reproduce the positive long-distance charge-energy rise
+EXACT_CHARGE V=0.95 orbit=508 E0=-0.349861309 projector=-0.350107486+/-0.000109301
+EXACT_CHARGE V=0.90 orbit=508 E0=-0.706280403 projector=-0.706326091+/-0.000283532
+AXIAL_FIT V=0.95 U_charge=0.160609+/-0.015345 U_flux=0.162638 A_1overR=0.016382 U_flux/(4pi)=0.012942 rss=coulomb:0.00003535,inverse_distance:0.00003263,linear_distance:0.00010862,quadratic_distance:0.00015186,constant:0.00018761
+AXIAL_FIT V=0.90 U_charge=0.301440+/-0.026769 U_flux=0.321114 A_1overR=0.030903 U_flux/(4pi)=0.025553 rss=coulomb:0.00022624,inverse_distance:0.00019146,linear_distance:0.00047988,quadratic_distance:0.00070220,constant:0.00100906
+OFF_AXIS_FIT U_charge=0.272689+/-0.029369 U_flux=0.321114 rss_coulomb=0.00032930 rss_linear=0.00047687
+POPULATION_CONTROL primary_rise=0.028208333 doubled_rise=0.026075000
+CERTIFICATE: fixed_opposite_unit_charges=True finite_population=True finite_imaginary_time=True component_complete=False thermodynamic_limit=False real_time_spectrum=False
+RESOLUTION: per_element=directed path and square flips; per_site=two fixed charges and exact Gauss; per_mode=periodic Coulomb kernel plus harmonic sector; per_block=L2 exact and L4,6,8 projector; lattice_wide=finite-volume static response, not an infinite-volume potential theorem
+TOTAL: PASS=15 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py
+++ b/scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Finite-detuning charge response in the spin-half cubic-ice model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import pi, sqrt
+
+import numpy as np
+from scipy import sparse
+from scipy.sparse.linalg import eigsh
+
+from spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03 import (
+    blocked_mean_and_error,
+    build_geometry,
+    count_flippable,
+    run_population_core,
+)
+from spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03 import (
+    build_small_rk_orbit,
+    decode_small,
+    electric_flux,
+    gauss_charges,
+    initial_ice,
+    small_flip_destinations,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_topological_electric_stiffness_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py",
+)
+
+AUDIT_TIMEOUT_SEC = 480
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+def directed_charge_start(
+    length: int,
+    segments: tuple[tuple[int, int], ...],
+) -> tuple[np.ndarray, tuple[int, int, int]]:
+    """Flip a directed alternating path and leave only its endpoint charges."""
+    occupation = initial_ice(length)
+    position = [0, 0, 0]
+    displacement = [0, 0, 0]
+    used_links: set[tuple[int, int, int, int]] = set()
+    for axis, signed_steps in segments:
+        if axis not in (0, 1, 2) or signed_steps == 0:
+            raise ValueError("each path segment needs an axis and nonzero step")
+        direction = 1 if signed_steps > 0 else -1
+        for _ in range(abs(signed_steps)):
+            if direction > 0:
+                root = tuple(position)
+                next_position = position.copy()
+                next_position[axis] = (next_position[axis] + 1) % length
+            else:
+                next_position = position.copy()
+                next_position[axis] = (next_position[axis] - 1) % length
+                root = tuple(next_position)
+            link = (*root, axis)
+            if link in used_links:
+                raise ValueError("directed path reuses a physical link")
+            occupation_number = int(occupation[link])
+            electric_change = (-1) ** sum(root) * (1 - 2 * occupation_number)
+            if electric_change != direction:
+                raise ValueError(
+                    f"segment does not follow the alternating electric arrow at {link}"
+                )
+            occupation[link] ^= 1
+            used_links.add(link)
+            position = next_position
+            displacement[axis] += direction
+    charges = gauss_charges(occupation)
+    if sorted(int(value) for value in charges[charges != 0]) != [-1, 1]:
+        raise AssertionError("directed path did not leave exactly two unit charges")
+    return occupation, tuple(displacement)
+
+
+def axial_segments(separation: int) -> tuple[tuple[int, int], ...]:
+    return ((0, separation),)
+
+
+@dataclass(frozen=True)
+class ChargeResult:
+    length: int
+    delta_v: float
+    displacement: tuple[int, int, int]
+    energy: float
+    energy_error: float
+    charge_signature: tuple[int, ...]
+    plane_flux: tuple[int, int, int]
+    minimum_effective_population_fraction: float
+    final_unique_fraction: float
+    count_consistent: bool
+    charge_consistent: bool
+
+    @property
+    def distance(self) -> float:
+        return sqrt(sum(component**2 for component in self.displacement))
+
+
+def run_charge_population(
+    length: int,
+    delta_v: float,
+    segments: tuple[tuple[int, int], ...] | None,
+    *,
+    population: int,
+    classical_sweeps: int,
+    burn_sweeps: int,
+    sample_sweeps: int,
+    seed: int,
+) -> ChargeResult:
+    if segments is None:
+        occupation = initial_ice(length)
+        displacement = (0, 0, 0)
+    else:
+        occupation, displacement = directed_charge_start(length, segments)
+    initial_charges = gauss_charges(occupation)
+    initial_flux = electric_flux(occupation)
+    geometry = build_geometry(length)
+    (
+        samples,
+        effective_populations,
+        count_checks,
+        final_states,
+        final_counts,
+    ) = run_population_core(
+        occupation.ravel(),
+        geometry.plaquette_links,
+        geometry.affected_plaquettes,
+        geometry.affected_counts,
+        delta_v,
+        population,
+        classical_sweeps,
+        burn_sweeps,
+        sample_sweeps,
+        max(16, geometry.plaquette_count // 8),
+        seed,
+    )
+    mean, error = blocked_mean_and_error(samples)
+    charge_consistent = True
+    for state in final_states:
+        final_occupation = state.reshape((length, length, length, 3))
+        charge_consistent = charge_consistent and bool(
+            np.array_equal(gauss_charges(final_occupation), initial_charges)
+        )
+    count_consistent = bool(
+        np.all(count_checks == 0)
+        and all(
+            count_flippable(state, geometry.plaquette_links) == count
+            for state, count in zip(final_states, final_counts, strict=True)
+        )
+    )
+    packed = np.packbits(final_states, axis=1)
+    unique_fraction = np.unique(packed, axis=0).shape[0] / population
+    return ChargeResult(
+        length=length,
+        delta_v=delta_v,
+        displacement=displacement,
+        energy=delta_v * mean,
+        energy_error=abs(delta_v) * error,
+        charge_signature=tuple(
+            sorted(int(value) for value in initial_charges[initial_charges != 0])
+        ),
+        plane_flux=initial_flux,
+        minimum_effective_population_fraction=float(
+            np.min(effective_populations) / population
+        ),
+        final_unique_fraction=float(unique_fraction),
+        count_consistent=count_consistent,
+        charge_consistent=charge_consistent,
+    )
+
+
+def periodic_green(length: int, displacement: tuple[int, int, int]) -> float:
+    result = 0.0
+    vector = np.asarray(displacement, dtype=float)
+    for mode in np.ndindex(length, length, length):
+        if mode == (0, 0, 0):
+            continue
+        momentum = 2.0 * np.pi * np.asarray(mode, dtype=float) / length
+        eigenvalue = 4.0 * float(np.sum(np.sin(momentum / 2.0) ** 2))
+        result += float(np.cos(momentum @ vector)) / eigenvalue
+    return result / length**3
+
+
+def coulomb_coordinate(length: int, displacement: tuple[int, int, int]) -> float:
+    origin = periodic_green(length, (0, 0, 0))
+    separated = periodic_green(length, displacement)
+    harmonic = sum(component**2 for component in displacement) / (
+        2.0 * length**3
+    )
+    return origin - separated + harmonic
+
+
+@dataclass(frozen=True)
+class ResponseFit:
+    coefficient: float
+    coefficient_error: float
+    rss: float
+
+
+def fit_response(
+    results_by_length: dict[int, list[ChargeResult]],
+    model: str,
+) -> ResponseFit:
+    lengths = sorted(results_by_length)
+    rows = [
+        result
+        for length in lengths
+        for result in results_by_length[length]
+        if result.displacement != (0, 0, 0)
+    ]
+    intercepts = np.column_stack(
+        [np.asarray([result.length == length for result in rows], dtype=float) for length in lengths]
+    )
+    if model == "coulomb":
+        predictor = np.asarray(
+            [coulomb_coordinate(result.length, result.displacement) for result in rows]
+        )
+    elif model == "inverse_distance":
+        predictor = np.asarray([-1.0 / result.distance for result in rows])
+    elif model == "linear_distance":
+        predictor = np.asarray([result.distance for result in rows])
+    elif model == "quadratic_distance":
+        predictor = np.asarray([result.distance**2 for result in rows])
+    elif model == "constant":
+        prediction = np.asarray(
+            [
+                np.mean(
+                    [item.energy for item in results_by_length[result.length] if item.displacement != (0, 0, 0)]
+                )
+                for result in rows
+            ]
+        )
+        values = np.asarray([result.energy for result in rows])
+        return ResponseFit(0.0, 0.0, float(np.sum((values - prediction) ** 2)))
+    else:
+        raise ValueError(model)
+    design = np.column_stack((intercepts, predictor))
+    values = np.asarray([result.energy for result in rows], dtype=float)
+    errors = np.asarray(
+        [max(result.energy_error, 1.0e-8) for result in rows], dtype=float
+    )
+    weights = 1.0 / errors**2
+    normal = design.T @ (weights[:, None] * design)
+    covariance = np.linalg.inv(normal)
+    coefficients = covariance @ (design.T @ (weights * values))
+    prediction = design @ coefficients
+    return ResponseFit(
+        coefficient=float(coefficients[-1]),
+        coefficient_error=float(np.sqrt(covariance[-1, -1])),
+        rss=float(np.sum((values - prediction) ** 2)),
+    )
+
+
+def exact_charged_energy(delta_v: float) -> tuple[float, float, int]:
+    occupation, _ = directed_charge_start(2, axial_segments(1))
+    orbit = build_small_rk_orbit(occupation)
+    flippabilities = np.asarray(
+        [len(small_flip_destinations(decode_small(state))) for state in orbit.states],
+        dtype=float,
+    )
+    hamiltonian = orbit.hamiltonian + sparse.diags(delta_v * flippabilities)
+    values, vectors = eigsh(
+        hamiltonian,
+        k=1,
+        which="SA",
+        v0=np.linspace(1.0, 2.0, len(orbit.states)),
+        tol=1.0e-12,
+    )
+    vector = vectors[:, 0]
+    if np.sum(vector) < 0:
+        vector = -vector
+    mixed = delta_v * float(np.dot(vector, flippabilities) / np.sum(vector))
+    return float(values[0]), mixed, len(orbit.states)
+
+
+def main() -> int:
+    checks = Checks()
+    detunings = (-0.05, -0.10)
+    flux_stiffness_reference = {-0.05: 0.162638, -0.10: 0.321114}
+
+    path_specs = (
+        ((0, 1),),
+        ((0, 2),),
+        ((0, 2), (1, 1)),
+        ((0, 2), (1, 2)),
+        ((0, 2), (1, 2), (2, 1)),
+    )
+    path_ok = True
+    for length in (4, 6, 8):
+        for segments in path_specs:
+            occupation, _ = directed_charge_start(length, segments)
+            path_ok = path_ok and bool(
+                sorted(
+                    int(value)
+                    for value in gauss_charges(occupation)[gauss_charges(occupation) != 0]
+                )
+                == [-1, 1]
+            )
+    checks.check(
+        path_ok,
+        "axial and off-axis directed paths leave exactly one positive and one negative unit charge",
+    )
+
+    green_symmetry_ok = True
+    for length in (4, 6, 8):
+        reference = coulomb_coordinate(length, (2, 1, 0))
+        for vector in ((1, 2, 0), (2, 0, 1), (-2, 1, 0), (2, -1, 0)):
+            green_symmetry_ok = green_symmetry_ok and abs(
+                coulomb_coordinate(length, vector) - reference
+            ) < 1.0e-12
+    checks.check(
+        green_symmetry_ok,
+        "the periodic Coulomb plus harmonic coordinate is cubic- and inversion-invariant",
+    )
+
+    exact_controls: list[tuple[float, float, float, int, ChargeResult]] = []
+    for detuning_index, delta_v in enumerate(detunings):
+        exact, mixed, orbit_size = exact_charged_energy(delta_v)
+        projector = run_charge_population(
+            2,
+            delta_v,
+            axial_segments(1),
+            population=2048,
+            classical_sweeps=100,
+            burn_sweeps=200,
+            sample_sweeps=500,
+            seed=6_000_000 + 100_000 * detuning_index,
+        )
+        exact_controls.append((delta_v, exact, mixed, orbit_size, projector))
+    checks.check(
+        all(
+            orbit_size == 508 and abs(exact - mixed) < 1.0e-9
+            for _, exact, mixed, orbit_size, _ in exact_controls
+        ),
+        "the complete 508-state charged L=2 orbit obeys the mixed-estimator identity at both detunings",
+    )
+    checks.check(
+        all(
+            abs(projector.energy - exact)
+            < max(8.0 * projector.energy_error, 0.004)
+            for _, exact, _, _, projector in exact_controls
+        ),
+        "the charged projector reproduces both exact L=2 finite-detuning ground energies",
+    )
+
+    axial: dict[tuple[float, int], list[ChargeResult]] = {}
+    all_results = [row[-1] for row in exact_controls]
+    for detuning_index, delta_v in enumerate(detunings):
+        for length in (4, 6, 8):
+            results: list[ChargeResult] = []
+            for separation in range(0, length // 2 + 1):
+                result = run_charge_population(
+                    length,
+                    delta_v,
+                    None if separation == 0 else axial_segments(separation),
+                    population=384,
+                    classical_sweeps=120,
+                    burn_sweeps=200,
+                    sample_sweeps=400,
+                    seed=(
+                        6_500_000
+                        + 100_000 * detuning_index
+                        + 100 * length
+                        + separation
+                    ),
+                )
+                results.append(result)
+                all_results.append(result)
+            axial[(delta_v, length)] = results
+
+    checks.check(
+        all(result.count_consistent and result.charge_consistent for result in all_results),
+        "every projector population preserves its exact charge pattern and local flippability count",
+    )
+    checks.check(
+        min(result.minimum_effective_population_fraction for result in all_results) > 0.90
+        and min(result.final_unique_fraction for result in all_results if result.length >= 4) > 0.25,
+        "all charged populations retain effective weight and final-state diversity",
+    )
+    checks.check(
+        all(
+            result.energy - results[0].energy
+            > 4.0 * np.hypot(result.energy_error, results[0].energy_error)
+            for results in axial.values()
+            for result in results[1:]
+        ),
+        "every separated charge pair has a resolved positive creation energy above its vacuum component",
+    )
+    checks.check(
+        all(
+            results[-1].energy - results[1].energy
+            > 2.0 * np.hypot(results[-1].energy_error, results[1].energy_error)
+            for results in axial.values()
+        ),
+        "opposite-charge energy rises from one-link separation to the half-box endpoint on every volume",
+    )
+
+    axial_fits: dict[float, dict[str, ResponseFit]] = {}
+    for delta_v in detunings:
+        by_length = {length: axial[(delta_v, length)] for length in (4, 6, 8)}
+        axial_fits[delta_v] = {
+            model: fit_response(by_length, model)
+            for model in (
+                "coulomb",
+                "inverse_distance",
+                "linear_distance",
+                "quadratic_distance",
+                "constant",
+            )
+        }
+    checks.check(
+        all(
+            fits["coulomb"].coefficient
+            > 5.0 * fits["coulomb"].coefficient_error
+            for fits in axial_fits.values()
+        ),
+        "the periodic Coulomb coordinate has a resolved positive coefficient at both detunings",
+    )
+    checks.check(
+        all(
+            fits["coulomb"].rss <= 1.25 * fits["inverse_distance"].rss
+            and fits["coulomb"].rss < 0.80 * fits["linear_distance"].rss
+            and fits["coulomb"].rss < 0.80 * fits["quadratic_distance"].rss
+            and fits["coulomb"].rss < 0.50 * fits["constant"].rss
+            for fits in axial_fits.values()
+        ),
+        "periodic and raw 1/R Coulomb forms remain near-degenerate and beat confining or constant controls",
+    )
+    checks.check(
+        all(
+            abs(
+                axial_fits[delta_v]["coulomb"].coefficient
+                / flux_stiffness_reference[delta_v]
+                - 1.0
+            )
+            < 0.25
+            for delta_v in detunings
+        ),
+        "charge-response and topological-flux determinations of U agree within twenty-five percent",
+    )
+    checks.check(
+        all(
+            abs(
+                axial_fits[delta_v]["inverse_distance"].coefficient
+                / (flux_stiffness_reference[delta_v] / (4.0 * pi))
+                - 1.0
+            )
+            < 0.30
+            for delta_v in detunings
+        ),
+        "the raw 1/R amplitude tracks the independently fixed U/(4 pi) normalization within thirty percent",
+    )
+
+    off_axis_specs = (
+        ((0, 2), (1, 1)),
+        ((0, 2), (1, 2)),
+        ((0, 2), (1, 2), (2, 1)),
+    )
+    off_axis: dict[int, list[ChargeResult]] = {}
+    for length in (6, 8):
+        results = list(axial[(-0.10, length)])
+        for index, segments in enumerate(off_axis_specs):
+            result = run_charge_population(
+                length,
+                -0.10,
+                segments,
+                population=256,
+                classical_sweeps=100,
+                burn_sweeps=150,
+                sample_sweeps=300,
+                seed=7_000_000 + 100 * length + index,
+            )
+            results.append(result)
+            all_results.append(result)
+        off_axis[length] = results
+    off_axis_fits = {
+        model: fit_response(off_axis, model)
+        for model in (
+            "coulomb",
+            "inverse_distance",
+            "linear_distance",
+            "quadratic_distance",
+            "constant",
+        )
+    }
+    checks.check(
+        off_axis_fits["coulomb"].coefficient > 0.0
+        and abs(
+            off_axis_fits["coulomb"].coefficient
+            / flux_stiffness_reference[-0.10]
+            - 1.0
+        )
+        < 0.30
+        and off_axis_fits["coulomb"].rss
+        < 0.85 * off_axis_fits["linear_distance"].rss
+        and off_axis_fits["coulomb"].rss
+        < 0.85 * off_axis_fits["quadratic_distance"].rss,
+        "off-axis charge geometries keep a positive flux-matched Coulomb coefficient and reject string growth",
+    )
+
+    path_order = []
+    for index, segments in enumerate(
+        (
+            ((0, 2), (1, 2)),
+            ((1, 2), (0, 2)),
+            ((0, 2), (1, 1)),
+            ((1, 2), (0, 1)),
+        )
+    ):
+        path_order.append(
+            run_charge_population(
+                6,
+                -0.10,
+                segments,
+                population=256,
+                classical_sweeps=100,
+                burn_sweeps=150,
+                sample_sweeps=300,
+                seed=7_500_000 + index,
+            )
+        )
+    same_endpoint_ok = abs(path_order[0].energy - path_order[1].energy) < 4.0 * np.hypot(
+        path_order[0].energy_error, path_order[1].energy_error
+    )
+    rotated_ok = abs(path_order[2].energy - path_order[3].energy) < 4.0 * np.hypot(
+        path_order[2].energy_error, path_order[3].energy_error
+    )
+    checks.check(
+        same_endpoint_ok and rotated_ok,
+        "path-order and cubic-rotation controls reproduce equal charge energies within four errors",
+    )
+
+    population_control = []
+    for separation in (1, 4):
+        population_control.append(
+            run_charge_population(
+                8,
+                -0.10,
+                axial_segments(separation),
+                population=768,
+                classical_sweeps=150,
+                burn_sweeps=250,
+                sample_sweeps=500,
+                seed=8_000_000 + separation,
+            )
+        )
+    primary_rise = axial[(-0.10, 8)][-1].energy - axial[(-0.10, 8)][1].energy
+    control_rise = population_control[-1].energy - population_control[0].energy
+    checks.check(
+        primary_rise > 0.0
+        and control_rise > 0.0
+        and abs(primary_rise - control_rise)
+        / (0.5 * (primary_rise + control_rise))
+        < 0.30,
+        "doubled L=8 populations reproduce the positive long-distance charge-energy rise",
+    )
+
+    for delta_v, exact, _, orbit_size, projector in exact_controls:
+        print(
+            "EXACT_CHARGE",
+            f"V={1.0 + delta_v:.2f}",
+            f"orbit={orbit_size}",
+            f"E0={exact:.9f}",
+            f"projector={projector.energy:.9f}+/-{projector.energy_error:.9f}",
+        )
+    for delta_v in detunings:
+        fits = axial_fits[delta_v]
+        print(
+            "AXIAL_FIT",
+            f"V={1.0 + delta_v:.2f}",
+            f"U_charge={fits['coulomb'].coefficient:.6f}+/-{fits['coulomb'].coefficient_error:.6f}",
+            f"U_flux={flux_stiffness_reference[delta_v]:.6f}",
+            f"A_1overR={fits['inverse_distance'].coefficient:.6f}",
+            f"U_flux/(4pi)={flux_stiffness_reference[delta_v] / (4.0 * pi):.6f}",
+            "rss="
+            + ",".join(
+                f"{model}:{fits[model].rss:.8f}"
+                for model in (
+                    "coulomb",
+                    "inverse_distance",
+                    "linear_distance",
+                    "quadratic_distance",
+                    "constant",
+                )
+            ),
+        )
+    print(
+        "OFF_AXIS_FIT",
+        f"U_charge={off_axis_fits['coulomb'].coefficient:.6f}+/-{off_axis_fits['coulomb'].coefficient_error:.6f}",
+        f"U_flux={flux_stiffness_reference[-0.10]:.6f}",
+        f"rss_coulomb={off_axis_fits['coulomb'].rss:.8f}",
+        f"rss_linear={off_axis_fits['linear_distance'].rss:.8f}",
+    )
+    print(
+        "POPULATION_CONTROL",
+        f"primary_rise={primary_rise:.9f}",
+        f"doubled_rise={control_rise:.9f}",
+    )
+    print(
+        "CERTIFICATE: fixed_opposite_unit_charges=True finite_population=True "
+        "finite_imaginary_time=True component_complete=False thermodynamic_limit=False "
+        "real_time_spectrum=False"
+    )
+    print(
+        "RESOLUTION: per_element=directed path and square flips; per_site=two fixed charges and exact Gauss; "
+        "per_mode=periodic Coulomb kernel plus harmonic sector; per_block=L2 exact and L4,6,8 projector; "
+        "lattice_wide=finite-volume static response, not an infinite-volume potential theorem"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the finite-detuning fixed-charge response on the same spin-half cubic-ice carrier whose topological flux tower fixes the electric stiffness.

- Directed alternating paths create exactly one +1 and one -1 Gauss charge; square projection preserves the full charge array.
- Exact 508-state charged `L=2` graphs calibrate the mixed estimator at `V=0.95` and `V=0.90`.
- All axial separations through `L/2` on `L=4,6,8` fit the periodic cubic Coulomb coordinate with `U_charge = 0.160609(15345)` and `0.301440(26769)`, versus independently determined `U_flux = 0.162638` and `0.321114`.
- Raw `1/R` is near-degenerate with the finite-periodic kernel and beats string/flat controls. Its asymptotic amplitude is visibly 27% and 21% above `U/(4 pi)`, inside the declared 30% finite-volume diagnostic; the PR does not claim the kernel correction is resolved.
- Off-axis, path-order, cubic-rotation, and 384-to-768 walker controls preserve the positive coefficient and long-distance energy rise.

## Verification

`python3 scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py`

Identity-pinned cache: `TOTAL: PASS=15 FAIL=0`, 313.19 seconds.

Cache freshness, staged claim typing, citation graph, enforced repository invariants, strict audit lint, diff check, and vocabulary lint pass. Strict lint has repository-baseline warnings/notices and zero errors.

## Boundary

Finite volumes `L<=8`, fixed external charges, finite projector population/time, and named mobile components. Periodic-lattice versus raw `1/R` is unresolved. This is not an infinite-volume potential, a moving-charge/matter result, a real-time photon pole, a component classification, a physical-site compiler, law selection, or empirical electromagnetism claim.

Open PR #7942 independently exposes the 937-component and pair-update-sampler boundaries; this calculation uses a different exact-positive projector and remains explicitly component-scoped.

Stacked on #7941.
