### PR TITLE
science(light): resolve relaxed magnetic twist stiffness

### DIFF
--- a/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_RELAXED_MAGNETIC_TWIST_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_RELAXED_MAGNETIC_TWIST_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,515 @@
+# Finite-Detuning Spin-Half Cubic Ice Has Positive Relaxed Magnetic-Twist Stiffness
+
+**Date:** 2026-09-04
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct transverse-dynamics parent:**
+[`SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_TRANSVERSE_LINEAR_SPECTRAL_CROSSOVER_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_TRANSVERSE_LINEAR_SPECTRAL_CROSSOVER_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Static charge-flux parent:**
+[`SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_CHARGE_COULOMB_FLUX_STIFFNESS_JOIN_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_CHARGE_COULOMB_FLUX_STIFFNESS_JOIN_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**RK carrier parent:**
+[`SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py`](../scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.txt`](../logs/runner-cache/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.txt)
+
+## Result up front
+
+The finite-detuning spin-half cubic-ice carrier has a directly measured,
+positive relaxed magnetic response on the same couplings where the parent
+calculations measured electric stiffness, Coulomb charge response, and a
+transverse linear spectral crossover.
+
+For one cubic plaquette orientation, put a phase `theta` on every directed
+ring move and let `E_0(theta)` be the lowest energy in the fixed Gauss and
+zero-electric-flux sector. The finite-volume relaxed response is
+
+```text
+K_L = (1/L^3) d^2 E_0(theta)/d theta^2 at theta=0.
+```
+
+The direct calculation finds, over `L=4,6,8,10`,
+
+```text
+V=0.95: K = 0.075561 +/- 0.000915,
+V=0.90: K = 0.076589 +/- 0.001155.
+```
+
+Every individual size and both continuation radii give a resolved positive
+coefficient. A doubled-population calculation reproduces the result, and
+three independently sampled plaquette orientations give one cubic response.
+The response is already present at the RK point and changes by less than ten
+percent over the two finite detunings.
+
+This resolves the immediate magnetic question positively: the microscopic
+finite-qubit carrier has a relaxed, same-detuning magnetic cost rather than
+only a bare phase-twisted trial-state cost.
+
+It also corrects an important normalization ambiguity. The RK parent reported
+
+```text
+J n_f approximately 0.2598
+```
+
+from the expectation value of a phase-twisted equal-amplitude state. That is
+a valid positive variational upper cost. It is not the relaxed ground-energy
+curvature. The present calculation finds the latter equal to
+`0.073357 +/- 0.000881` on the tested RK volumes. The two numbers answer
+different questions and must not be
+substituted for one another in `c^2=U K`.
+
+Using the newly measured same-detuning `K`, the static-dynamic Maxwell
+comparison is not yet quantitatively closed on the finite matrices. The
+stronger detuning is statistically compatible at the declared resolution;
+the weak detuning retains a greater-than-two-error tension. This is positive
+localization of the remaining light-sector work, not a no-photon result. The
+shortest next test is to extend the transverse spectrum farther into the
+infrared and ask whether its fitted `c^2` approaches the independently fixed
+`U K`.
+
+This note does not claim a thermodynamic helicity modulus, an infinite-volume
+photon pole, or a Standard Model electromagnetic normalization.
+
+## 1. Carrier and physical twist
+
+The carrier is the same one-qubit-per-link cubic ice model used throughout the
+parent stack. In a fixed three-of-six Gauss sector and electric-flux sector,
+
+```text
+H(0) = - sum_p (|clockwise><counterclockwise| + h.c.) + V N_f.
+```
+
+For a chosen plaquette orientation `mu nu`, assign each flippable directed
+move a sign `s_p(x)=+/-1`. Reversing the move reverses the sign. The Hermitian
+twisted Hamiltonian is
+
+```text
+H(theta)_(x,y) = -exp(i theta s_p(x))
+```
+
+when `x` and `y` differ by that oriented plaquette flip. Other orientations
+retain matrix element `-1`, and the diagonal remains `V N_f(x)`. Because the
+reverse matrix element is the complex conjugate, `H(theta)` is Hermitian.
+
+The fully relaxed curvature is
+
+```text
+K_L = E_0''(0)/L^3.
+```
+
+It includes both the direct ring-energy curvature and the state relaxation
+induced by the twist. This distinction is why it can be smaller than the
+expectation value in one fixed phase-twisted trial state.
+
+For a uniform magnetic flux quantum, `theta=2 pi/L^2`, so a positive stable
+`K_L` produces the Maxwell finite-volume scaling
+
+```text
+Delta E = 2 pi^2 K_L/L + higher powers.
+```
+
+The runner measures the zero-angle curvature. It does not simulate a whole
+quantized-flux ladder.
+
+## 2. Sign-free analytic continuation
+
+Direct stochastic projection at real `theta` has a phase problem. The runner
+uses the analytic continuation
+
+```text
+theta = i eta.
+```
+
+Then the target off-diagonal weights are real and positive:
+
+```text
+exp(-eta s_p(x)).
+```
+
+The continued matrix is non-Hermitian, but its Green matrix is positive and
+has a Perron eigenvalue. Moreover,
+
+```text
+H(-i eta) = H(i eta)^T,
+```
+
+so the two signs have exactly the same spectrum. Analyticity around zero gives
+
+```text
+E_0(i eta) = E_0(0) - (K_L L^3/2) eta^2 + O(eta^4).
+```
+
+Thus
+
+```text
+K_L(eta) = -2 [E_0(i eta)-E_0(0)]/(eta^2 L^3)
+```
+
+approaches the physical Hermitian curvature. The runner averages independent
+`+eta` and `-eta` populations and repeats the measurement at `eta=0.10` and
+`eta=0.16`.
+
+### Exact continuation control
+
+The complete connected `L=2` orbit is diagonalized twice: once at real
+`theta=0.02` and once at `theta=i 0.02`. At all three tested couplings,
+
+```text
+V=1.00, 0.95, 0.90,
+```
+
+the continued curvature reproduces the physical Hermitian curvature to
+better than `10^-4` relative. The stochastic `L=2` results then reproduce the
+same exact curvatures within the declared population errors.
+
+This test establishes the sign of the continuation rather than assuming it.
+
+## 3. Exact positive projector
+
+Let `M=3L^3` be the number of square moves. The runner uses
+
+```text
+G_eta = I - H(i eta)/(1.5 M).
+```
+
+For every sampled state, its exact row sum is
+
+```text
+b_eta(x) = 1 + [W_eta(x)-V N_f(x)]/(1.5 M),
+```
+
+where
+
+```text
+W_eta(x) = sum over flippable p of exp(-eta s_p(x))
+```
+
+on the target orientation and unit weight on the other two. A random
+plaquette proposal is accepted with the exact normalized Green weight.
+Fixed-population stochastic reconfiguration samples the positive left Perron
+vector. Its local row-energy estimator is
+
+```text
+E_local(x)=V N_f(x)-W_eta(x).
+```
+
+At `eta=0`, this reduces to the already verified constant-trial identity
+
+```text
+E_local=(V-1)N_f.
+```
+
+The runner updates both `N_f` and `W_eta` only on the exact affected
+plaquettes after each ring move, then independently recounts them in every
+final walker. It also checks the three-of-six Gauss law, zero electric flux,
+transition-probability bounds, effective population, and final-state
+diversity.
+
+This is an exact Green-kernel representation followed by a finite-population,
+finite-projection stochastic estimate. It is not exact diagonalization above
+`L=2`.
+
+## 4. Declared finite matrix
+
+The primary matrix uses
+
+```text
+V = 0.95 and 0.90,
+L = 2,4,6,8,10,
+eta = 0, +/-0.10, +/-0.16.
+```
+
+The reported volume summaries omit `L=2`, which is retained as the exact
+calibration. They average the `L=4,6,8,10` estimates after combining the two
+continuation radii. Errors conservatively take the larger of propagated
+within-run uncertainty and the standard error across volumes.
+
+Additional controls are:
+
+- an RK ladder at `L=2,4,6,8,10`;
+- independent samples of all three cubic orientations at `V=0.90,L=6`;
+- doubled `L=8` populations at both finite detunings; and
+- exact real-versus-imaginary twist diagonalization on `L=2`.
+
+The two continuation radii are a truncation control. Their agreement does not
+prove the absence of every higher-order effect outside the tested interval.
+
+## 5. Finite-detuning result
+
+The final cached values are inserted from the identity-pinned runner receipt.
+The runner reports `TOTAL: PASS=13 FAIL=0` and gives
+
+| coupling | relaxed `K`, `L=4,6,8,10` | `K_L` at `L=4,6,8,10` |
+|---:|---:|---|
+| 0.95 | `0.075561 +/- 0.000915` | `0.076864, 0.077237, 0.073327, 0.074815` |
+| 0.90 | `0.076589 +/- 0.001155` | `0.079733, 0.075228, 0.076852, 0.074541` |
+
+At each coupling:
+
+1. every `K_L(eta)` is more than three internal errors above zero;
+2. `eta=0.10` and `0.16` agree within twenty percent;
+3. the combined `L=4,6,8,10` spread is below ten percent;
+4. doubled populations reproduce the primary `L=8` value within eight
+   percent; and
+5. all exact counts, Gauss sectors, electric fluxes, and transition bounds
+   remain intact.
+
+These statements establish positive finite-volume relaxed response. Four
+large but finite boxes do not establish a nonzero thermodynamic limit.
+
+The doubled `L=8` populations return `0.076116 +/- 0.000736` at `V=0.95`
+and `0.075662 +/- 0.000900` at `V=0.90`. The three independent orientation
+controls return `0.077130`, `0.073878`, and `0.075619`. The minimum effective
+population fraction over the complete retained matrix is `0.946030`.
+
+## 6. RK variational cost versus relaxed response
+
+The earlier RK calculation evaluated the original Hamiltonian in a specified
+phase-twisted equal-amplitude state. If `n_f` is its flippability density,
+
+```text
+Delta E_trial = J n_f L^3 [1-cos(theta)].
+```
+
+It measured `J n_f` near `0.2598`. By the variational principle, this is a
+positive upper cost for that trial state. Allowing the state to relax can
+lower the curvature through the current-response term. The present runner
+does allow that relaxation by taking the Perron eigenvalue at each continued
+twist.
+
+The direct RK ladder gives
+
+```text
+K_RK,relaxed = 0.073357 +/- 0.000881
+```
+
+over `L=4,6,8,10`, strictly positive and well below `0.2598`. Its four values
+are `0.075488, 0.072042, 0.072466, 0.073433`. The finite-detuning coefficients
+remain within ten percent of it. Therefore:
+
+```text
+positive bare twist cost: retained,
+positive relaxed twist cost: newly measured,
+equality of the two: rejected on the tested finite systems.
+```
+
+This is a correction of interpretation, not a retraction of the earlier
+positive variational calculation.
+
+## 7. Static-dynamic Maxwell join
+
+The direct parents measured
+
+```text
+U(0.95)=0.162638,
+U(0.90)=0.321114,
+```
+
+and transverse crossover coefficients
+
+```text
+c_dynamic^2(0.95)=0.027162 +/- 0.005322,
+c_dynamic^2(0.90)=0.032683 +/- 0.005489.
+```
+
+For one quadratic Maxwell normalization,
+
+```text
+c^2=U K.
+```
+
+The runner performs this comparison without refitting `U`, `K`, or the
+dynamic ladders. The static predictions are
+
+```text
+V=0.95: U K = 0.012289 +/- 0.001169,
+V=0.90: U K = 0.024594 +/- 0.002083.
+```
+
+The strong-detuning comparison differs by `1.378` combined reported errors.
+The weak-detuning comparison differs by `2.729`. The direction is the same at
+both couplings: the finite-volume spectral fit returns a larger `c^2` than the
+static product.
+
+This does not negate the positive transverse crossover. The spectral parent
+explicitly did not claim an asymptotic pole, and at `V=0.95` its lowest tested
+momenta sit near the crossover between the RK `q^4` term and the emergent
+`q^2` term. A two-term finite-volume fit can therefore assign curvature to
+the `q^2` coefficient before the true infrared regime is cleanly isolated.
+
+The comparison makes the next decision test concrete:
+
+```text
+extend V=0.95 to lower q and test c^2 = U K as a fixed prediction.
+```
+
+If the fitted coefficient moves toward `U K`, the light normalization closes.
+If controlled lower momenta preserve the discrepancy, the effective
+Hamiltonian normalization or measured operator assignment must be revised.
+
+## 8. Program and axiom consequence
+
+The light stack now reads
+
+```text
+finite local qubits and exact Gauss constraint
+ -> local ring dynamics and RK Coulomb tensor
+ -> positive finite-detuning electric stiffness
+ -> charge Coulomb response with the same U
+ -> direct transverse linear spectral crossover
+ -> positive same-detuning relaxed magnetic response.
+```
+
+This is meaningful TOE-facing progress: the magnetic ingredient has moved
+from a fixed trial-state expectation to a relaxed response on the same finite
+carrier. The remaining light issue is no longer “does the carrier have a
+magnetic stiffness?” It is the quantitative infrared join among three
+independently measured coefficients.
+
+No axiom edit is justified. The four axioms permit the carrier and its local
+dynamics but do not fix this supplier Hamiltonian, its coupling, or its
+continuum normalization. The current discrepancy is inside the supplied
+physics and its finite-size extraction. Writing it into the axioms would hide
+rather than solve the calculation.
+
+No official TOE score moves until independent classification. The science
+position improves because one named ingredient is now directly positive and
+the remaining closure test is sharper.
+
+## 9. Structured wall audit
+
+### N1 — Alternative routes
+
+The campaign considered four routes to the same-detuning magnetic coefficient:
+
+1. reuse the RK flippability expectation;
+2. evaluate a finite-detuning phase-twisted ground-state trial vector;
+3. sample the real-twist Hamiltonian directly; and
+4. extract the fully relaxed curvature by sign-free analytic continuation.
+
+Route 1 changes the coupling and does not include relaxation. Route 2 gives
+only a variational upper cost. Route 3 has a phase problem. Route 4 is retained
+because its continuation sign and normalization can be checked by exact
+diagonalization.
+
+### N2 — Wall independence
+
+The positive magnetic result does not depend on the transverse spectral fit:
+it uses only the local Hamiltonian, exact twist definition, and Perron
+eigenvalue. Conversely, the observed Maxwell-join tension depends on comparing
+independent static and dynamic calculations. Removing the dynamic parent
+removes the comparison, not the positive magnetic theorem.
+
+### N3 — Hidden-wall scan
+
+The main hidden risks are finite population, finite projection time,
+continuation-radius truncation, cubic-axis bias, and confusing a variational
+expectation with a relaxed eigenvalue. The runner attacks them with doubled
+populations, two radii, exact `L=2`, all three orientations, and an explicit
+separation of the two response definitions.
+
+### N4 — Residual matching
+
+What remains unclosed is exactly the residual measured here:
+
+```text
+c_dynamic^2 - U K_relaxed.
+```
+
+It is not relabeled as an axiom issue, a missing magnetic term, or evidence
+against the carrier. The next campaign must reduce the spectral momentum or
+find a normalization change that quantitatively explains this residual.
+
+### N5 — Rhetoric audit
+
+“Stiffness” in the title means finite-volume relaxed twist curvature. It does
+not mean an audited thermodynamic phase theorem. “Correction” refers to using
+the old variational number as a relaxed coefficient; the old calculation
+itself remains positive and reproducible.
+
+### N6 — Partial-closure path
+
+Even if the static-dynamic equality remains unresolved, the positive relaxed
+magnetic response is independently useful. It closes the existence question,
+provides a direct target for larger-volume spectroscopy, and supplies a
+quantitative response for comparison with other carriers.
+
+### N7 — Steelman
+
+A hostile reviewer can say that a non-Hermitian continuation may encounter an
+exceptional point, fixed-population Perron sampling is biased, two finite
+radii do not determine a derivative, and four volumes do not prove a limit.
+They can also say that the greater-than-two-error weak-detuning discrepancy
+uses uncertainties from separate stochastic pipelines and therefore should
+not be called a sharp rejection.
+
+The bounded reply is that exact `L=2` continuation fixes the local sign and
+curvature, `+/-eta` transpose symmetry is exact, the two radii agree, cubic
+orientations agree, doubled populations agree, and the volume ladder is
+stable. These controls justify the finite-matrix positive result and the word
+“tension,” not a thermodynamic theorem or no-go.
+
+### N8 — Cross-cycle echo and failed-attempt ledger
+
+The first scout used one continuation radius and one population. It found a
+positive coefficient near `0.08` but underestimated the exact `L=2` value in
+some seeds. Raising the `L=2` population through `512`, `1024`, and `2048`
+converged onto exact diagonalization. The retained runner therefore includes
+an exact stochastic calibration and a doubled-population large-volume
+control.
+
+The first production ladder showed one noisy `V=0.95,L=8,eta=0.10` point.
+It was not deleted or used to select another radius. A second radius was
+already declared, and a doubled-population `L=8` calculation independently
+returned the common `K` near `0.075`. Both primary radii remain in the final
+summary.
+
+An efficiency-tuned full pass then reduced every primary population to `512`.
+It failed two declared quality checks: the cheap `V=0.90,L=4` point lifted the
+four-volume spread above ten percent, and one population reached effective
+weight fraction `0.8255` against the retained `0.85` floor. Neither threshold
+was lowered. The retained calculation increases only the `L=4` population and
+sampling length, and resamples weights twelve rather than eight times per
+plaquette sweep. The physical volume set, two continuation radii, estimator,
+and response thresholds remain unchanged.
+
+The initial interpretation compared `c^2/U` to the RK flippability number
+near `0.260`. The present relaxed calculation showed that comparison joined
+different observables. The distinction is retained explicitly, and the
+same-detuning relaxed value is used instead.
+
+No failed or interesting result was discarded.
+
+## Falsifiers
+
+This bounded claim fails if the cached runner does not reproduce its final
+zero-failure line, or if an independent implementation finds any of:
+
+- real and imaginary exact `L=2` twist curvatures disagree at quadratic order;
+- the Green transition weights fail to reproduce `I-H(i eta)/(1.5M)`;
+- `+eta` and `-eta` have different Perron eigenvalues;
+- local recounting changes `N_f` or the weighted flippability sum;
+- any accepted move changes Gauss charge or electric flux;
+- doubled populations or cubic orientations move the response outside the
+  declared controls;
+- controlled larger volumes drive the relaxed curvature to zero; or
+- lower-momentum spectroscopy preserves the current discrepancy after every
+  operator and normalization factor is matched.
+
+Run:
+
+```bash
+python3 scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15836,
- "node_count": 5580,
+ "edge_count": 15840,
+ "node_count": 5581,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17412,6 +17412,10 @@
   },
   "spin_half_cubic_ice_finite_detuning_projector_maxwell_stiffness_bounded_theorem_note_2026-09-03": {
    "deps_hash": "864f3fd41e7e",
+   "out_degree": 4
+  },
+  "spin_half_cubic_ice_finite_detuning_relaxed_magnetic_twist_stiffness_bounded_theorem_note_2026-09-04": {
+   "deps_hash": "c2c9504bad65",
    "out_degree": 4
   },
   "spin_half_cubic_ice_finite_detuning_transverse_linear_spectral_crossover_bounded_theorem_note_2026-09-03": {

--- a/logs/runner-cache/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.txt
@@ -1,0 +1,59 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py
+runner_sha256: a61b5ca89ea5b39ac932744b12e3af46167d81fd4ed5eb52acdb08644f74b28b
+input_fingerprint_sha256: 1660a34646f70428d69a0109352991d6656c1fe479c7cec7d9d6f3665c22447a
+timeout_sec: 1800
+exit_code: 0
+elapsed_sec: 1139.22
+status: ok
+----- stdout -----
+[PASS] 01 exact L=2 analytic continuation reproduces the positive Hermitian twist curvature
+[PASS] 02 every finite-volume imaginary-twist pair resolves positive physical magnetic curvature
+[PASS] 03 two continuation radii reproduce the zero-angle curvature within twenty percent
+[PASS] 04 the stochastic L=2 twist curvatures reproduce exact diagonalization
+[PASS] 05 the L=4,6,8,10 magnetic response is volume-stable at both detunings
+[PASS] 06 the relaxed RK twist curvature is positive and stable across L=4,6,8,10
+[PASS] 07 the relaxed RK stiffness is strictly below the older flippability variational upper cost
+[PASS] 08 the relaxed magnetic stiffness changes by less than ten percent across the two finite detunings
+[PASS] 09 three independently sampled cubic orientations reproduce one magnetic response
+[PASS] 10 doubled L=8 populations reproduce the primary magnetic response within eight percent
+[PASS] 11 the same-detuning Maxwell comparison localizes a weak-detuning spectral-normalization tension while the stronger detuning remains statistically compatible
+[PASS] 12 every twisted projector preserves exact local weights, Gauss charge, flux, and valid transition probabilities
+[PASS] 13 every twisted population retains the declared weight and diversity floors
+EXACT_CONTINUATION V=1.00 K_real=0.105119698 K_imag=0.105123106
+EXACT_CONTINUATION V=0.95 K_real=0.107537604 K_imag=0.107540619
+EXACT_CONTINUATION V=0.90 K_real=0.109733090 K_imag=0.109735755
+TWIST V=0.90 L=2 eta=0.10 K=0.120745+/-0.016791
+TWIST V=0.90 L=2 eta=0.16 K=0.115056+/-0.008840
+TWIST V=0.90 L=4 eta=0.10 K=0.085277+/-0.006352
+TWIST V=0.90 L=4 eta=0.16 K=0.078927+/-0.002422
+TWIST V=0.90 L=6 eta=0.10 K=0.073549+/-0.004170
+TWIST V=0.90 L=6 eta=0.16 K=0.075582+/-0.001913
+TWIST V=0.90 L=8 eta=0.10 K=0.078774+/-0.003241
+TWIST V=0.90 L=8 eta=0.16 K=0.076419+/-0.001540
+TWIST V=0.90 L=10 eta=0.10 K=0.073076+/-0.002947
+TWIST V=0.90 L=10 eta=0.16 K=0.074934+/-0.001525
+TWIST V=0.95 L=2 eta=0.10 K=0.082390+/-0.017101
+TWIST V=0.95 L=2 eta=0.16 K=0.094147+/-0.008488
+TWIST V=0.95 L=4 eta=0.10 K=0.080811+/-0.003702
+TWIST V=0.95 L=4 eta=0.16 K=0.075051+/-0.002509
+TWIST V=0.95 L=6 eta=0.10 K=0.078690+/-0.002839
+TWIST V=0.95 L=6 eta=0.16 K=0.076810+/-0.001539
+TWIST V=0.95 L=8 eta=0.10 K=0.071645+/-0.001754
+TWIST V=0.95 L=8 eta=0.16 K=0.073934+/-0.001054
+TWIST V=0.95 L=10 eta=0.10 K=0.074463+/-0.001492
+TWIST V=0.95 L=10 eta=0.16 K=0.074956+/-0.000948
+SUMMARY V=0.95 K=0.075561+/-0.000915 K_L=4:0.076864,6:0.077237,8:0.073327,10:0.074815
+SUMMARY V=0.90 K=0.076589+/-0.001155 K_L=4:0.079733,6:0.075228,8:0.076852,10:0.074541
+RK_RELAXED K=0.073357+/-0.000881 K_L=4:0.075488,6:0.072042,8:0.072466,10:0.073433 variational_upper=0.259800
+ORIENTATION_CONTROL axis=0:0.077130,axis=1:0.073878,axis=2:0.075619
+POPULATION_CONTROL V=0.95 primary=0.073327 doubled=0.076116+/-0.000736
+MAXWELL_JOIN V=0.95 UK=0.012289+/-0.001169 c2_dynamic=0.027162+/-0.005322 difference_sigma=2.729
+POPULATION_CONTROL V=0.90 primary=0.076852 doubled=0.075662+/-0.000900
+MAXWELL_JOIN V=0.90 UK=0.024594+/-0.002083 c2_dynamic=0.032683+/-0.005489 difference_sigma=1.378
+HEALTH min_ess=0.946030 min_unique=0.705078
+CERTIFICATE: exact_L2_real_twist=True imaginary_twist_positive_projector=True finite_population=True finite_imaginary_time=True thermodynamic_limit=False
+TOTAL: PASS=13 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py
@@ -1,0 +1,912 @@
+#!/usr/bin/env python3
+"""Finite-detuning magnetic-twist response in spin-half cubic ice.
+
+The physical twist is first defined with a Hermitian phase ``theta`` on all
+ring moves of one cubic orientation.  Its zero-angle energy curvature is the
+finite-volume magnetic response.  Direct sampling at real theta has a phase
+problem.  This runner instead continues ``theta -> i eta``.  The resulting
+Green matrix is real and strictly positive, so its Perron eigenvalue can be
+sampled without a sign problem.  Even-in-eta energy curvature is the negative
+of the physical curvature.  Exact L=2 diagonalization checks the continuation
+before any larger-volume projector result is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+import numpy as np
+from numba import njit
+from scipy import sparse
+from scipy.sparse.linalg import eigs, eigsh
+
+from spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03 import (
+    build_geometry,
+    count_flippable,
+    is_flippable,
+)
+from spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03 import (
+    build_small_rk_orbit,
+    decode_small,
+    electric_flux,
+    encode_small,
+    initial_ice,
+    vertex_degrees,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_finite_delta_transverse_pole_2026_09_03.py",
+)
+
+AUDIT_TIMEOUT_SEC = 1800
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@njit(cache=True)
+def flip_weight(
+    state: np.ndarray,
+    plaquette: int,
+    target_orientation: int,
+    eta: float,
+    plaquette_links: np.ndarray,
+    orientation_volume: int,
+) -> float:
+    if plaquette // orientation_volume != target_orientation:
+        return 1.0
+    sign = 1.0 if state[plaquette_links[plaquette, 0]] else -1.0
+    return np.exp(-eta * sign)
+
+
+@njit(cache=True)
+def count_flippable_and_weight(
+    state: np.ndarray,
+    target_orientation: int,
+    eta: float,
+    plaquette_links: np.ndarray,
+    orientation_volume: int,
+) -> tuple[int, float]:
+    count = 0
+    weighted = 0.0
+    for plaquette in range(plaquette_links.shape[0]):
+        if is_flippable(state, plaquette_links[plaquette]):
+            count += 1
+            weighted += flip_weight(
+                state,
+                plaquette,
+                target_orientation,
+                eta,
+                plaquette_links,
+                orientation_volume,
+            )
+    return count, weighted
+
+
+@njit(cache=True)
+def flip_and_update_twisted(
+    state: np.ndarray,
+    plaquette: int,
+    current_count: int,
+    current_weight: float,
+    target_orientation: int,
+    eta: float,
+    plaquette_links: np.ndarray,
+    affected_plaquettes: np.ndarray,
+    affected_counts: np.ndarray,
+    orientation_volume: int,
+) -> tuple[int, float]:
+    before_count = 0
+    before_weight = 0.0
+    for slot in range(affected_counts[plaquette]):
+        neighbor = affected_plaquettes[plaquette, slot]
+        if is_flippable(state, plaquette_links[neighbor]):
+            before_count += 1
+            before_weight += flip_weight(
+                state,
+                neighbor,
+                target_orientation,
+                eta,
+                plaquette_links,
+                orientation_volume,
+            )
+    for link in plaquette_links[plaquette]:
+        state[link] ^= np.uint8(1)
+    after_count = 0
+    after_weight = 0.0
+    for slot in range(affected_counts[plaquette]):
+        neighbor = affected_plaquettes[plaquette, slot]
+        if is_flippable(state, plaquette_links[neighbor]):
+            after_count += 1
+            after_weight += flip_weight(
+                state,
+                neighbor,
+                target_orientation,
+                eta,
+                plaquette_links,
+                orientation_volume,
+            )
+    return (
+        current_count + after_count - before_count,
+        current_weight + after_weight - before_weight,
+    )
+
+
+@njit(cache=True)
+def systematic_resample_twisted(
+    states: np.ndarray,
+    counts: np.ndarray,
+    weighted_counts: np.ndarray,
+    log_weights: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    population = states.shape[0]
+    maximum = np.max(log_weights)
+    weights = np.exp(log_weights - maximum)
+    total = np.sum(weights)
+    effective = total * total / np.sum(weights * weights)
+    cumulative = np.cumsum(weights / total)
+    offset = np.random.random() / population
+    new_states = np.empty_like(states)
+    new_counts = np.empty_like(counts)
+    new_weighted = np.empty_like(weighted_counts)
+    source = 0
+    for destination in range(population):
+        position = offset + destination / population
+        while source + 1 < population and cumulative[source] < position:
+            source += 1
+        new_states[destination] = states[source]
+        new_counts[destination] = counts[source]
+        new_weighted[destination] = weighted_counts[source]
+    return new_states, new_counts, new_weighted, effective
+
+
+@njit(cache=True)
+def run_twisted_core(
+    start_state: np.ndarray,
+    plaquette_links: np.ndarray,
+    affected_plaquettes: np.ndarray,
+    affected_counts: np.ndarray,
+    delta_v: float,
+    eta: float,
+    target_orientation: int,
+    population: int,
+    classical_sweeps: int,
+    burn_sweeps: int,
+    sample_sweeps: int,
+    resample_interval: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, int]:
+    np.random.seed(seed)
+    plaquette_count = plaquette_links.shape[0]
+    orientation_volume = plaquette_count // 3
+    scale = 1.5
+    green_denominator = scale * plaquette_count
+    potential = 1.0 + delta_v
+    states = np.empty((population, start_state.shape[0]), dtype=np.uint8)
+    counts = np.empty(population, dtype=np.int32)
+    weighted_counts = np.empty(population, dtype=np.float64)
+    for walker in range(population):
+        states[walker] = start_state
+        count, weighted = count_flippable_and_weight(
+            states[walker],
+            target_orientation,
+            eta,
+            plaquette_links,
+            orientation_volume,
+        )
+        counts[walker] = count
+        weighted_counts[walker] = weighted
+
+    # Symmetric ring flips decorrelate the identical ice starts before the
+    # non-Hermitian positive projector is applied.
+    for _ in range(classical_sweeps * plaquette_count):
+        for walker in range(population):
+            plaquette = np.random.randint(plaquette_count)
+            if is_flippable(states[walker], plaquette_links[plaquette]):
+                counts[walker], weighted_counts[walker] = (
+                    flip_and_update_twisted(
+                        states[walker],
+                        plaquette,
+                        counts[walker],
+                        weighted_counts[walker],
+                        target_orientation,
+                        eta,
+                        plaquette_links,
+                        affected_plaquettes,
+                        affected_counts,
+                        orientation_volume,
+                    )
+                )
+
+    total_steps = (burn_sweeps + sample_sweeps) * plaquette_count
+    first_sample_step = burn_sweeps * plaquette_count
+    samples = np.empty(sample_sweeps, dtype=np.float64)
+    log_weights = np.zeros(population, dtype=np.float64)
+    minimum_effective = float(population)
+    invalid_acceptances = 0
+    sample_index = 0
+    for step in range(total_steps):
+        for walker in range(population):
+            branch = 1.0 + (
+                weighted_counts[walker] - potential * counts[walker]
+            ) / green_denominator
+            log_weights[walker] += np.log(branch)
+            plaquette = np.random.randint(plaquette_count)
+            if is_flippable(states[walker], plaquette_links[plaquette]):
+                weight = flip_weight(
+                    states[walker],
+                    plaquette,
+                    target_orientation,
+                    eta,
+                    plaquette_links,
+                    orientation_volume,
+                )
+                acceptance = weight / (scale * branch)
+                if acceptance > 1.0:
+                    invalid_acceptances += 1
+                if np.random.random() < min(acceptance, 1.0):
+                    counts[walker], weighted_counts[walker] = (
+                        flip_and_update_twisted(
+                            states[walker],
+                            plaquette,
+                            counts[walker],
+                            weighted_counts[walker],
+                            target_orientation,
+                            eta,
+                            plaquette_links,
+                            affected_plaquettes,
+                            affected_counts,
+                            orientation_volume,
+                        )
+                    )
+        if (step + 1) % resample_interval == 0:
+            states, counts, weighted_counts, effective = (
+                systematic_resample_twisted(
+                    states, counts, weighted_counts, log_weights
+                )
+            )
+            minimum_effective = min(minimum_effective, effective)
+            log_weights[:] = 0.0
+        if step + 1 >= first_sample_step and (
+            step + 1 - first_sample_step
+        ) % plaquette_count == 0:
+            # The interval is chosen to divide one plaquette sweep, so the
+            # population here is unweighted.  The local row-energy estimator
+            # is exact for the Perron eigenvalue in the infinite projection
+            # and population limits.
+            samples[sample_index] = np.mean(
+                potential * counts - weighted_counts
+            )
+            sample_index += 1
+    return (
+        samples,
+        states,
+        counts,
+        weighted_counts,
+        minimum_effective,
+        invalid_acceptances,
+    )
+
+
+def blocked_mean_error(
+    values: np.ndarray, block_count: int = 12
+) -> tuple[float, float]:
+    usable = (len(values) // block_count) * block_count
+    blocks = values[:usable].reshape(block_count, -1).mean(axis=1)
+    return float(np.mean(blocks)), float(
+        np.std(blocks, ddof=1) / np.sqrt(block_count)
+    )
+
+
+@dataclass(frozen=True)
+class TwistResult:
+    length: int
+    delta_v: float
+    eta: float
+    orientation: int
+    energy: float
+    energy_error: float
+    minimum_effective_fraction: float
+    final_unique_fraction: float
+    count_consistent: bool
+    sector_consistent: bool
+    invalid_acceptances: int
+
+
+def run_twist(
+    length: int,
+    delta_v: float,
+    eta: float,
+    orientation: int,
+    *,
+    population: int,
+    classical_sweeps: int,
+    burn_sweeps: int,
+    sample_sweeps: int,
+    seed: int,
+) -> TwistResult:
+    geometry = build_geometry(length)
+    interval = max(8, geometry.plaquette_count // 12)
+    while geometry.plaquette_count % interval:
+        interval -= 1
+    (
+        samples,
+        states,
+        counts,
+        weighted_counts,
+        minimum_effective,
+        invalid_acceptances,
+    ) = run_twisted_core(
+        initial_ice(length).ravel(),
+        geometry.plaquette_links,
+        geometry.affected_plaquettes,
+        geometry.affected_counts,
+        delta_v,
+        eta,
+        orientation,
+        population,
+        classical_sweeps,
+        burn_sweeps,
+        sample_sweeps,
+        interval,
+        seed,
+    )
+    mean, error = blocked_mean_error(samples)
+    volume = length**3
+    count_consistent = True
+    weight_consistent = True
+    for state, count, weighted in zip(
+        states, counts, weighted_counts, strict=True
+    ):
+        exact_count, exact_weight = count_flippable_and_weight(
+            state,
+            orientation,
+            eta,
+            geometry.plaquette_links,
+            volume,
+        )
+        count_consistent = count_consistent and exact_count == count
+        weight_consistent = weight_consistent and abs(exact_weight - weighted) < 1e-8
+    sector_consistent = all(
+        np.all(vertex_degrees(state.reshape(length, length, length, 3)) == 3)
+        and electric_flux(state.reshape(length, length, length, 3)) == (0, 0, 0)
+        for state in states
+    )
+    packed = np.packbits(states, axis=1)
+    return TwistResult(
+        length=length,
+        delta_v=delta_v,
+        eta=eta,
+        orientation=orientation,
+        energy=mean,
+        energy_error=error,
+        minimum_effective_fraction=minimum_effective / population,
+        final_unique_fraction=np.unique(packed, axis=0).shape[0] / population,
+        count_consistent=count_consistent and weight_consistent,
+        sector_consistent=sector_consistent,
+        invalid_acceptances=invalid_acceptances,
+    )
+
+
+def exact_small_hamiltonian(delta_v: float, angle: complex) -> sparse.csr_matrix:
+    length = 2
+    volume = length**3
+    orbit = build_small_rk_orbit(initial_ice(length))
+    index = {state: position for position, state in enumerate(orbit.states)}
+    geometry = build_geometry(length)
+    rows: list[int] = []
+    columns: list[int] = []
+    data: list[complex] = []
+    for row, encoded in enumerate(orbit.states):
+        state = decode_small(encoded).ravel()
+        count = 0
+        for plaquette, links in enumerate(geometry.plaquette_links):
+            if not is_flippable(state, links):
+                continue
+            count += 1
+            moved = state.copy()
+            moved[links] ^= 1
+            destination = encode_small(moved.reshape(2, 2, 2, 3))
+            sign = 1.0 if state[links[0]] else -1.0
+            phase = np.exp(1j * angle * sign) if plaquette // volume == 0 else 1.0
+            rows.append(row)
+            columns.append(index[destination])
+            data.append(-phase)
+        rows.append(row)
+        columns.append(row)
+        data.append((1.0 + delta_v) * count)
+    return sparse.coo_matrix(
+        (data, (rows, columns)),
+        shape=(len(index), len(index)),
+        dtype=np.complex128,
+    ).tocsr()
+
+
+def exact_small_energy(delta_v: float, angle: complex) -> float:
+    hamiltonian = exact_small_hamiltonian(delta_v, angle)
+    if abs(angle.imag) < 1e-15:
+        value = eigsh(
+            hamiltonian,
+            k=1,
+            which="SA",
+            return_eigenvectors=False,
+            tol=1e-12,
+        )[0]
+    else:
+        value = eigs(
+            hamiltonian,
+            k=1,
+            which="SR",
+            return_eigenvectors=False,
+            tol=1e-12,
+        )[0]
+    if abs(value.imag) > 1e-9:
+        raise AssertionError("continued ground energy is not real")
+    return float(value.real)
+
+
+def curvature_from_triplet(
+    zero: TwistResult, positive: TwistResult, negative: TwistResult
+) -> tuple[float, float]:
+    if positive.eta <= 0.0 or negative.eta != -positive.eta:
+        raise ValueError("curvature needs a symmetric nonzero eta pair")
+    eta_squared = positive.eta**2
+    even_energy = 0.5 * (positive.energy + negative.energy)
+    even_error = 0.5 * np.hypot(
+        positive.energy_error, negative.energy_error
+    )
+    curvature = -2.0 * (even_energy - zero.energy) / (
+        eta_squared * zero.length**3
+    )
+    error = 2.0 * np.hypot(even_error, zero.energy_error) / (
+        eta_squared * zero.length**3
+    )
+    return float(curvature), float(error)
+
+
+def combine_estimates(
+    estimates: list[tuple[float, float]],
+) -> tuple[float, float]:
+    values = np.asarray([value for value, _ in estimates], dtype=float)
+    errors = np.asarray([error for _, error in estimates], dtype=float)
+    weights = 1.0 / np.maximum(errors, 1e-12) ** 2
+    return (
+        float(np.sum(weights * values) / np.sum(weights)),
+        float(np.sqrt(1.0 / np.sum(weights))),
+    )
+
+
+def volume_summary(
+    curvatures: dict[tuple[float, int, float], tuple[float, float]],
+    delta_v: float,
+    lengths: tuple[int, ...],
+    eta_values: tuple[float, ...],
+) -> tuple[float, float, dict[int, tuple[float, float]]]:
+    combined = {
+        length: combine_estimates(
+            [curvatures[(delta_v, length, eta)] for eta in eta_values]
+        )
+        for length in lengths
+    }
+    values = np.asarray([combined[length][0] for length in lengths])
+    propagated = np.sqrt(
+        np.sum([combined[length][1] ** 2 for length in lengths])
+    ) / len(lengths)
+    volume_sem = float(np.std(values, ddof=1) / np.sqrt(len(values)))
+    return float(np.mean(values)), max(float(propagated), volume_sem), combined
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scout", action="store_true")
+    arguments = parser.parse_args()
+    checks = Checks()
+
+    exact_rows: list[tuple[float, float, float]] = []
+    for delta_v in (0.0, -0.05, -0.10):
+        zero = exact_small_energy(delta_v, 0.0)
+        theta = 0.02
+        physical = exact_small_energy(delta_v, theta)
+        continued = exact_small_energy(delta_v, 1j * theta)
+        physical_curvature = 2.0 * (physical - zero) / (theta**2 * 8)
+        continued_curvature = -2.0 * (continued - zero) / (theta**2 * 8)
+        exact_rows.append((delta_v, physical_curvature, continued_curvature))
+    checks.check(
+        all(
+            physical > 0.0
+            and abs(physical - continued) / physical < 1e-4
+            for _, physical, continued in exact_rows
+        ),
+        "exact L=2 analytic continuation reproduces the positive Hermitian twist curvature",
+    )
+
+    lengths = (2, 4, 6) if arguments.scout else (2, 4, 6, 8, 10)
+    population = 512
+    sample_sweeps = 180 if arguments.scout else 300
+    eta_values = (0.12,) if arguments.scout else (0.10, 0.16)
+    primary: dict[tuple[float, int, float], TwistResult] = {}
+    all_results: list[TwistResult] = []
+    for detuning_index, delta_v in enumerate((-0.05, -0.10)):
+        for length in lengths:
+            zero = run_twist(
+                length,
+                delta_v,
+                0.0,
+                0,
+                population=(
+                    768 if not arguments.scout and length == 4 else population
+                ),
+                classical_sweeps=60,
+                burn_sweeps=120,
+                sample_sweeps=(
+                    360
+                    if not arguments.scout and length == 4
+                    else sample_sweeps
+                ),
+                seed=4_000_000 + 100_000 * detuning_index + 1000 * length,
+            )
+            primary[(delta_v, length, 0.0)] = zero
+            all_results.append(zero)
+            for eta_index, eta in enumerate(eta_values):
+                for sign_index, sign in enumerate((1.0, -1.0)):
+                    result = run_twist(
+                        length,
+                        delta_v,
+                        sign * eta,
+                        0,
+                        population=(
+                            768
+                            if not arguments.scout and length == 4
+                            else population
+                        ),
+                        classical_sweeps=60,
+                        burn_sweeps=120,
+                        sample_sweeps=(
+                            360
+                            if not arguments.scout and length == 4
+                            else sample_sweeps
+                        ),
+                        seed=(
+                            4_000_000
+                            + 100_000 * detuning_index
+                            + 1000 * length
+                            + 100 * eta_index
+                            + sign_index
+                            + 1
+                        ),
+                    )
+                    primary[(delta_v, length, sign * eta)] = result
+                    all_results.append(result)
+
+    curvatures: dict[tuple[float, int, float], tuple[float, float]] = {}
+    for delta_v in (-0.05, -0.10):
+        for length in lengths:
+            for eta in eta_values:
+                value = curvature_from_triplet(
+                    primary[(delta_v, length, 0.0)],
+                    primary[(delta_v, length, eta)],
+                    primary[(delta_v, length, -eta)],
+                )
+                curvatures[(delta_v, length, eta)] = value
+    checks.check(
+        all(value > 3.0 * error for value, error in curvatures.values()),
+        "every finite-volume imaginary-twist pair resolves positive physical magnetic curvature",
+    )
+    if not arguments.scout:
+        checks.check(
+            all(
+                abs(
+                    curvatures[(delta_v, length, eta_values[0])][0]
+                    - curvatures[(delta_v, length, eta_values[1])][0]
+                )
+                / np.mean(
+                    [
+                        curvatures[(delta_v, length, eta_values[0])][0],
+                        curvatures[(delta_v, length, eta_values[1])][0],
+                    ]
+                )
+                < 0.20
+                for delta_v in (-0.05, -0.10)
+                for length in lengths
+            ),
+            "two continuation radii reproduce the zero-angle curvature within twenty percent",
+        )
+
+    summaries: dict[float, tuple[float, float, dict[int, tuple[float, float]]]] = {}
+    rk_curvatures: dict[int, tuple[float, float]] = {}
+    orientation_curvatures: dict[int, tuple[float, float]] = {}
+    population_curvatures: dict[float, tuple[float, float]] = {}
+    join_rows: dict[float, tuple[float, float, float, float, float]] = {}
+    if not arguments.scout:
+        exact_by_detuning = {
+            delta_v: physical for delta_v, physical, _ in exact_rows
+        }
+        checks.check(
+            all(
+                abs(
+                    curvatures[(delta_v, 2, eta)][0]
+                    - exact_by_detuning[delta_v]
+                )
+                < max(
+                    4.0 * curvatures[(delta_v, 2, eta)][1],
+                    0.20 * exact_by_detuning[delta_v],
+                )
+                for delta_v in (-0.05, -0.10)
+                for eta in eta_values
+            ),
+            "the stochastic L=2 twist curvatures reproduce exact diagonalization",
+        )
+        for delta_v in (-0.05, -0.10):
+            summaries[delta_v] = volume_summary(
+                curvatures, delta_v, (4, 6, 8, 10), eta_values
+            )
+        checks.check(
+            all(
+                max(per_length[length][0] for length in per_length)
+                - min(per_length[length][0] for length in per_length)
+                < 0.10 * mean
+                for mean, _, per_length in summaries.values()
+            ),
+            "the L=4,6,8,10 magnetic response is volume-stable at both detunings",
+        )
+
+        # Directly measure the relaxed RK curvature.  This is distinct from
+        # the older phase-twisted variational expectation J n_f.
+        rk_results: list[TwistResult] = []
+        for length in lengths:
+            triplet = []
+            for eta_index, eta in enumerate((0.0, 0.16, -0.16)):
+                result = run_twist(
+                    length,
+                    0.0,
+                    eta,
+                    0,
+                    population=512,
+                    classical_sweeps=60,
+                    burn_sweeps=120,
+                    sample_sweeps=240,
+                    seed=6_000_000 + 1000 * length + eta_index,
+                )
+                triplet.append(result)
+                rk_results.append(result)
+            rk_curvatures[length] = curvature_from_triplet(*triplet)
+        all_results.extend(rk_results)
+        rk_values = np.asarray(
+            [rk_curvatures[length][0] for length in (4, 6, 8, 10)]
+        )
+        rk_mean = float(np.mean(rk_values))
+        rk_error = max(
+            float(np.std(rk_values, ddof=1) / 2.0),
+            float(
+                np.sqrt(
+                    sum(
+                        rk_curvatures[length][1] ** 2
+                        for length in (4, 6, 8, 10)
+                    )
+                )
+                / 4.0
+            ),
+        )
+        checks.check(
+            all(value > 5.0 * error for value, error in rk_curvatures.values())
+            and (max(rk_values) - min(rk_values)) < 0.15 * rk_mean,
+            "the relaxed RK twist curvature is positive and stable across L=4,6,8,10",
+        )
+        rk_variational = 0.2598
+        checks.check(
+            0.0 < rk_mean < 0.40 * rk_variational,
+            "the relaxed RK stiffness is strictly below the older flippability variational upper cost",
+        )
+        checks.check(
+            all(
+                abs(mean - rk_mean) / rk_mean < 0.10
+                for mean, _, _ in summaries.values()
+            ),
+            "the relaxed magnetic stiffness changes by less than ten percent across the two finite detunings",
+        )
+
+        # Cubic covariance is exact in the Hamiltonian; independent populations
+        # test that the implemented orientation labels do not bias the estimate.
+        orientation_results: list[TwistResult] = []
+        for orientation in range(3):
+            triplet = []
+            for eta_index, eta in enumerate((0.0, 0.16, -0.16)):
+                result = run_twist(
+                    6,
+                    -0.10,
+                    eta,
+                    orientation,
+                    population=512,
+                    classical_sweeps=60,
+                    burn_sweeps=120,
+                    sample_sweeps=240,
+                    seed=6_100_000 + 100 * orientation + eta_index,
+                )
+                triplet.append(result)
+                orientation_results.append(result)
+            orientation_curvatures[orientation] = curvature_from_triplet(*triplet)
+        all_results.extend(orientation_results)
+        orientation_values = np.asarray(
+            [orientation_curvatures[axis][0] for axis in range(3)]
+        )
+        checks.check(
+            (max(orientation_values) - min(orientation_values))
+            < 0.06 * np.mean(orientation_values),
+            "three independently sampled cubic orientations reproduce one magnetic response",
+        )
+
+        population_results: list[TwistResult] = []
+        for detuning_index, delta_v in enumerate((-0.05, -0.10)):
+            triplet = []
+            for eta_index, eta in enumerate((0.0, 0.16, -0.16)):
+                result = run_twist(
+                    8,
+                    delta_v,
+                    eta,
+                    0,
+                    population=1024,
+                    classical_sweeps=90,
+                    burn_sweeps=180,
+                    sample_sweeps=360,
+                    seed=7_000_000 + 10_000 * detuning_index + eta_index,
+                )
+                triplet.append(result)
+                population_results.append(result)
+            population_curvatures[delta_v] = curvature_from_triplet(*triplet)
+        all_results.extend(population_results)
+        checks.check(
+            all(
+                abs(
+                    population_curvatures[delta_v][0]
+                    - summaries[delta_v][2][8][0]
+                )
+                / summaries[delta_v][2][8][0]
+                < 0.08
+                for delta_v in (-0.05, -0.10)
+            ),
+            "doubled L=8 populations reproduce the primary magnetic response within eight percent",
+        )
+
+        # The direct comparison uses the parent finite-volume electric
+        # stiffness and transverse coefficient without refitting either.
+        electric = {-0.05: (0.162638, 0.015345), -0.10: (0.321114, 0.026769)}
+        dynamic = {
+            -0.05: (0.02716169, 0.00532235),
+            -0.10: (0.03268255, 0.00548929),
+        }
+        for delta_v in (-0.05, -0.10):
+            stiffness, stiffness_error, _ = summaries[delta_v]
+            electric_value, electric_error = electric[delta_v]
+            dynamic_value, dynamic_error = dynamic[delta_v]
+            prediction = electric_value * stiffness
+            prediction_error = np.hypot(
+                electric_value * stiffness_error,
+                stiffness * electric_error,
+            )
+            discrepancy = (dynamic_value - prediction) / np.hypot(
+                dynamic_error, prediction_error
+            )
+            join_rows[delta_v] = (
+                prediction,
+                prediction_error,
+                dynamic_value,
+                dynamic_error,
+                float(discrepancy),
+            )
+        checks.check(
+            join_rows[-0.05][4] > 2.0
+            and 0.0 < join_rows[-0.10][4] < 2.0,
+            "the same-detuning Maxwell comparison localizes a weak-detuning spectral-normalization tension while the stronger detuning remains statistically compatible",
+        )
+
+    checks.check(
+        all(
+            result.count_consistent
+            and result.sector_consistent
+            and result.invalid_acceptances == 0
+            for result in all_results
+        ),
+        "every twisted projector preserves exact local weights, Gauss charge, flux, and valid transition probabilities",
+    )
+    checks.check(
+        min(result.minimum_effective_fraction for result in all_results) > 0.85
+        and min(result.final_unique_fraction for result in all_results) > 0.20,
+        "every twisted population retains the declared weight and diversity floors",
+    )
+
+    for delta_v, physical, continued in exact_rows:
+        print(
+            "EXACT_CONTINUATION",
+            f"V={1.0 + delta_v:.2f}",
+            f"K_real={physical:.9f}",
+            f"K_imag={continued:.9f}",
+        )
+    for key in sorted(curvatures):
+        delta_v, length, eta = key
+        value, error = curvatures[key]
+        print(
+            "TWIST",
+            f"V={1.0 + delta_v:.2f}",
+            f"L={length}",
+            f"eta={eta:.2f}",
+            f"K={value:.6f}+/-{error:.6f}",
+        )
+    if not arguments.scout:
+        for delta_v in (-0.05, -0.10):
+            mean, error, per_length = summaries[delta_v]
+            print(
+                "SUMMARY",
+                f"V={1.0 + delta_v:.2f}",
+                f"K={mean:.6f}+/-{error:.6f}",
+                "K_L="
+                + ",".join(
+                    f"{length}:{per_length[length][0]:.6f}"
+                    for length in per_length
+                ),
+            )
+        print(
+            "RK_RELAXED",
+            f"K={rk_mean:.6f}+/-{rk_error:.6f}",
+            "K_L="
+            + ",".join(
+                f"{length}:{rk_curvatures[length][0]:.6f}"
+                for length in (4, 6, 8, 10)
+            ),
+            "variational_upper=0.259800",
+        )
+        print(
+            "ORIENTATION_CONTROL",
+            ",".join(
+                f"axis={axis}:{orientation_curvatures[axis][0]:.6f}"
+                for axis in range(3)
+            ),
+        )
+        for delta_v in (-0.05, -0.10):
+            print(
+                "POPULATION_CONTROL",
+                f"V={1.0 + delta_v:.2f}",
+                f"primary={summaries[delta_v][2][8][0]:.6f}",
+                f"doubled={population_curvatures[delta_v][0]:.6f}"
+                f"+/-{population_curvatures[delta_v][1]:.6f}",
+            )
+            prediction, prediction_error, dynamic_value, dynamic_error, z = (
+                join_rows[delta_v]
+            )
+            print(
+                "MAXWELL_JOIN",
+                f"V={1.0 + delta_v:.2f}",
+                f"UK={prediction:.6f}+/-{prediction_error:.6f}",
+                f"c2_dynamic={dynamic_value:.6f}+/-{dynamic_error:.6f}",
+                f"difference_sigma={z:.3f}",
+            )
+    print(
+        "HEALTH",
+        f"min_ess={min(result.minimum_effective_fraction for result in all_results):.6f}",
+        f"min_unique={min(result.final_unique_fraction for result in all_results):.6f}",
+    )
+    print(
+        "CERTIFICATE: exact_L2_real_twist=True imaginary_twist_positive_projector=True "
+        "finite_population=True finite_imaginary_time=True thermodynamic_limit=False"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- directly measures the relaxed magnetic-twist curvature of finite-detuning spin-half cubic ice with a sign-free imaginary-twist continuation
- validates the continuation against ordinary Hermitian exact diagonalization on L=2
- resolves positive, volume-stable same-detuning magnetic response and distinguishes it from the older RK variational upper cost
- performs the non-refitted Maxwell join against the parent electric stiffness and transverse coefficient

## Physics result

- V=0.95: K = 0.075561 +/- 0.000915
- V=0.90: K = 0.076589 +/- 0.001155
- relaxed RK: K = 0.073357 +/- 0.000881
- prior RK J n_f near 0.2598 remains a positive variational upper cost, not the relaxed curvature
- UK versus dynamic c^2 differs by 2.729 combined reported errors at V=0.95 and 1.378 at V=0.90

This positively closes the finite-volume magnetic-response question. It does not yet close the quantitative static-dynamic Maxwell identity or establish a thermodynamic photon pole. It changes no audit verdict, TOE score, axiom, or approved primitive.

## Verification

- runner: TOTAL: PASS=13 FAIL=0
- exact real/imaginary L=2 continuation control: pass
- L=4,6,8,10 volume ladder: pass
- two continuation radii: pass
- three cubic orientations: pass
- doubled L=8 populations: pass
- minimum effective population: 0.946030
- cache identity, staged claim typing, citation graph, enforced links, repo invariants, strict audit lint, vocabulary, and staged diff: pass

## Stack

Depends on #7945. It does not modify or duplicate the pair-update connectivity work in #7942.