### PR TITLE
feat(ticks): no site-wise formation rule preserves the sea; the eigenvector condition is per step and set-wise

### DIFF
--- a/docs/NO_SITE_WISE_FORMATION_RULE_PRESERVES_THE_SEA_UNDER_TICK_EVOLUTION_THE_EIGENVECTOR_CONDITION_IS_PER_STEP_AND_SET_WISE_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/NO_SITE_WISE_FORMATION_RULE_PRESERVES_THE_SEA_UNDER_TICK_EVOLUTION_THE_EIGENVECTOR_CONDITION_IS_PER_STEP_AND_SET_WISE_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: no_site_wise_formation_rule_preserves_the_sea_2026_09_03
+claim_type: bounded_theorem
+claim_scope: "On two finite subgraphs of the cubic lattice with qubits on the EDGE sites, ordinary composition, the superfast encoding and the corner parity dictionary n_v = (1 - B_v)/2, in the staggered (pi-flux) Kawamoto-Smit sector H = -sum_e eta_e T_e, t = 1, at half filling -- the 2x2x2 cube (8 corners, 12 edge sites, record space 2^12, sea E = -4 sqrt 3) and the 2x2x3 slab open in z (12 corners, 20 edge sites, record space 2^20 held on the half-filled sector J, |J| = 473088, sea E = -(8 + 2 sqrt 2)) -- for the STIPULATED tick of PR #7876 Model A (Lueders formation with the Born odds of the pre-record state; exp(-i tau H_R) between formations, H_R the hop terms on the unrecorded edges) and for the DECLARED formation rules A1/A1v (energy above the sea, edge and corner form), A2/A2v (energy scale), B (least entangled first), E (eigenvector first), the 24 declared orders C and the corner-set rule D, each walked as a complete exact tree (greedy paths for the stochastic rules, the odds along the path quantified): (T1) at tau = 0 every rule reproduces the sea's registration exactly (TV <= 8.2e-17), so rate selection in the instantaneous limit says nothing about rates; (T2) at tau = 0.5 every site-wise rule and every one of the 24 orders ends at TV 0.289-0.456 from the sea's law with all 256 cancellation zeros lost (support 2240), the average of the 24 orders is closer (0.239) with the same support, the same holds at tau = 0.1 and 2.0, and D keeps all 2112 zeros at TV <= 1.2e-15; (T3) on the slab, exact sparse trees to six records at tau = 0.5 give full-law TV 0.115-0.139 after one record and 0.212-0.409 after six for every rule, while the leaf-TV on the formed sites is <= 7.2e-14 at three records for every rule and through six for A2/A2v; (T4) the energy-above-sea rule is exactly uniform in the instantaneous limit and at finite tau orders formation along the evolution's own energy spread -- the four parallel z-edges, a matching -- with the greedy site carrying 0.50-1.00 (cube) and 0.44-0.61 (slab) of the odds at steps 2-4, its record odds exact for three records and off by 0.189 at the fourth; the corner energy-scale form follows the degree-4 corners' edges and is the worst rule by the full law (0.409); (T5) the SUFFICIENT condition is per step and set-wise: if the conditioned state is an H_R eigenvector after each formation the registration is exact for every tau, which holds when each formed set is a union of whole corner stars satisfying the two-mode condition, and the necessary diagonal-invariance (dephasing) condition is met by no non-eigenvector node in any of 12 scanned trees (0 of 27848; smallest displacement 7.1e-05) and by no single edge site at any step (best-site residual >= 0.496 for seven steps on the cube, 0.5638-0.7354 on the slab); (T6) the column pair of degree-3 stars star(0) u star(2) on the slab restores the exact eigenvector property as a six-record joint tick (residual 2.1e-15 at all 64 outcomes, full-law TV 3.6e-16 after the tick) although each star alone leaves 0.207107 = (sqrt 2 - 1)/2 and the same six sites formed one at a time with tau = 0.5 ticks end at TV 0.316. The tick, the rules and the orders are stipulated reconstructions supplied by no axiom; no rate, unit or tick is foreclosed; the dephasing condition is shown unmet numerically, not proved impossible. No seeds anywhere."
+upstream_dependencies: []
+runner: scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py
+---
+
+# No site-wise formation rule preserves the sea's registration under tick evolution; the eigenvector condition is per step and set-wise
+
+**Date:** 2026-09-03
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py`](../scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py)
+**Runner cache:**
+[`logs/runner-cache/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.txt`](../logs/runner-cache/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.txt)
+**Parents:** none. Every premise used below is declared in this note.
+
+`RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_..._2026-09-03.md` (open PR #7876) found that on the `2x2x2` cube no pre-record state is invariant under all the post-record
+Hamiltonians, so a tick in which records form one site at a time with unitary evolution between them does not reproduce the sea's registration. `JOINT_FORMATION_ON_A_CORNERS_RECORD_SET_...`
+(open PR #7900) and `THE_CORNER_EIGENVECTOR_PROPERTY_IS_A_TWO_MODE_SPECTRAL_CONDITION_...` (open PR #7902) found the one unit that does: a corner's whole record set forming together, at
+corners whose site vector lives in exactly two one-particle modes. The question those results leave open, asked with the formation-rate ruler of PRs #7916 and #7925 in view, is whether
+a **site-wise rule that chooses where the next record forms** -- a rate keyed to the local energy above the sea, or any other function of the pre-record state -- could restore the sea's
+registration where the plain tick loses it. This note answers it on the cube and on the `2x2x3` slab, by complete exact trees: **no.** The site rule is invisible without evolution,
+changes the distance to the sea by at most a factor `1.6` with it, and never recovers the sea's zeros. The preserving rule lives in the **set** a tick forms, per step, and that set-wise
+rule extends one step beyond the flat-band corners -- as a six-record joint tick on a pair of degree-`3` stars, never site-wise.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Finite-sector statements on two named clusters -- the 2^12 record space of the 2x2x2 cube and the 2^20 record space of the 2x2x3 slab, in the staggered sector at half filling -- for the stipulated tick of PR #7876 Model A and for formation rules declared in full in this note. Every tree is a complete exact enumeration in the unnormalised-branch form (one vector per level, one node label per basis state), so the final laws, the per-node residuals and the per-node diagonal displacements are deterministic double-precision evaluations of exactly specified quantities at the stated thresholds; the propagator is a Chebyshev series under the rigorous bound ||H_R|| <= number of free edges, checked against expm_multiply to 1e-16. The setting checks are exact symplectic Pauli and F2 arithmetic. Nothing is sampled, there is no seed anywhere in the runner, every order and set is written out, and no dense object above 4096 x 4096 is formed."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Carry the set-wise criterion into the tick lane as the object to compute: which unions of corner stars are eigen-sets on a given cluster, by the invariance of the occupied one-particle space restricted to the deleted vertex set -- the multi-site form of PR #7902's two-mode condition -- and whether every corner of a larger open slab belongs to some eigen-set; report the full record law, never the leaf statistics."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the six theorems below, exactly the runner's check groups: the cube's setting (`A1`), `T1` (`A2`), `T2` (`A3`-`A5`), `T4` on the cube (`A6`), `T5`
+(`A7`-`A8`), the slab's setting (`B1`), `T3` (`B2`-`B4`), `T4` on the slab (`B5`), `T6` (`B6`-`B7`) and the timing (`B8`). `A1` and `B1` carry **exact** content: the encoding
+relations `R0`-`R4` in symplectic Pauli arithmetic with phases mod `4`, the face group, the flux sector, and the cluster combinatorics. Everything else is a **deterministic
+double-precision evaluation** of an exactly specified quantity at the stated threshold. Nothing is sampled: the Lanczos start vector on the slab is the fixed vector
+`cos(0.7 i + 0.3) + i cos(1.3 i + 1.1)` projected into the code space, written out in the runner, and every rule, order and set is written out there too. There is **no seed anywhere**.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. The Bravyi-Kitaev superfast encoding, the Kawamoto-Smit staggered signs, Lueders conditioning, Lanczos, the Jacobi-Anger
+expansion of the propagator and the total-variation distance are standard methodology; every object is redeclared here and the runner recomputes every statement, the encoding's
+relations included. No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no weight, with each one's
+state at the time of writing: `RECORD_TICKS_ADMIT_NO_INVARIANT_PRE_RECORD_STATE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (**open PR #7876, not on main** -- the tick, Model A, its
+representative `tau = 0.5`); `A_RELAXATION_TICK_IS_WELL_POSED_AND_LOSES_THE_SEAS_RECORD_STATISTICS_BOUNDED_THEOREM_NOTE_2026-09-03.md` (**open PR #7895, not on main** -- the
+relaxation tick `M_R`, a different model already excluded there, and the restriction identity `P_S H P_S = H_R`);
+`JOINT_FORMATION_ON_A_CORNERS_RECORD_SET_KEEPS_THE_SEAS_ZEROS_UNDER_THE_UNITARY_TICK_BOUNDED_THEOREM_NOTE_2026-09-03.md` (**open PR #7900, not on main** -- the corner-set unit, rule
+`D` here); `THE_CORNER_EIGENVECTOR_PROPERTY_IS_A_TWO_MODE_SPECTRAL_CONDITION_EXACT_ON_FLAT_BANDS_NOT_GENERAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (**open PR #7902, not on main** -- the
+two-mode condition, the slab's failing degree-`3` corners, and the blindness of marginal tests);
+`THE_RECORD_DENSITY_RULER_IS_ONE_PRODUCT_KAPPA_NU_EQUALS_ONE_AND_THE_HALF_FILLED_SEA_SUPPLIES_ZERO_BOUNDED_THEOREM_NOTE_2026-09-03.md` (**open PR #7916, not on main** -- the ruler
+whose rate form the energy-above-sea rule `A1` reproduces) and `A_FORMATION_RATE_RULER_EVADES_THE_SEAS_SUBLATTICE_CANCELLATION_..._2026-09-04.md` (**open PR #7925, not on main** --
+the corner form of that rate, `A1v` here); and `MINIMAL_AXIOMS_2026-06-29.md` (on main), from which the axiom text in "Setting" is quoted verbatim. This note cites no grade of any
+and consumes no ledger row.
+
+## Setting
+
+The four framework axioms are quoted, not amended. Lattice / Physical Locality and Qubit / Site Possibility are used only through the graph structure of the two clusters and the
+`M_2(C)` site algebra. **Admissibility / Local Constraint**, verbatim: "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic
+rotations." "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions." Reading note (2), interpretive and
+non-governing, is quoted with it because it is what makes every rule below a free choice: "Read with Record, the distribution concerns which possibility a forming record locks,
+conditional on formation at that site; it does not supply the formation site, probability, or rate." **Record / Fixed Reality**, verbatim: "Records form." "When present, a record locks
+exactly one admissible local possibility. A site never carries more than one record; records are permanent." "Only records are readable. A readout value is determined by record content
+alone. A site with no record cannot be read."
+
+Composition is **ordinary**: the algebra of a region is the tensor product of its sites' algebras and operators on disjoint regions commute. A record at an edge site **registers** a
+`Z`-value there; it does not report one the site already carried. The **tick** is PR #7876's Model A, adopted unchanged: a forming record locks its value by Lueders conditioning with
+the Born odds of the current pre-record state, and between formations the pre-record state runs by `exp(-i tau H_R)`, `H_R` the sum of the hop terms on the unrecorded edges, which is
+exactly `P_S H P_S` on the record sector because every hop's Pauli `X`-part is one edge qubit. `tau = 0` is the boundary in which records form faster than the state can run.
+
+**The rules, declared in full.** A rule is a map (current state `psi`, record set `R`) to the next site. Greedy means the deterministic argmax, ties broken by the lowest edge index
+after rounding to `1e-9`. `A1`, energy above the sea: `r_q = max(eps_q(psi) - eps_q(sea), 0)`, `eps_q = <psi|h_q|psi>` with `h_q = -eta_q T_q` the hop term of edge `q`; its stochastic
+odds are `r_q / sum r` (uniform when all vanish), and along the greedy path the runner reports their **contrast** (largest odds times the number of free sites, `1` = uniform) and the
+odds of the greedy site. `A1v`, the corner form: `eps_v = (1/2) sum_{e in star(v)} eps_e`, `r_e = max((excess_i + excess_j)/2, 0)` for `e = (i, j)`. `A2`, energy scale: `r_q =
+|eps_q(psi)|`; `A2v` its corner form. `B`, least entangled first: argmax of the purity `Tr rho_q^2` of the one-site reduced state, `rho_q = [[p0, c], [c*, p1]]`. `C`, declared orders:
+the identity `0..11` and its `11` cyclic shifts, the reverse and its `11` cyclic shifts (`24` orders on the cube); the identity `0..5` on the slab. `D`, corner sets: joint formation of
+whole corner stars on the even sublattice -- cube `star(0), star(3), star(5), star(6)`, a partition of the `12` edges; slab `star(4), star(7)` (degree `4`) -- evolving after each star.
+`E`, eigenvector first: argmin over free `q` of the Born-weighted `H_{R+q}` eigenvector residual of the two conditioned states; the rule **exists** at a step iff that minimum is `0`.
+
+**Reading, not theorem.** The tick, Lueders formation with Born odds, the rate rules and the declared orders are stipulated reconstructions of what would be registered -- they are
+not axiom content, and nothing here is presented as following from an axiom. Reading note (2) is explicit that Admissibility supplies no formation site, probability or rate; the axioms
+supply no formation unit either. Every rule above is a candidate for what the axioms leave open, and the theorems say what each candidate does to the sea's registration.
+
+## Definitions
+
+The **cube** is the `2x2x2` cube graph: `8` corners, `12` edge sites, `6` faces, every corner of degree `3`, record space `2^12 = 4096`. The **slab** is the `2x2x3` lattice open
+in `z`: `12` corners, `20` edge sites, `11` faces, degree `4` at the four middle corners `1, 4, 7, 10` and `3` at the other eight; vertices indexed `(x*Ly + y)*Lz + z`; its record
+space `2^20` is held on the half-filled sector `J` (`N = 6`, `|J| = 473088`). The encoding, the staggered signs `eta_x = 1`, `eta_y = (-1)^x`, `eta_z = (-1)^(x+y)` (flux `-1` on
+every face of both clusters), `H = -sum_e eta_e T_e` with `T_ij = (i/2) A_ij (B_i - B_j)`, the code space (all `S_f = +1`, dimension `128` and `2048`) and the **sea** (the ground
+state of `H` there at half filling) are PR #7902's. A **tree** is the complete branching of the tick under a rule: a node is a record set `R` with values `w` and the branch state
+`psi_{R,w}`; the **law** after every edge has formed is the distribution on the `2^12` patterns (cube), and the **full law** at `k` records on the slab is the `20`-edge law obtained by
+registering every remaining edge at once from the propagated branches. `TV` is total variation, `(1/2) L1`, against the sea's Born law. The sea's **zeros** on the cube are `2112`:
+`1856` **charge zeros** (patterns with `N != 4`) and `256` **cancellation zeros** (the `8` closed corner stars times `32`), both exact. The **residual** of a branch state under `H_R`
+is `||H_R psi - <H_R> psi||`; the **diagonal displacement** of a tick is the `TV` by which `exp(-i tau H_R)` changes the branch state's `Z`-diagonal; **margerr** is the difference
+between the next record's odds and the sea's own conditional `P_sea(z_q = b | z_R = w)`; the **leaf-TV** at `k` records is `(1/2) sum_leaves |p_rule - p_sea|` on the formed sites.
+
+## Theorem 1 -- with no evolution every rule is exact, so the instantaneous limit says nothing about rates
+
+**Conclusion.** `[numerical, 1e-12]` At `tau = 0` every rule -- `A1`, `A1v`, `A2`, `A2v`, `B`, `E`, `D`, each of the `24` declared orders and their average -- ends at `TV <= 8.2e-17`
+from the sea's law, with support `1984` and all `1856` charge and `256` cancellation zeros kept; the next record's odds equal the sea's own conditional at every node
+(`margerr <= 4.1e-17`). The energy-above-sea odds are **exactly uniform** at steps `1`-`5` (contrast `1.0000` at each). `[numerical, 1e-12]` The conditioned sea is an `H_R`
+eigenvector after a single edge forms at none of the `12` edges (residual `0.577350 = 1/sqrt 3` at every one) and exactly when a corner star is completed (`1.4e-14` at `star(0)`);
+rule `E` on the un-evolved sea finds this by itself, `0.577 / 0.577 / 0.000` at its first three records.
+
+**Proof.** Sequential Lueders conditioning of a fixed state is order-independent and the products of the conditional odds telescope to the state's own Born law, so with no evolution
+every tree returns the sea's law identically; the runner walks each tree anyway and reports the distance. Uniformity of `A1`: Lueders conditioning deposits the excess energy on the
+recorded edge alone (`<h_e>` goes from `-0.5774` to `0`) and leaves every unrecorded edge's local energy untouched until the record set contains a whole star, and on the flat-band cube
+even then only at the star's neighbours.
+
+**Reading, not theorem.** The rule is invisible without evolution. Rate selection in the instantaneous limit is exact for every rule and therefore tests none.
+
+## Theorem 2 -- on the cube every site-wise rule loses all 256 cancellation zeros, at every declared tick
+
+**Conclusion.** `[numerical, 1e-12]` At `tau = 0.5`, the final `4096`-pattern law sits at `TV` `0.337565692` (`A1`), `0.320717027` (`A1v`), `0.422413255` (`A2`), `0.449953329`
+(`A2v`), `0.453896665` (`B`), `0.362827766` (`E`) from the sea's, with support `2240` -- all of `N = 4` -- so every one of the `256` cancellation zeros is lost while the `1856` charge
+zeros are kept by everything (`N` is conserved and diagonal in the record basis). The `24` declared orders give `0.289380397` (the reverse order, the best) to `0.456208220`, mean
+`0.379401338`, identity `0.324925161`, each with support `2240`; the **average** of the `24` laws is closer, `TV 0.239288631`, and has support `2240` as well, so no mixture of site-wise
+trees reaches the sea. Rule `D` keeps all `2112` zeros at `TV 6.8e-16`, its branch states eigenvectors at every node (residual `<= 1.4e-14`, diagonal displacement `<= 1.1e-15`).
+`[numerical, 1e-12]` At `tau = 0.1`: `A1 0.2603`, `A1v 0.1298`, `A2 0.0704`, `A2v 0.2679`, `B 0.1527`, `E 0.1203`, orders `0.0459`-`0.2990`; at `tau = 2.0`: `0.4691`, `0.3604`,
+`0.4662`, `0.3263`, `0.3698`, `0.4149`, orders `0.3272`-`0.5243`; every site-wise law has support `2240` and `0` of `256` cancellation zeros at both, the rules cross each other
+(`A2` best at `0.1`, among the worst at `0.5` and `2.0`), and `D` is exact at both (`3.2e-16`, `1.2e-15`).
+
+**Proof.** Complete exact trees: `124` of them on the `4096`-dimensional record space, each level one vector, each node's odds a bincount, each evolution the Chebyshev series of
+`exp(-i tau H_lev)` with `H_lev` the sparse `H` with every node's own recorded hops masked out. The census counts the patterns of the final law below `1e-14` against the sea's exact
+zero set.
+
+**Reading, not theorem.** Whatever site the rule prefers, the first tick after the first record already leaks weight into the patterns the sea forbids, and no later choice takes
+it back. Choosing the order changes the distance by a factor of at most `1.6`; it never changes the support.
+
+## Theorem 3 -- on the slab the full law leaks from the first record and the leaf statistics cannot see it
+
+**Conclusion.** `[numerical, 1e-10]` Exact sparse trees to six records at `tau = 0.5`, full `20`-edge law against the sea's, for `A1 / A1v / A2 / A2v / B / E / C`: after one record
+`0.1148 / 0.1148 / 0.1259 / 0.1387 / 0.1259 / 0.1259 / 0.1148`, the propagated object already off the sea's support `411648` (supports `436224`-`458752`); after six
+`0.3727 / 0.2116 / 0.3895 / 0.4089 / 0.3431 / 0.3167 / 0.3156`. The sites formed, in order: `A1` `(0,1)(3,4)(6,7)(9,10)(5,11)(2,8)`; `A1v` `(0,1)(0,3)(0,6)(6,7)(6,9)(3,9)`; `A2`
+`(0,3)(0,6)(3,9)(0,1)(5,11)(6,9)`; `A2v` `(1,4)(7,10)(1,7)(0,3)(5,11)(2,8)`; `B` `(0,6)(0,3)(0,1)(2,8)(2,5)(1,2)`; `E` `(0,3)(0,6)(6,9)(1,7)(0,1)(6,7)`. At `tau = 2.0` (`A1`, `C`):
+`0.0268 / 0.0268` after one record, `0.353 / 0.347` after six -- same picture, different numbers. `[numerical, 1e-10]` The **leaf-TV** on the formed sites is `<= 7.2e-14` at three
+records for every rule, while the full law is already `0.207`-`0.314` away; `A2` and `A2v` stay at `2.6e-14 / 2.1e-14` through six records with full-law `TV 0.389 / 0.409`; `A1`
+breaks at the fourth record (`0.152`, and stays there), `A1v` at the fifth (`0.118`), `B`, `E`, `C` only at the sixth (`0.079 / 0.146 / 0.023`). `[numerical, 1e-9]` Rule `E` does not
+exist on the slab: the minimum over free sites of the conditioned-state residual is `0.5638 / 0.6358 / 0.6389 / 0.6943 / 0.6829 / 0.7354` at records `1`-`6`, identical across every
+branch of a level (spread `<= 1.3e-15`), never `0`, and ending above where it began. Along every rule's path the branch residual is `0.50`-`1.37` and the tick displaces the diagonal by
+`0.078`-`0.291`.
+
+**Proof.** The `2^20` record space is touched only on `J` by sparse Pauli strings; the sea comes from Lanczos at the declared start, projected into the code space and polished by
+`20` shifted power steps, with `E = -(8 + 2 sqrt 2)` to `0.0e+00` and residual `2.5e-15` when the Rayleigh quotient is reduced exactly (a sequential reduction over `473088` terms is
+off by `3.8e-12`, the cancellation trap PR #7902 named; every residual near zero reported here uses an exact or pairwise reduction). The leaf-TV and the full law are two bincounts of the
+same propagated vector.
+
+**Reading, not theorem.** A lane that checks a site-wise tick by comparing the records it formed with the sea's odds on those sites will see agreement to `1e-13` for three
+records, and for `A2` and `A2v` for all six, while the full record law is a third of the way to somewhere else. Only the full law discriminates.
+
+## Theorem 4 -- what the energy-rate rule does: uniform at the instant, then a matching along the evolution's own spread
+
+**Conclusion.** `[numerical, 1e-12]` On the cube at `tau = 0.5`, `A1` forms `(0,1)(2,3)(4,5)(6,7)` -- the four `z`-edges, a perfect matching, no star -- with contrast
+`1.00 / 5.50 / 6.85 / 9.00` and the greedy site carrying `0.083 / 0.500 / 0.685 / 1.000` of the odds at steps `1`-`4`: uniform at step `1` exactly, and the greedy path the process's
+dominant path from step `2`. The odds of the first three records are still the sea's own (`margerr 0 / 6e-15 / 1e-15`) and break at the fourth (`0.189`); the branch state is never an
+eigenvector (residual `0.58 / 0.85 / 0.84 / 0.45`) and the tick displaces its diagonal by `0.125 / 0.140 / 0.129 / 0.056`. The corner form `A1v` completes `star(0)` and then
+`star(4)` site-wise within five records, and its third record -- the one that completes `star(0)` -- leaves residual `0.671`, not `0`, because the two earlier ticks already took the
+state off the conditioned sea. `[numerical]` On the slab, `A1` is uniform at step `1` (contrast `1.000000`), then contrast `8.4 / 8.4 / 10.4 / 5.0 / 8.7` with the greedy site at
+`0.440 / 0.466 / 0.611 / 0.311 / 0.579` at steps `2`-`6`, forming the four parallel `z`-edges between the two stacked cubes first. The corner energy-scale form `A2v` forms the middle
+edges `(1,4)(7,10)(1,7)` first -- the edges of exactly the degree-`4` corners where PR #7902's two-mode condition holds -- and is the **worst** rule by the full law at six records
+(`0.4089`, the maximum of `0.373 / 0.212 / 0.389 / 0.409 / 0.343 / 0.317 / 0.316`).
+
+**Proof.** The rates are the declared functions of the branch state, evaluated per node by bincounts of the same products that give the local energies; the stochastic odds are read
+off the same rates along the greedy path. Which site the rate selects at `tau = 2.0` differs from the `tau = 0.5` choice (the slab path becomes `(0,1)(4,5)(8,11)(2,5) ...`), so the
+order a rate selects is itself a function of `tau`.
+
+**Reading, not theorem.** At the instant the rate sees nothing: the excess energy of a record sits on the recorded edge. With evolution the hop dynamics spreads that excess to the
+edge across the pi-flux face and the rate follows it, forming parallel edges rather than stars. Its corner form does complete stars, but one edge at a time, after the state has
+already left the sea. The one rate that follows the flat-band corners is the worst of all by the full law: the flat-band structure belongs to the whole star, not to its edges.
+
+## Theorem 5 -- the condition is per step and set-wise; the site-wise dephasing condition is met nowhere computed
+
+**Conclusion.** `[numerical, 1e-12]` **Sufficient condition, proved.** If at every node the conditioned state `P_w|sea>` is an eigenvector of `H_R`, then `exp(-i tau H_R)` is a
+phase on it, the branch state stays `P_w|sea>` for every `tau`, and the rule reproduces the sea's registration exactly for every completion. This holds when each formed set is a union
+of whole corner stars satisfying the two-mode condition: `P_w = 2^-d sum_T eps_T Z_T` with every `Z_T` commuting with `H_R`, so `P_w|sea>` is an `H_R` eigenvector iff the fermionic
+projection is (PR #7902). Rule `D` on the cube is the instance: `TV 6.8e-16 / 3.2e-16 / 1.2e-15` at `tau = 0.5 / 0.1 / 2.0`. `[numerical, 1e-9]` **Set-wise, not site-wise.** The
+residual of the sea conditioned on two edges of one star is `0.577350`, on two parallel `z`-edges `1.000000`, on two far edges `0.816497 = sqrt(2/3)`, on a whole star `1.4e-14`, on
+three edges not a star `1.290994`, on `A1`'s four-edge matching `1.323435`: for a partial star the logical content of `P_w` is `I` alone and the criterion is never met. Rule `E`'s
+best-site residual along its own path at `tau = 0.5` is `0.577 / 0.685 / 0.671 / 0.643 / 0.552 / 0.512 / 0.496` at steps `1`-`7`, and the first branch in which some site leaves an
+eigenvector appears at step `9`, with four free edges left, long after the law has left the sea (`E`'s final `TV 0.362828`, `0` of `256` cancellation zeros). `[numerical]` **Necessary
+condition, tested.** A branch state that is not an `H_R` eigenvector has an invariant `Z`-diagonal for all `tau` iff the dephasing condition `sum_{k,l : E_k - E_l = Delta} c_k c_l^*
+<z|k><l|z> = 0` holds for every `z` and every `Delta != 0`. Over `12` trees (`A1`, the identity order, `A1v`, `B` at `tau = 0.5, 0.1, 2.0`; `5246`-`5822` nodes each) every node with
+residual `> 1e-6` has diagonal displacement `> 7.1e-05` (`0` invariant of `27848`; the smallest displacement `7.1e-05` at `tau = 0.1`, `8.2e-04` at `0.5`, `3.6e-03` at `2.0`) and
+every node with residual `<= 1e-6` has displacement `< 1e-9` (`0` displaced of `40672`).
+
+**Proof.** The sufficient half is two lines: a phase on the branch state leaves its `Z`-diagonal and therefore every later conditional untouched. The set-wise statement is PR #7902's
+factorisation, reproduced by the declared-set residuals. The scan reads each node's residual before its tick and its displacement after it from the same level vectors.
+
+**Reading, not theorem.** A tick preserves the sea's registration when the state it leaves behind after each formation is one the remaining law holds still. No single edge ever
+leaves such a state on either object; only a set that is a whole star -- or a union of stars with the right spectral property -- does. That is what a site-wise rule cannot buy: it can
+choose the order, and the order is not the issue.
+
+## Theorem 6 -- the positive result: a pair of degree-3 stars is an eigen-set, as a six-record joint tick
+
+**Conclusion.** `[numerical, 1e-11]` With no evolution, rule `E` run on the sea of the slab forms `(0,3)(0,6)(0,1)` and then `(1,2)(2,5)(2,8)` -- `star(0)` and then `star(2)`, the
+two degree-`3` stars flanking the degree-`4` corner `1` along `z` -- with best residuals `0.5638 / 0.5210 / 0.2071 / 0.5210 / 0.5638 / 0.0000`. Each star alone leaves
+`0.207107 = (sqrt 2 - 1)/2` at all `8` outcomes (PR #7902's failing value), and the **column pair `star(0) u star(2)` restores the exact eigenvector property**: residual `<= 2.1e-15`
+at all `64` outcomes. As a **six-record joint tick** at `tau = 0.5` the pair keeps the sea: residual `2.1e-15`, diagonal displacement `<= 4.0e-16`, full-law `TV 3.6e-16` on the
+sea's own support `411648`. The **same six sites formed one at a time** with `tau = 0.5` ticks between them (rule `C`, the identity order, is exactly this sequence) leak from the
+first record and end at full-law `TV 0.3156`. The degree-`4` sets `D` (`star(4)` then `star(7)`, joint, evolving between) give full-law `TV 2.4e-16 / 3.3e-16` at `4 / 8` records,
+residual `<= 3.9e-15`, support `411648`.
+
+**Proof.** One joint formation of the six edges is one relabelling of the level vector into `64` sectors; the residual of each sector's normalised state under `H_R`, the tick, its
+displacement and the full law follow as in every other tree. The single-star controls are the same computation on three edges.
+
+**Reading, not theorem.** PR #7902 found that a degree-`3` corner of the slab fails the two-mode condition and nothing at that corner restores it. The pair of degree-`3` stars
+stacked along `z` does restore it -- but only as one formation event of six records. The eigenvector condition is about the set formed in one tick, not about which sites are
+eventually recorded.
+
+## Corollary -- where the preserving rule lives, and where the next lane is
+
+Within the setting declared above, on the two named clusters, in the staggered sector at half filling, for PR #7876's Model A tick and the rules declared in full here:
+
+1. **No site-wise formation rule preserves the sea's registration under evolution between formations** -- energy-rate, purity, uniform, the declared orders, or the eigenvector-seeking
+   rule itself -- on the cube (`TV 0.29`-`0.46`, all `256` cancellation zeros lost, at every declared `tau > 0`) or on the slab (full-law `TV 0.11`-`0.14` after one record, `0.21`-`0.41`
+   after six). What a site rule can do is choose an order; the order changes the distance by a factor `1.6` at most and never the support (`T2`, `T3`).
+2. **The formation rate is not the missing supplier of the sea's registration; the formation unit is.** The energy-rate rule in the ruler's form is uniform at the instant and, at finite
+   `tau`, follows the evolution's own energy spread into a matching -- neither the flat-band order nor a preserving one; its corner form completes stars only after the state has left the
+   sea; the one form that follows the flat-band corners is the worst by the full law (`T4`).
+3. **The exact condition is per step and set-wise**: the conditioned state must be an `H_R` eigenvector after each formation -- the sufficient condition proved -- which holds when each
+   formed set is a union of whole corner stars satisfying the two-mode condition; no single edge site meets it at any step, and the necessary dephasing condition is met by no
+   non-eigenvector node in any tree computed (`T5`).
+4. **The rule that does preserve the sea therefore exists exactly where PRs #7900 and #7902 said** -- whole corner stars and their eigen-set unions, formed jointly -- **and nowhere a
+   site-wise rate can extend it.** It does extend set-wise one step beyond the flat-band corners: the column pair of degree-`3` stars is an eigen-set as a six-record joint tick (`T6`).
+5. **The natural next lane** is which unions of stars are eigen-sets on a general cluster. The criterion is the invariance of the occupied one-particle space restricted to the deleted
+   vertex set -- the multi-site form of PR #7902's two-mode condition -- and the question is whether every corner of a larger open slab belongs to some eigen-set.
+
+## Reading, not theorem -- the whole thing in plain words
+
+The tick lane hoped that if records picked their own moment -- forming first where the energy sits above the sea -- the sea's own statistics might survive the evolution between
+them. They do not. With no evolution every way of picking sites is perfect, so picking sites proves nothing there; with evolution every way of picking sites leaks into the patterns
+the sea forbids, from the first tick, and the energy rule just follows the disturbance it is supposed to avoid. What survives is a statement not about which site forms next but about
+how many form at once: a whole corner's records forming together leave the sea a state its remaining law holds still, and so, one cube taller, do two stacked corners' records forming
+together as one event of six; one record at a time never does.
+
+## Interfaces named for other lanes, not settled here
+
+- **PR #7876 (the tick).** Its no-invariant-state result is reproduced at its representative `tau = 0.5` and extended: no site rule fixes it. Model B is not touched.
+- **PR #7895 (the relaxation tick).** `M_R` is a different between-event model, already excluded there; no relaxation tick is run here.
+- **PRs #7900 and #7902 (the corner-set condition).** Rule `D` is their unit; `T6` adds one eigen-set on the same cluster and names the multi-site criterion, computed nowhere else.
+- **PRs #7916 and #7925 (the rate ruler form).** `A1` and `A1v` are the ruler's rate in edge and corner form on the pre-record state; a rate on the record configuration is not computed.
+
+## Executable claim block
+
+The canonical machine-bound restatement of the six theorem conclusions.
+
+```text
+setting: qubits on the EDGE sites of the 2x2x2 cube (12 edges, record space 2^12) and the 2x2x3 slab open in z (20 edges, record space 2^20 on the half-filled sector J, |J| = 473088); ordinary composition; Admissibility and Record quoted verbatim from MINIMAL_AXIOMS_2026-06-29.md with Admissibility reading note (2)
+law: eta = Kawamoto-Smit staggered signs, flux -1 on every face; H = -sum_e eta_e T_e, t = 1; sea = the code-space ground state at half filling, E = -4 sqrt 3 (cube, residual 5.4e-15) and -(8 + 2 sqrt 2) (slab, to 0.0e+00, residual 2.5e-15 with an exact reduction); H_R = the hops on the UNRECORDED edges = P_S H P_S
+tick_model: STIPULATED, PR #7876 Model A adopted unchanged -- Lueders formation with the Born odds of the pre-record state; exp(-i tau H_R) between formations; tau in {0, 0.1, 0.5, 2.0} (cube) and {0, 0.5, 2.0} (slab)
+rules: DECLARED IN FULL -- A1 energy above the sea, A1v its corner form, A2 energy scale, A2v its corner form, B least entangled first, E eigenvector first (greedy paths, odds along the path quantified), C the 24 declared orders (cube) and the identity (slab), D joint corner stars; every tree a complete exact enumeration; no seed
+T1_instantaneous [numerical, 1e-12]: tau = 0 -- every rule, D, each of the 24 orders and their average at TV <= 8.2e-17, support 1984, 1856/1856 charge and 256/256 cancellation zeros kept, margerr <= 4.1e-17; A1 exactly uniform at steps 1-5; one edge leaves residual 0.577350 = 1/sqrt 3 at all 12 edges, a whole star 1.4e-14
+T2_cube [numerical, 1e-12]: tau = 0.5 -- TV A1 0.337565692 A1v 0.320717027 A2 0.422413255 A2v 0.449953329 B 0.453896665 E 0.362827766, 24 orders 0.289380397 (reverse) to 0.456208220 mean 0.379401338, their average 0.239288631; every site-wise law support 2240 with 0/256 cancellation zeros; D 6.8e-16 with 256/256, node residual <= 1.4e-14. tau = 0.1 -- 0.2603/0.1298/0.0704/0.2679/0.1527/0.1203, orders 0.0459-0.2990, D 3.2e-16; tau = 2.0 -- 0.4691/0.3604/0.4662/0.3263/0.3698/0.4149, orders 0.3272-0.5243, D 1.2e-15; 0/256 cancellation zeros for every site-wise law at both
+T3_slab [numerical, 1e-10]: tau = 0.5, six records, full-law TV after one 0.1148/0.1148/0.1259/0.1387/0.1259/0.1259/0.1148 (A1/A1v/A2/A2v/B/E/C, supports 436224-458752 > 411648), after six 0.3727/0.2116/0.3895/0.4089/0.3431/0.3167/0.3156; tau = 2.0 A1/C 0.0268/0.0268 then 0.353/0.347; leaf-TV <= 7.2e-14 at three records for every rule, A2/A2v <= 2.6e-14 through six; rule E's best-site residual 0.5638/0.6358/0.6389/0.6943/0.6829/0.7354, never 0
+T4_rate_rule [numerical]: cube A1 forms the z-matching (0,1)(2,3)(4,5)(6,7), contrast 1.00/5.50/6.85/9.00, greedy odds 0.083/0.500/0.685/1.000, margerr <= 6e-15 for three records then 0.189, residual 0.58/0.85/0.84/0.45; A1v completes star(0) then star(4) within five records, its third record leaving 0.671; slab A1 uniform at step 1 then greedy odds 0.440/0.466/0.611 at steps 2-4 on the parallel z-edges (0,1)(3,4)(6,7)(9,10); A2v forms (1,4)(7,10)(1,7) first and is worst at six records, 0.4089
+T5_condition [numerical, 1e-9]: sufficient -- an H_R eigenvector after each formation gives exact registration for every tau (D); set-wise -- two edges of one star 0.577350, parallel 1.000000, far 0.816497, star 1.4e-14, three not a star 1.290994, the matching 1.323435; E's best site 0.577/0.685/0.671/0.643/0.552/0.512/0.496 at steps 1-7 with no eigenvector site before step 9; necessary (dephasing), tested -- 12 trees, 5246-5822 nodes: 0 of 27848 non-eigenvector nodes with an invariant diagonal (smallest displacement 7.1e-05 / 8.2e-04 / 3.6e-03 at tau 0.1 / 0.5 / 2.0), 0 of 40672 eigenvector nodes displaced
+T6_column_pair [numerical, 1e-11]: at tau = 0 rule E forms star(0) then star(2) with residuals 0.5638/0.5210/0.2071/0.5210/0.5638/0.0000; each star alone 0.207107 = (sqrt 2 - 1)/2; star(0) u star(2) as one six-record tick at tau = 0.5: residual <= 2.1e-15 at 64/64 outcomes, displacement <= 4.0e-16, full-law TV 3.6e-16 on support 411648; the same six sites one at a time with tau = 0.5 ticks: 0.3156; D star(4) then star(7): 2.4e-16 / 3.3e-16 at 4 / 8 records
+boundary: greedy paths of the stochastic rules with the exact mixture bounded below by the support argument; 24 declared orders standing in for the uniform-order average; the sufficient condition proved, the dephasing condition shown unmet numerically and not proved impossible; nothing derived from any axiom; no rate, unit or tick foreclosed
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=16 FAIL=0
+```
+
+## Proof boundary
+
+Every statement above is proved on **two finite clusters** -- the `2x2x2` cube graph and the `2x2x3` slab open in `z` -- in **one flux sector** (all-minus, the Kawamoto-Smit
+staggered signs) at **half filling only**, with `t = 1`, and for **one between-event model**, PR #7876's Model A, at `tau in {0, 0.1, 0.5, 2.0}` on the cube and
+`{0, 0.5, 2.0}` on the slab, the slab trees to **six records** (deeper is outside this session's runtime stipulation; the depth is stated wherever a slab figure appears). Nothing is
+claimed for other clusters, other sectors, other particle numbers, infinite lattices, or any law family other than the one in "Definitions". The law is **designed**, not derived.
+
+**The stochastic rate rules are walked along their greedy (max-rate) paths**, with the stochastic odds along the path quantified: uniform at step `1` exactly, the greedy site
+carrying `0.50`-`1.00` (cube) and `0.44`-`0.61` (slab) of the odds at steps `2`-`4`. The exact stochastic mixture is bounded below by the **support argument**: every tree computed has
+support `2240` on the cube, mixing only enlarges support, and the sea's is `1984`. The **24 declared orders stand in for the uniform-order average**; their average is the closest
+object found and is not the sea. **Not covered:** rates that depend on the record configuration rather than on the pre-record state; joint formation of sets other than corner stars
+and the one star pair of `T6`; any interacting or non-flat `H`; the relaxation tick of PR #7895.
+
+**What is proved and what is tested.** The eigenvector condition per step is the **sufficient** condition, proved. The **necessary** half -- the dephasing condition on a
+non-eigenvector branch state -- is shown numerically never to be met off the eigenvector case on these two objects (`0` of `27848` nodes) and is **not proved impossible**. `T6` is a
+value on one declared set of one cluster; the multi-site criterion is named and not computed elsewhere.
+
+**The tick, the formation, the rates and the orders are stipulated reconstructions**, adopted or declared here and supplied by no axiom; reading note (2) says the axioms supply no
+formation site, probability or rate, and they supply no unit either. This note supplies none, adds none, and amends none. Every line not tagged `[exact]` is a deterministic
+double-precision evaluation at the stated threshold; the `2^20` object is touched by sparse Pauli strings, Lanczos and a Chebyshev propagator only, no dense object above `4096 x 4096`
+is formed, peak memory stays under `1 GB`, and there is **no seed anywhere**. The one floating-point trap met -- a sequential Rayleigh quotient over `473088` terms carrying a `3.8e-12`
+floor, its variance form negative -- is named in `T3` and avoided by exact and pairwise reductions wherever a residual near zero is reported. No absolute unit appears anywhere, no
+axiom text is amended, extended, reworded or reinterpreted, no hypothesis is adopted, no status value is set, and no registry or manifest node is created or edited.
+
+## Review record
+
+**Honest-auditor read.** An honest auditor should come away with a bounded negative and one bounded positive, both on declared finite sets: no site-wise formation rule -- rate,
+purity, uniform, declared order, or the eigenvector-seeking rule itself -- reproduces the sea's registration under Model A evolution on either cluster, while the set-wise rule of PRs
+#7900 and #7902 does, and extends by exactly one further eigen-set found here. The tick, the rules and the orders are declared as stipulations in the front matter, the setting, the
+claim block and the proof boundary alike; nothing is presented as following from an axiom; no rate, unit or tick is foreclosed. The disagreements with the expectation this probe was
+run under are stated plainly: rate selection at `tau -> 0` is exact for every rule and so says nothing about rates; the rule that "forms first where the two-mode condition holds"
+exists (`A2v`) and is the worst of all by the full law; the leaf statistics on the formed sites are blind for three to six records; the closest object on the cube is the average over
+orders, not any rate rule; and against PR #7902's reading that nothing restores the property at a failing degree-`3` corner, the column pair of degree-`3` stars does -- as a six-record
+joint tick, never site-wise.
+
+Departures from the scratch computation this note lands, stated here. The scratch sea on the slab carried a residual of `6.0e-12`, its conditioned eigen-sets `1.4e-13` and its `D`
+figures `8e-14`; those were the floors of sequential reductions over `473088` terms, and with exact and pairwise reductions the same vectors give `2.5e-15`, `2.1e-15` and `3.9e-15`
+-- the numbers reported here, and the reason `T3` names the trap. The propagator is a Chebyshev series under a rigorous norm bound rather than the scratch's dense eigendecomposition
+(cube) and `expm_multiply` (slab); it agrees with `expm_multiply` to `1e-16` and every cube distance agrees with the scratch to nine digits, every slab distance to four. The scratch's
+statement that rule `E`'s best-site residual on the cube is "never `0`" is refined: it is `>= 0.496` for seven steps and an eigenvector site first appears at step `9`, with four free
+edges left; the scratch's "greedy site carrying `44`-`100 %` of the odds" is separated by object, `0.50`-`1.00` on the cube and `0.44`-`0.61` on the slab at steps `2`-`4`. Node
+counts in the `T5` scan differ from the scratch's by the pruning convention (`5246`-`5822` against `5263`-`5863`); the verdict, `0` invariant non-eigenvector nodes and `0` displaced
+eigenvector nodes, is the same.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the "Imports and authority" pointers are plain
+text carrying no grade and no weight, each with its PR state at the time of writing (all five parents are open PRs, none on main). Hard landing conditions are a fresh runner and cache
+pair at `PASS=16 FAIL=0`, runtime under the declared `180` seconds, and passing pipeline, strict-lint and changed-evidence gates; audit remains a separate lane, and the ledger has
+been unaudited since 2026-08-07.

--- a/logs/runner-cache/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.txt
+++ b/logs/runner-cache/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.txt
@@ -1,0 +1,28 @@
+===== runner cache v1 =====
+runner: scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py
+runner_sha256: b08ab37f22ba19e7560d8360cb31f71b380fe75081f4e6ba9cd051220cab35bb
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 35.78
+status: ok
+----- stdout -----
+PASS A1 [exact; 1e-12] cube: R0-R4 True, k=5, code 128, D=4096, flux {-1} x6; sea E=-6.928203230276=-4sqrt3 (0.0e+00), resid 5.4e-15, gap 3.464102; support 1984, zeros 2112=1856 charge+256 cancellation; eps_q(sea)=-0.577350 x12 (spread 3e-16); residual one edge 0.577350=1/sqrt3 x12 (spread 3e-15), star(0) 1.4e-14.
+PASS A2 [1e-12] T1 tau=0: every rule (A1 A1v A2 A2v B E, D, all 24 orders) reproduces the sea: max TV 8.2e-17 / 0.0e+00, support 1984, 1856/1856 charge + 256/256 cancellation zeros kept; margerr <= 4.1e-17 at every node; A1 contrast at steps 1-5 = 1.0000/1.0000/1.0000/1.0000/1.0000.
+PASS A3 [1e-12] T2 tau=0.5 TV(sea): A1 0.337565692 A1v 0.320717027 A2 0.422413255 A2v 0.449953329 B 0.453896665 E 0.362827766; each support 2240, 1856/1856 charge, 0/256 cancellation kept; D (stars 0,3,5,6) TV 6.8e-16, 256/256, node residual <= 1.4e-14, diagonal displaced <= 1.1e-15.
+PASS A4 T2 24 orders tau=0.5: per-order TV min 0.289380397 (order 12 = reverse) max 0.456208220 mean 0.379401338, identity 0.324925161, each support 2240, 0/256 cancellation; their average law TV 0.239288631 with support 2240, not 1984.
+PASS A5 T2 TV(sea) at tau 0.1: A1 0.2603 A1v 0.1298 A2 0.0704 A2v 0.2679 B 0.1527 E 0.1203, orders 0.0459-0.2990, D 3.2e-16; tau 2.0: A1 0.4691 A1v 0.3604 A2 0.4662 A2v 0.3263 B 0.3698 E 0.4149, orders 0.3272-0.5243, D 1.2e-15; every site-wise law support 2240 with 0/256 cancellation at both; D 256/256 at both.
+PASS A6 [1e-12] T4 cube A1 tau=0.5 forms (0,1)(2,3)(4,5)(6,7) (the z-matching): contrast 1.00/5.50/6.85/9.00, greedy odds 0.083/0.500/0.685/1.000, margerr 0e+00/6e-15/1e-15 then 0.189 at step 4; residual 0.58/0.85/0.84/0.45, diagonal displaced 0.125/0.140/0.129/0.056. A1v: star(0) then star(4) in 5 records ((0,1)(0,2)(0,4)(4,5)(4,6)), residual 0.671 after its 3rd.
+PASS A7 T5 sea conditioned on two edges of one star 0.577350, two parallel z-edges 1.000000, two far edges 0.816497=sqrt(2/3), a whole star 1.4e-14, three edges not a star 1.290994, the z-matching 1.323435. Scan of 12 trees (A1, identity, A1v, B x tau 0.5/0.1/2.0; 5246-5822 nodes): non-eigenvector nodes (res > 1e-6) with invariant diagonal (< 1e-9) 0 of 27848; eigenvector nodes displaced 0 of 40672; min displacement among non-eigenvector nodes 7.1e-05/8.2e-04/3.6e-03 at tau 0.1/0.5/2.0.
+PASS A8 rule E on the cube, best-site residual (min over all branches): tau=0.5 0.577/0.685/0.671/0.643/0.552/0.512/0.496 at steps 1-7 (min 0.496), first eigenvector site at step 9 (4 free edges left); tau=0 0.577/0.577/0.000/0.577 -- the third record completes star(0) exactly, but after one tau=0.5 tick that completion leaves 0.671; E's final law at tau=0.5: TV 0.362828, 0/256 cancellation.
+PASS B1 [exact; 1e-10] slab 2x2x3 open in z: degrees 343343343343, 20 edges, 11 faces, R0-R4 True, k=9, code 2048, flux {-1} x11, |J|=473088; sea by Lanczos + 20 polish steps: E=-10.828427124746=-(8+2sqrt2) (0.0e+00; the sequential Rayleigh quotient is off by 3.8e-12), resid 2.5e-15, support 411648; eps(sea) -0.500000 x12 / -0.603553=-(1+sqrt2)/4 x8; corner -1.0000 (deg 4) / -0.8536 (deg 3); one-edge residual 0.612372=sqrt(3/8) / 0.563792.
+PASS B2 [1e-10] T3 6 records, tau=0.5, full 20-edge law vs the sea (A1/A1v/A2/A2v/B/E/C): after one 0.1148/0.1148/0.1259/0.1387/0.1259/0.1259/0.1148 (support 436224-458752 > 411648), after six 0.3727/0.2116/0.3895/0.4089/0.3431/0.3167/0.3156; order: A1 (0,1)(3,4)(6,7)(9,10)(5,11)(2,8) A1v (0,1)(0,3)(0,6)(6,7)(6,9)(3,9) A2v (1,4)(7,10)(1,7)(0,3)(5,11)(2,8) E (0,3)(0,6)(6,9)(1,7)(0,1)(6,7). tau=2.0: A1/C 0.0268/0.0268 after one, 0.353/0.347 after six.
+PASS B3 [1e-10] T3 leaf-TV on the formed sites is blind: <= 7.2e-14 at three records for every rule while the full law is 0.207-0.314 away; A2/A2v stay at 2.6e-14/2.1e-14 through six (full law 0.389/0.409); A1 0.000/0.152/0.152/0.152 at records 3-6, A1v 0.118 at 5, B/E/C 0.079/0.146/0.023 at 6 only.
+PASS B4 [1e-9] rule E on the slab: best-site residual 0.5638/0.6358/0.6389/0.6943/0.6829/0.7354 at records 1-6, identical across a level's branches (spread <= 1.3e-15), never 0, ending above where it began; residual along every path 0.50-1.37, diagonal displaced per tick 0.078-0.291.
+PASS B5 T4 slab A1: contrast 1.000000 at step 1, then 8.4/8.4/10.4/5.0/8.7 with greedy odds 0.440/0.466/0.611/0.311/0.579 at steps 2-6, the parallel z-edges (0,1)(3,4)(6,7)(9,10) first (a matching); A2v forms the degree-4 corners' middle edges (1,4)(7,10)(1,7) first and is worst at six records (0.4089 = max of 0.373/0.212/0.389/0.409/0.343/0.317/0.316).
+PASS B6 [1e-11] T6 tau=0: rule E on the sea forms (0,3)(0,6)(0,1)(1,2)(2,5)(2,8) = star(0) then star(2), best residuals 0.5638/0.5210/0.2071/0.5210/0.5638/0.0000; each degree-3 star alone leaves 0.207107=(sqrt2-1)/2 (0.207107/0.207107); the pair star(0) u star(2) restores the eigenvector property exactly: residual max 2.1e-15 over its 64 outcomes; control full-law TV <= 0.0e+00.
+PASS B7 [1e-11] T6 the six-record JOINT tick on star(0) u star(2) at tau=0.5: residual max 2.1e-15 (64 outcomes), diagonal displaced max 4.0e-16, full-law TV 3.6e-16, support 411648; the same six sites one at a time with tau=0.5 ticks (rule C): 0.3156. D star(4) then star(7): full-law TV 2.4e-16/3.3e-16 at 4/8 records, residual max 2.7e-15/3.9e-15, support 411648.
+PASS B8 [timing] cube 124 trees 2 s, slab sea 12 s, nine slab trees to 6 records 19 s, total 35 s < 180 s; no dense object above 4096 x 4096, no seed.
+TOTAL: PASS=16 FAIL=0
+
+----- stderr -----
+

--- a/scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py
+++ b/scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py
@@ -1,0 +1,1030 @@
+#!/usr/bin/env python3
+"""No site-wise formation rule preserves the sea's registration under tick evolution;
+the eigenvector condition is per step and set-wise.
+
+Class-A finite-dimensional runner, self-contained. Qubits sit on the EDGE sites of two
+finite subgraphs of the cubic lattice: the 2x2x2 cube (8 corners, 12 edge sites, 6
+faces, record space 2^12 = 4096, held whole) and the 2x2x3 slab open in z (12 corners,
+20 edge sites, 11 faces, record space 2^20, held only on the conserved half-filling index
+set J, |J| = 473088, as a sparse matrix and 7.5 MB vectors; no dense object above
+4096 x 4096 is formed anywhere and peak memory stays well under 1 GB). A record at an
+edge site REGISTERS a Z-value there. The law is H = -sum_e eta_e T_e with the
+Kawamoto-Smit staggered signs (flux -1 on every face, the pi-flux sector), t = 1; the
+sea is the ground state of H in the code space at half filling. Between formations the
+pre-record state runs by exp(-i tau H_R), H_R = the hop terms on the UNRECORDED edges
+(PR #7876 Model A; P_S H P_S = H_R exactly). Formation = Lueders conditioning with the
+Born odds of the current pre-record state.
+
+THE RULES, declared in full (a rule is a map (state, record set) -> next site; greedy =
+deterministic argmax with the lowest edge index on ties after rounding to 1e-9):
+  A1  energy-above-sea   r_q = max(eps_q(psi) - eps_q(sea), 0), eps_q = <psi|h_q|psi>
+  A1v corner form        eps_v = (1/2) sum_{e in star(v)} eps_e, r_e = mean endpoint excess
+  A2  energy-scale       r_q = |eps_q(psi)|;   A2v its corner form
+  B   least-entangled    argmax of the purity Tr rho_q^2 of the one-site reduced state
+  C   declared orders    the identity 0..11 and its 11 cyclic shifts, the reverse and its
+                         11 cyclic shifts (24 orders, cube); the identity 0..5 (slab)
+  D   corner sets        joint formation of whole corner stars, evolving after each star
+  E   eigenvector-first  argmin over free q of the Born-weighted H_{R+q} residual of the
+                         two conditioned states; the rule "exists" iff that minimum is 0
+For the stochastic A rules the greedy (max-rate) path is walked and the stochastic odds
+along it are quantified: contrast = max odds x number of free sites (1 = uniform) and
+p_chosen = the odds of the greedy site.
+
+Every tree is an EXACT enumeration in the unnormalised-branch form: the branch vectors of
+one level live in disjoint record sectors, so the whole level is one vector Phi with a
+node label per basis state; Lueders conditioning with both outcomes is then the identity
+on Phi, the per-node Born odds are bincounts of |Phi|^2, and the evolution of every branch
+at once is exp(-i tau H_lev) Phi with H_lev = H with the hops on each node's OWN recorded
+edges zeroed (a mask on the sparse data). The law after every record has formed is
+|Phi|^2 exactly. The propagator is the Chebyshev (Jacobi-Anger) series of exp(-i tau H_lev)
+with the rigorous spectral bound ||H_R|| <= number of free edges (each hop term T_e has
+T_e^2 = (1 - B_i B_j)/2, so ||T_e|| = 1), truncated where the Bessel coefficients fall below
+1e-17; it agrees with scipy's expm_multiply to 1e-16 and keeps three live vectors and no
+matrix copy. Nothing is sampled and there is no seed anywhere: the Lanczos start on the
+slab is the fixed vector cos(0.7 i + 0.3) + i cos(1.3 i + 1.1) projected into the code
+space, and every order and set is declared above. Reductions over the 473088-entry slab
+vectors are done by exact (fsum) or pairwise summation wherever a residual near zero is
+reported, because a sequential Rayleigh quotient over that many terms carries a ~4e-12
+floor (its variance form even comes out negative) -- the cancellation trap of PR #7902.
+
+Source blocks reproduced (scratch T1 of 2026-09-03, read-only against the repository;
+nothing is imported from any worktree):
+  * L3/l3_core.py          Pauli algebra P/pact/comm, cube_cluster, cube_faces, Enc
+                           (A_ij, B_v, S_f, hop_pauli), audit R0-R4, code_space
+  * L3j/l3j_core.py        the cube: eta_ks, HAMP (here the per-edge hop pairs), NVAL,
+                           the 128-dim code space, the sea by one 128 x 128 eigh
+  * L3m/l3m_geom.py        slab(), face_flux
+  * L3m/l3m_mb.py          the sparse half-filling Model (AMPJ, H, apply_pauli,
+                           project_code); the seeded Lanczos start is replaced by the
+                           declared deterministic start of PR #7902's runner
+  * T1/t1_cube.py          rates A1/A1v/A2/A2v/B/E, select, the 24 orders, the corner
+                           sets, cond_sea_marg (margerr), diag_tv, the census
+  * T1/t1_slab.py          leaf-TV and full-law TV per level, the E-rule residual scan
+  * T1/t1_scan.py          the per-node eigenvector-vs-diagonal-invariance scan and the
+                           declared-set residuals on the sea
+
+Line tags. `[exact]` = integer, F2 or symplectic Pauli arithmetic with no floating point
+in the statement. `[numerical, tol]` = a deterministic double-precision evaluation of an
+exactly specified quantity at the stated threshold.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`. Exit 0 iff FAIL = 0.
+"""
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+import time
+from functools import reduce
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+from scipy.special import jv
+
+AUDIT_TIMEOUT_SEC = 180
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+PMIN = 1e-13
+
+
+def check(label, cond):
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+def f3(x):
+    return "%.3e" % x
+
+
+# ==========================================================================
+# Pauli algebra in the symplectic representation, phases mod 4  (L3/l3_core.py)
+def pc(n):
+    return bin(n).count("1")
+
+
+class P:
+    __slots__ = ("k", "x", "z")
+
+    def __init__(s, k, x, z):
+        s.k = k % 4
+        s.x = x
+        s.z = z
+
+    def __mul__(a, b):
+        return P(a.k + b.k + 2 * pc(a.z & b.x), a.x ^ b.x, a.z ^ b.z)
+
+    def neg(s):
+        return P(s.k + 2, s.x, s.z)
+
+    def __eq__(a, b):
+        return a.k == b.k and a.x == b.x and a.z == b.z
+
+    def __hash__(s):
+        return hash((s.k, s.x, s.z))
+
+    def is_herm(s):
+        return s.k % 2 == pc(s.x & s.z) % 2
+
+    def is_id(s):
+        return s.x == 0 and s.z == 0 and s.k == 0
+
+    def is_mid(s):
+        return s.x == 0 and s.z == 0 and s.k == 2
+
+
+ID = P(0, 0, 0)
+PH = [1 + 0j, 1j, -1 + 0j, -1j]
+
+
+def comm(a, b):
+    return (pc(a.x & b.z) + pc(a.z & b.x)) % 2 == 0
+
+
+def pact(p, b):
+    return b ^ p.x, PH[p.k] * ((-1) ** (pc(p.z & b) % 2))
+
+
+def parity(x):
+    x = x.astype(np.int64)
+    x = x ^ (x >> 32)
+    x = x ^ (x >> 16)
+    x = x ^ (x >> 8)
+    x = x ^ (x >> 4)
+    x = x ^ (x >> 2)
+    x = x ^ (x >> 1)
+    return (x & 1).astype(np.int8)
+
+
+# ==========================================================================
+# the clusters  (L3/l3_core.py cube_cluster, cube_faces; L3m/l3m_geom.py slab, face_flux)
+def cube_cluster():
+    B = [(s, s ^ bit) for s in range(8) for bit in (4, 2, 1) if s ^ bit > s]
+    return 8, sorted(B)
+
+
+def cube_faces():
+    out = []
+    for ax in range(3):
+        bits = [4, 2, 1]
+        fb = bits[ax]
+        ob = [b for b in bits if b != fb]
+        for val in (0, fb):
+            out.append((val, val | ob[1], val | ob[0] | ob[1], val | ob[0]))
+    return out
+
+
+def slab(Lx=2, Ly=2, Lz=3):
+    idx = {}
+    for x in range(Lx):
+        for y in range(Ly):
+            for z in range(Lz):
+                idx[(x, y, z)] = (x * Ly + y) * Lz + z
+    V = Lx * Ly * Lz
+    E = []
+
+    def add(p, q, a):
+        i, j = idx[p], idx[q]
+        E.append((min(i, j), max(i, j), a, p))
+
+    for (x, y, z) in idx:
+        if x + 1 < Lx:
+            add((x, y, z), (x + 1, y, z), 0)
+        if y + 1 < Ly:
+            add((x, y, z), (x, y + 1, z), 1)
+        if z + 1 < Lz:
+            add((x, y, z), (x, y, z + 1), 2)
+    E.sort(key=lambda t: (t[0], t[1]))
+    EDGES = [(i, j) for (i, j, a, p) in E]
+    ETA = {}
+    for (i, j, a, p) in E:
+        x, y, z = p
+        ETA[(i, j)] = 1 if a == 0 else (-1 if (a == 1 and x & 1) else
+                                        (-1 if (a == 2 and (x + y) & 1) else 1))
+    FACES = []
+
+    def nxt(c, a):
+        v = list(c)
+        if v[a] + 1 < (Lx, Ly, Lz)[a]:
+            v[a] += 1
+            return tuple(v)
+        return None
+
+    for c in idx:
+        for a, b in itertools.combinations(range(3), 2):
+            p1, p2 = nxt(c, a), nxt(c, b)
+            if p1 is None or p2 is None:
+                continue
+            p3 = nxt(p1, b)
+            if p3 is None or p3 != nxt(p2, a):
+                continue
+            cyc = (idx[c], idx[p1], idx[p3], idx[p2])
+            if len(set(cyc)) == 4:
+                FACES.append(cyc)
+    return V, EDGES, sorted(set(FACES)), [ETA[e] for e in EDGES]
+
+
+def face_flux(FACES, EDGES, eta):
+    EIDX = {}
+    for q, (i, j) in enumerate(EDGES):
+        EIDX[(i, j)] = EIDX[(j, i)] = q
+    out = []
+    for cyc in FACES:
+        f = 1
+        for t in range(len(cyc)):
+            f *= int(eta[EIDX[(cyc[t], cyc[(t + 1) % len(cyc)])]])
+        out.append(f)
+    return out
+
+
+def corner_xyz(s):
+    return ((s >> 2) & 1, (s >> 1) & 1, s & 1)
+
+
+def eta_ks(v, a):
+    if a == 0:
+        return 1
+    if a == 1:
+        return -1 if (v[0] & 1) else 1
+    return -1 if ((v[0] + v[1]) & 1) else 1
+
+
+# ==========================================================================
+# the superfast encoding, its audit and the code-space cosets  (L3/l3_core.py)
+class Enc:
+    def __init__(self, V, EDGES, FACES):
+        self.V = V
+        self.EDGES = list(EDGES)
+        self.FACES = list(FACES)
+        self.NQ = len(EDGES)
+        self.DIM = 1 << self.NQ
+        self.EIDX = {}
+        for q, (i, j) in enumerate(self.EDGES):
+            self.EIDX[(i, j)] = q
+            self.EIDX[(j, i)] = q
+        self.NBR = {i: sorted(j for (a, b) in self.EDGES
+                              for j in ((b,) if a == i else ((a,) if b == i else ())))
+                    for i in range(V)}
+        self.STAR = {i: [self.EIDX[(i, k)] for k in self.NBR[i]] for i in range(V)}
+        self.STARMASK = {i: reduce(lambda a, b: a | (1 << b), self.STAR[i], 0) for i in range(V)}
+
+    def A_unsigned(self, i, j):
+        x = 1 << self.EIDX[(i, j)]
+        z = 0
+        for k in self.NBR[i]:
+            if k != j and k < j:
+                z ^= 1 << self.EIDX[(i, k)]
+        for l in self.NBR[j]:
+            if l != i and l < i:
+                z ^= 1 << self.EIDX[(j, l)]
+        return P(pc(x & z) % 2, x, z)
+
+    def A(self, i, j):
+        p = self.A_unsigned(i, j)
+        return p if i < j else p.neg()
+
+    def B(self, i):
+        return P(0, 0, self.STARMASK[i])
+
+    def loop(self, cyc):
+        out = ID
+        n = len(cyc)
+        for a in range(n):
+            out = out * self.A(cyc[a], cyc[(a + 1) % n])
+        return out
+
+    def record(self, z):
+        return tuple(pc(z & self.STARMASK[i]) % 2 for i in range(self.V))
+
+    def hop_pauli(self, i, j):
+        A = self.A(i, j)
+        return A * self.B(i), A * self.B(j)
+
+
+def audit(E):
+    R = {}
+    A = {e: E.A(*e) for e in E.EDGES}
+    Bv = {i: E.B(i) for i in range(E.V)}
+    R["R0_welldef"] = all(E.A_unsigned(i, j) == E.A_unsigned(j, i) for (i, j) in E.EDGES)
+    R["R0_antisym"] = all(E.A(j, i) == E.A(i, j).neg() for (i, j) in E.EDGES)
+    R["R1"] = (all(A[e].is_herm() and (A[e] * A[e]).is_id() for e in E.EDGES)
+               and all(Bv[i].is_herm() and (Bv[i] * Bv[i]).is_id() for i in range(E.V)))
+    r2 = True
+    for i, j in itertools.combinations(range(E.V), 2):
+        r2 &= comm(Bv[i], Bv[j])
+    for e in E.EDGES:
+        for v in range(E.V):
+            r2 &= (comm(A[e], Bv[v]) != (v in e))
+    R["R2"] = bool(r2)
+    r3 = True
+    for e, f in itertools.combinations(E.EDGES, 2):
+        r3 &= (comm(A[e], A[f]) != (len(set(e) & set(f)) == 1))
+    R["R3"] = bool(r3)
+    S = [E.loop(f) for f in E.FACES]
+    r4 = True
+    for s in S:
+        r4 &= s.is_herm() and (s * s).is_id()
+        for e in E.EDGES:
+            r4 &= comm(s, A[e])
+        for v in range(E.V):
+            r4 &= comm(s, Bv[v])
+    for a, b in itertools.combinations(S, 2):
+        r4 &= comm(a, b)
+    R["R4"] = bool(r4)
+    gens, basis = [], []
+    for s in S:
+        v = s.x
+        for b in basis:
+            v = min(v, v ^ b)
+        if v != 0:
+            basis.append(v)
+            basis.sort(reverse=True)
+            gens.append(s)
+    R["k"] = len(gens)
+    R["gens"] = gens
+    grp = []
+    for m in range(1 << len(gens)):
+        p = ID
+        for t in range(len(gens)):
+            if (m >> t) & 1:
+                p = p * gens[t]
+        grp.append(p)
+    R["grp"] = grp
+    R["grp_ok"] = (not any(g.is_mid() for g in grp)) and sum(1 for g in grp if g.x == 0) == 1
+    R["code_dim"] = E.DIM >> len(gens)
+    return R
+
+
+def code_space(E, R):
+    grp = R["grp"]
+    phi = np.zeros(E.DIM, dtype=complex)
+    cid = -np.ones(E.DIM, dtype=np.int64)
+    reps = []
+    for z0 in range(E.DIM):
+        if cid[z0] >= 0:
+            continue
+        c = len(reps)
+        reps.append(z0)
+        for g in grp:
+            b, a = pact(g, z0)
+            assert cid[b] < 0
+            cid[b] = c
+            phi[b] = a
+    assert (cid >= 0).all()
+    recs = [E.record(reps[c]) for c in range(len(reps))]
+    for z in range(E.DIM):
+        assert E.record(z) == recs[cid[z]]
+    return cid, phi, reps, recs
+
+
+# ==========================================================================
+# a record space held on an index set: the whole 2^12 (cube) or J (slab)
+# (L3j/l3j_core.py HAMP and L3m/l3m_mb.py Model, unified: H[z^bq, z] = 1j * amp_q(z))
+class Space:
+    def __init__(self, En, eta, Z, loc, name):
+        self.En, self.name = En, name
+        self.NQ, self.EDGES, self.V = En.NQ, En.EDGES, En.V
+        self.Z, self.loc, self.n = Z, loc, len(Z)
+        n, NQ = self.n, self.NQ
+        self.BIT = [((Z >> q) & 1).astype(bool) for q in range(NQ)]
+        self.src, self.tgt, self.amp, self.p0src, self.p0tgt = [], [], [], [], []
+        rows, cols, dat = [], [], []
+        self.xpart_ok = True
+        for q, e in enumerate(En.EDGES):
+            P1, P2 = En.hop_pauli(*e)
+            self.xpart_ok &= (P1.x == P2.x == (1 << q))
+            s1 = 1 - 2 * parity(Z & P1.z).astype(np.int64)
+            s2 = 1 - 2 * parity(Z & P2.z).astype(np.int64)
+            a = 0.5j * (PH[P1.k] * s1 - PH[P2.k] * s2)
+            ai = np.round(a.imag).astype(np.int8)
+            assert np.max(np.abs(a.real)) < 1e-12 and np.max(np.abs(a.imag - ai)) < 1e-12
+            amp = (-int(eta[q])) * ai
+            m = np.flatnonzero(amp != 0)
+            t = loc[Z[m] ^ (1 << q)]
+            assert np.all(t >= 0)
+            self.src.append(m.astype(np.int32))
+            self.tgt.append(t.astype(np.int32))
+            self.amp.append(amp[m])
+            rows.append(t.astype(np.int32))
+            cols.append(m.astype(np.int32))
+            dat.append(1j * amp[m].astype(np.float64))
+            m0 = np.flatnonzero(~self.BIT[q])
+            t0 = loc[Z[m0] ^ (1 << q)]
+            ok = t0 >= 0
+            self.p0src.append(m0[ok].astype(np.int32))
+            self.p0tgt.append(t0[ok].astype(np.int32))
+        H = sp.coo_matrix((np.concatenate(dat), (np.concatenate(rows), np.concatenate(cols))),
+                          shape=(n, n)).tocsr()
+        H.sort_indices()
+        self.H = H
+        self.rows = np.repeat(np.arange(n, dtype=np.int32), np.diff(H.indptr))
+        self.cols = H.indices
+        self.EI = np.array([i for (i, j) in En.EDGES])
+        self.EJ = np.array([j for (i, j) in En.EDGES])
+        self.MHALF = np.zeros((self.V, NQ))
+        for q, (i, j) in enumerate(En.EDGES):
+            self.MHALF[i, q] = self.MHALF[j, q] = 0.5
+        self.gens = None
+
+    def set_gens(self, gens):
+        self.gens = []
+        for g in gens:
+            perm = self.loc[self.Z ^ g.x]
+            assert np.all(perm >= 0)
+            sign = (1 - 2 * parity(self.Z & g.z)).astype(np.int8)
+            self.gens.append((perm.astype(np.int32), sign, PH[g.k]))
+
+    def project_code(self, v):
+        for perm, sign, ph in self.gens:
+            out = np.zeros_like(v)
+            out[perm] = (ph * sign) * v
+            v = 0.5 * (v + out)
+        return v
+
+    def intra(self, nid):
+        mask = nid[self.rows] == nid[self.cols]
+        return sp.csr_matrix((self.H.data * mask, self.cols, self.H.indptr), shape=(self.n, self.n))
+
+    def set_sea(self, sea):
+        self.SEA = sea
+        self.P_SEA = np.abs(sea) ** 2
+        self.SUPP = int((self.P_SEA > 1e-14).sum())
+        z0 = np.zeros(self.n, dtype=np.int64)
+        self.EPS_SEA = local_energies(self, sea, z0, 1)[0]
+        self.EPSV_SEA = self.EPS_SEA @ self.MHALF.T
+
+
+def local_energies(S, Phi, nid, nn):
+    eps = np.zeros((nn, S.NQ))
+    for q in range(S.NQ):
+        s, t = S.src[q], S.tgt[q]
+        ns = nid[s]
+        same = ns == nid[t]
+        val = -S.amp[q] * (np.conj(Phi[t]) * Phi[s]).imag
+        eps[:, q] = np.bincount(ns[same], weights=val[same], minlength=nn)
+    return eps
+
+
+def purities(S, Phi, d, nid, nn, inv_p):
+    out = np.zeros((nn, S.NQ))
+    for q in range(S.NQ):
+        b = S.BIT[q]
+        p1 = np.bincount(nid[b], weights=d[b], minlength=nn) * inv_p
+        s, t = S.p0src[q], S.p0tgt[q]
+        prod = np.conj(Phi[s]) * Phi[t]
+        cre = np.bincount(nid[s], weights=prod.real, minlength=nn)
+        cim = np.bincount(nid[s], weights=prod.imag, minlength=nn)
+        out[:, q] = (1 - p1) ** 2 + p1 ** 2 + 2 * (cre ** 2 + cim ** 2) * inv_p ** 2
+    return out
+
+
+def e_residuals(S, Phi, d, nid, nn, p, G):
+    """Born-weighted H_{R+q} residual of the two conditioned states, per node and site
+    (direct form, never the variance form)."""
+    out = np.zeros((nn, S.NQ))
+    nk = 2 * nn
+    for q in range(S.NQ):
+        s, t = S.src[q], S.tgt[q]
+        hq = np.zeros(S.n, dtype=np.complex128)
+        hq[t] = (1j * S.amp[q]) * Phi[s]
+        Gq = G - hq
+        key = nid * 2 + S.BIT[q]
+        PB = np.bincount(key, weights=d, minlength=nk)
+        EVk = np.bincount(key, weights=(np.conj(Phi) * Gq).real, minlength=nk)
+        evk = np.where(PB > 0, EVk / np.where(PB > 0, PB, 1.0), 0.0)
+        diff = Gq - evk[key] * Phi
+        R2 = np.bincount(key, weights=np.abs(diff) ** 2, minlength=nk)
+        resk = np.sqrt(np.where(PB > 0, R2 / np.where(PB > 0, PB, 1.0), 0.0)).reshape(nn, 2)
+        pb = PB.reshape(nn, 2) / np.where(p > 0, p, 1.0)[:, None]
+        out[:, q] = np.where(pb >= PMIN, pb * resk, 0.0).sum(1)
+    return out
+
+
+def node_residual(S, Phi, nid, nn, p, Hl):
+    """per-node residual ||H_R psi - <H_R> psi|| of the normalised branch states, direct form;
+    on the large object a node whose bincount residual is already below 1e-8 is re-evaluated
+    with pairwise sums so the reported figure is not the sequential-reduction floor."""
+    G = Hl @ Phi
+    prod = (np.conj(Phi) * G).real
+    EV = np.bincount(nid, weights=prod, minlength=nn)
+    ev = np.where(p > 0, EV / np.where(p > 0, p, 1.0), 0.0)
+    diff = G - ev[nid] * Phi
+    R2 = np.bincount(nid, weights=np.abs(diff) ** 2, minlength=nn)
+    res = np.sqrt(np.where(p > 0, R2 / np.where(p > 0, p, 1.0), 0.0))
+    if S.n > 100000:
+        small = np.flatnonzero((res < 1e-8) & (p >= PMIN))
+        if 0 < len(small) <= 512:
+            d = np.abs(Phi) ** 2
+            for i in small:
+                m = nid == i
+                pi = float(np.sum(d[m]))
+                evi = float(np.sum(prod[m])) / pi
+                di = G[m] - evi * Phi[m]
+                res[i] = math.sqrt(float(np.sum(np.abs(di) ** 2)) / pi)
+                ev[i] = evi
+    return res, ev, G
+
+
+def cheb_evolve(Hl, v, tau, lam):
+    """exp(-i tau Hl) v by the Jacobi-Anger expansion on [-lam, lam], lam >= ||Hl||:
+    exp(-i x y) = J_0(x) + 2 sum_{n>=1} (-i)^n J_n(x) T_n(y), x = tau lam, truncated
+    two terms past the first n > x with |J_n(x)| < 1e-17."""
+    x = tau * lam
+    n = int(math.ceil(x))
+    while n < x or abs(jv(n, x)) > 1e-17:
+        n += 1
+    nmax = n + 2
+    c = [(1.0 if k == 0 else 2.0) * ((-1j) ** k) * jv(k, x) for k in range(nmax + 1)]
+    T0 = v.copy()
+    T1 = (Hl @ v) / lam
+    out = c[0] * T0 + c[1] * T1
+    for k in range(2, nmax + 1):
+        T2 = (2.0 / lam) * (Hl @ T1) - T0
+        out += c[k] * T2
+        T0, T1 = T1, T2
+    return out
+
+
+def tv(p, q):
+    return 0.5 * float(np.abs(p - q).sum())
+
+
+def run_tree(S, rule, tau, depth, order=None, sets=None, margerr=False):
+    """Exact tree in the unnormalised-branch form; returns the final law and per-level stats."""
+    n, NQ = S.n, S.NQ
+    Phi = S.SEA.astype(np.complex128).copy()
+    nid = np.zeros(n, dtype=np.int64)
+    nn = 1
+    Rm = np.zeros(1, dtype=np.int64)
+    levels = []
+    for k in range(depth):
+        d = np.abs(Phi) ** 2
+        p = np.bincount(nid, weights=d, minlength=nn)
+        alive = p >= PMIN
+        inv_p = np.where(p > 0, 1.0 / np.where(p > 0, p, 1.0), 0.0)
+        lev = dict(k=k + 1)
+        if rule == "D":
+            Sset = sets[k]
+            qs = [q for q in range(NQ) if (Sset >> q) & 1]
+        else:
+            if rule == "C":
+                qsel = np.full(nn, order[k], dtype=np.int64)
+            else:
+                free = ((Rm[:, None] >> np.arange(NQ)[None, :]) & 1) == 0
+                if rule in ("A1", "A1v", "A2", "A2v"):
+                    eps = local_energies(S, Phi, nid, nn) * inv_p[:, None]
+                    if rule == "A1":
+                        r = np.maximum(eps - S.EPS_SEA[None, :], 0.0)
+                    elif rule == "A2":
+                        r = np.abs(eps)
+                    else:
+                        ev = eps @ S.MHALF.T
+                        if rule == "A1v":
+                            ex = ev - S.EPSV_SEA[None, :]
+                            r = np.maximum(0.5 * (ex[:, S.EI] + ex[:, S.EJ]), 0.0)
+                        else:
+                            ea = np.abs(ev)
+                            r = 0.5 * (ea[:, S.EI] + ea[:, S.EJ])
+                elif rule == "B":
+                    r = purities(S, Phi, d, nid, nn, inv_p)
+                else:
+                    G = S.intra(nid) @ Phi
+                    r = -e_residuals(S, Phi, d, nid, nn, p, G)
+                r = np.where(free, r, -np.inf)
+                qsel = np.argmax(np.round(r, 9), axis=1)
+                if rule[0] == "A":
+                    rf = np.where(free, np.maximum(r, 0.0), 0.0)
+                    tot = rf.sum(1)
+                    nfree = free.sum(1)
+                    odds = np.where(tot[:, None] > 1e-12, rf / np.where(tot > 1e-12, tot, 1.0)[:, None],
+                                    free / np.maximum(nfree, 1)[:, None])
+                    contrast = odds.max(1) * nfree
+                    pch = odds[np.arange(nn), qsel]
+                    lev["contrast"] = float(np.mean(contrast[alive]))
+                    lev["pch"] = float(np.mean(pch[alive]))
+                if rule == "E":
+                    emin = -r[np.arange(nn), qsel]
+                    lev["emin"] = float(emin[alive][0])
+                    lev["emin_min"] = float(emin[alive].min())
+                    lev["emin_spread"] = float(emin[alive].max() - emin[alive].min())
+            lev["q_w"] = np.bincount(qsel[alive], weights=p[alive], minlength=NQ)
+            if margerr:
+                b = ((S.Z >> qsel[nid]) & 1).astype(bool)
+                p1 = np.bincount(nid[b], weights=d[b], minlength=nn) * inv_p
+                sm = np.bincount(nid, weights=S.P_SEA, minlength=nn)
+                s1 = np.bincount(nid[b], weights=S.P_SEA[b], minlength=nn)
+                okm = alive & (sm > 0)
+                me = np.abs(p1 - s1 / np.where(sm > 0, sm, 1.0))
+                lev["margerr"] = float((p[okm] * me[okm]).sum() / p[okm].sum())
+            qs = None
+        # --- split: Lueders conditioning with both outcomes is the identity on Phi
+        if rule == "D":
+            key = np.zeros(n, dtype=np.int64)
+            for a, q in enumerate(qs):
+                key |= S.BIT[q].astype(np.int64) << a
+            new = nid * (1 << len(qs)) + key
+        else:
+            qz = qsel[nid]
+            new = nid * 2 + ((S.Z >> qz) & 1)
+        uniq, inv = np.unique(new, return_inverse=True)
+        nid = inv.astype(np.int64)
+        nn = len(uniq)
+        if rule == "D":
+            Rm = Rm[uniq >> len(qs)] | Sset
+        else:
+            par = uniq >> 1
+            Rm = Rm[par] | (1 << qsel[par])
+        d = np.abs(Phi) ** 2
+        p = np.bincount(nid, weights=d, minlength=nn)
+        alive = p >= PMIN
+        nrec = int(bin(int(Rm[0])).count("1"))
+        Hl = S.intra(nid)
+        res, ev, _ = node_residual(S, Phi, nid, nn, p, Hl)
+        if tau > 0 and nrec < NQ:
+            Phi2 = cheb_evolve(Hl, Phi, tau, float(NQ - nrec))
+            dtv = 0.5 * np.bincount(nid, weights=np.abs(d - np.abs(Phi2) ** 2), minlength=nn) \
+                * np.where(p > 0, 1.0 / np.where(p > 0, p, 1.0), 0.0)
+            Phi = Phi2
+        else:
+            dtv = np.zeros(nn)
+        del Hl
+        full = np.abs(Phi) ** 2
+        psea = np.bincount(nid, weights=S.P_SEA, minlength=nn)
+        lev.update(nrec=nrec, nalive=int(alive.sum()),
+                   res_w=float((p[alive] * res[alive]).sum() / p[alive].sum()),
+                   res_max=float(res[alive].max()),
+                   dtv_w=float((p[alive] * dtv[alive]).sum() / p[alive].sum()),
+                   dtv_max=float(dtv[alive].max()),
+                   res_list=res[alive], dtv_list=dtv[alive],
+                   leaf_tv=0.5 * float(np.abs(p - psea).sum()),
+                   full_tv=tv(full, S.P_SEA), support=int((full > 1e-14).sum()))
+        levels.append(lev)
+    return dict(law=np.abs(Phi) ** 2, levels=levels)
+
+
+def set_residual(S, bits, vals):
+    """residual of the sea conditioned on the declared records (bits, vals) under H_R (t1_scan.py)."""
+    m = np.ones(S.n, dtype=bool)
+    R = 0
+    for q, b in zip(bits, vals):
+        m &= (S.BIT[q] if b else ~S.BIT[q])
+        R |= 1 << q
+    ph = np.where(m, S.SEA, 0)
+    ph = ph / np.linalg.norm(ph)
+    nid = np.zeros(S.n, dtype=np.int64)
+    nid[~m] = 1
+    Hl = S.intra(nid)
+    Rm = np.zeros(2, dtype=np.int64)
+    Rm[:] = R
+    p = np.array([1.0, 0.0])
+    res, ev, _ = node_residual(S, ph, nid, 2, p, Hl)
+    return float(res[0]), float(ev[0])
+
+
+def joint_set(S, mask, tau):
+    """one joint formation of the whole set `mask` on the sea, then exp(-i tau H_R):
+    per-outcome residuals, the diagonal moved, and the full law afterwards."""
+    r = run_tree(S, "D", tau, 1, sets=[mask])
+    L = r["levels"][0]
+    return L, r["law"]
+
+
+# ==========================================================================
+# A. THE CUBE
+V8, EDG = cube_cluster()
+FAC = cube_faces()
+EnC = Enc(8, sorted(EDG), FAC)
+AUDC = audit(EnC)
+ok_c = all(AUDC[k] for k in ("R0_welldef", "R0_antisym", "R1", "R2", "R3", "R4", "grp_ok"))
+ETA_C = []
+for (i, j) in EnC.EDGES:
+    ETA_C.append(eta_ks(corner_xyz(min(i, j)), {4: 0, 2: 1, 1: 2}[min(i, j) ^ max(i, j)]))
+FLUX_C = face_flux(FAC, EnC.EDGES, ETA_C)
+ZC = np.arange(4096, dtype=np.int64)
+SC = Space(EnC, ETA_C, ZC, ZC, "cube")
+CID, PHI, REPS, RECS = code_space(EnC, AUDC)
+W = np.zeros((4096, 128), dtype=np.complex128)
+W[ZC, CID] = PHI / np.sqrt(32.0)
+HW = SC.H @ W
+HC = W.conj().T @ HW
+herm_c = float(np.max(np.abs(HC - HC.conj().T)))
+inv_c = float(np.max(np.abs(HW - W @ HC)))
+EVC, VCC = np.linalg.eigh(HC)
+SEA_C = W @ VCC[:, 0]
+E_SEA_C = float(EVC[0])
+GAP_C = float(EVC[1] - EVC[0])
+SC.set_sea(SEA_C)
+NVAL_C = np.zeros(4096, dtype=np.int64)
+for v in range(8):
+    NVAL_C += parity(ZC & EnC.STARMASK[v])
+ZERO_C = SC.P_SEA < 1e-14
+CHARGE_C = ZERO_C & (NVAL_C != 4)
+CANC_C = ZERO_C & (NVAL_C == 4)
+HsC = SC.H @ SEA_C
+E_SEA_C = math.fsum((np.conj(SEA_C) * HsC).real) / math.fsum(np.abs(SEA_C) ** 2)
+sea_res_c = float(np.linalg.norm(HsC - E_SEA_C * SEA_C))
+
+
+def census(law):
+    z = law < 1e-14
+    return dict(support=int((~z).sum()), charge=int((z & CHARGE_C).sum()), canc=int((z & CANC_C).sum()),
+                tv=tv(law, SC.P_SEA), off=float(law[ZERO_C].sum()))
+
+
+r1 = [set_residual(SC, [q], [0])[0] for q in range(12)]
+r_star0 = set_residual(SC, [0, 1, 2], [0, 0, 0])[0]
+check("A1 [exact; 1e-12] cube: R0-R4 %s, k=%d, code %d, D=4096, flux %s x6; sea E=%.12f=-4sqrt3 (%.1e), resid %.1e, "
+      "gap %.6f; support %d, zeros %d=%d charge+%d cancellation; eps_q(sea)=%.6f x12 (spread %.0e); residual one edge %.6f=1/sqrt3 x12 "
+      "(spread %.0e), star(0) %.1e."
+      % (ok_c, AUDC["k"], AUDC["code_dim"], set(FLUX_C), E_SEA_C, abs(E_SEA_C + 4 * np.sqrt(3)), sea_res_c, GAP_C,
+         SC.SUPP, int(ZERO_C.sum()), int(CHARGE_C.sum()), int(CANC_C.sum()), SC.EPS_SEA.mean(), np.ptp(SC.EPS_SEA),
+         np.mean(r1), np.ptp(r1), r_star0),
+      ok_c and AUDC["k"] == 5 and AUDC["code_dim"] == 128 and SC.xpart_ok and set(FLUX_C) == {-1}
+      and abs(E_SEA_C + 4 * np.sqrt(3)) < 1e-12 and sea_res_c < 1e-12 and herm_c < 1e-11 and inv_c < 1e-11
+      and SC.SUPP == 1984 and int(CHARGE_C.sum()) == 1856 and int(CANC_C.sum()) == 256
+      and np.ptp(SC.EPS_SEA) < 1e-12 and abs(SC.EPS_SEA.mean() + 1 / np.sqrt(3)) < 1e-12
+      and np.ptp(r1) < 1e-12 and abs(np.mean(r1) - 1 / np.sqrt(3)) < 1e-12 and r_star0 < 1e-12)
+
+SITE_RULES = ("A1", "A1v", "A2", "A2v", "B", "E")
+IDENT = list(range(12))
+ORDERS = [IDENT[s:] + IDENT[:s] for s in range(12)]
+REV = IDENT[::-1]
+ORDERS += [REV[s:] + REV[:s] for s in range(12)]
+STARS_C = [EnC.STARMASK[v] for v in (0, 3, 5, 6)]
+RES = {}
+for tau in (0.0, 0.5, 2.0, 0.1):
+    for rule in SITE_RULES:
+        RES[(rule, tau)] = run_tree(SC, rule, tau, 12, margerr=True)
+        RES[(rule, tau)]["c"] = census(RES[(rule, tau)]["law"])
+    rD = run_tree(SC, "D", tau, 4, sets=STARS_C)
+    rD["c"] = census(rD["law"])
+    RES[("D", tau)] = rD
+    acc = np.zeros(4096)
+    tvs = []
+    for oi, o in enumerate(ORDERS):
+        rr = run_tree(SC, "C", tau, 12, order=o, margerr=(oi == 0))
+        acc += rr["law"] / len(ORDERS)
+        tvs.append(tv(rr["law"], SC.P_SEA))
+        if oi == 0:
+            RES[("Cid", tau)] = rr
+    RES[("C", tau)] = dict(c=census(acc), tvs=tvs)
+t_cube = time.time() - T0
+
+c0 = [RES[(r, 0.0)]["c"] for r in SITE_RULES] + [RES[("D", 0.0)]["c"], RES[("C", 0.0)]["c"]]
+a1_0 = RES[("A1", 0.0)]["levels"]
+con0 = [a1_0[k]["contrast"] for k in range(5)]
+me0 = max(max(L["margerr"] for L in a1_0), max(L["margerr"] for L in RES[("Cid", 0.0)]["levels"]))
+check("A2 [1e-12] T1 tau=0: every rule (A1 A1v A2 A2v B E, D, all 24 orders) reproduces the sea: max TV %.1e / %.1e, support 1984, "
+      "1856/1856 charge + 256/256 cancellation zeros kept; margerr <= %.1e at every node; A1 "
+      "contrast at steps 1-5 = %s."
+      % (max(c["tv"] for c in c0), max(RES[("C", 0.0)]["tvs"]), me0, "/".join("%.4f" % c for c in con0)),
+      all(c["tv"] < 1e-12 and c["support"] == 1984 and c["charge"] == 1856 and c["canc"] == 256 for c in c0)
+      and max(RES[("C", 0.0)]["tvs"]) < 1e-12 and me0 < 1e-12 and all(abs(c - 1) < 1e-9 for c in con0))
+
+c5 = {r: RES[(r, 0.5)]["c"] for r in SITE_RULES}
+cD5 = RES[("D", 0.5)]["c"]
+dl = RES[("D", 0.5)]["levels"]
+check("A3 [1e-12] T2 tau=0.5 TV(sea): A1 %.9f A1v %.9f A2 %.9f A2v %.9f B %.9f E %.9f; each support 2240, 1856/1856 charge, "
+      "0/256 cancellation kept; D (stars 0,3,5,6) TV %.1e, 256/256, node "
+      "residual <= %.1e, diagonal displaced <= %.1e."
+      % tuple([c5[r]["tv"] for r in SITE_RULES] + [cD5["tv"],
+                                                 max(L["res_max"] for L in dl), max(L["dtv_max"] for L in dl)]),
+      all(0.30 < c5[r]["tv"] < 0.46 and c5[r]["support"] == 2240 and c5[r]["charge"] == 1856 and c5[r]["canc"] == 0 for r in SITE_RULES)
+      and cD5["tv"] < 1e-12 and cD5["canc"] == 256 and cD5["support"] == 1984
+      and max(L["res_max"] for L in dl) < 1e-12 and max(L["dtv_max"] for L in dl) < 1e-12)
+
+tvs5 = RES[("C", 0.5)]["tvs"]
+cC5 = RES[("C", 0.5)]["c"]
+check("A4 T2 24 orders tau=0.5: per-order TV min %.9f (order %d%s) max %.9f mean %.9f, identity %.9f, each support 2240, 0/256 cancellation; "
+      "their average law TV %.9f with support %d, not 1984."
+      % (min(tvs5), int(np.argmin(tvs5)), " = reverse" if int(np.argmin(tvs5)) == 12 else "", max(tvs5), float(np.mean(tvs5)), tvs5[0],
+         cC5["tv"], cC5["support"]),
+      0.28 < min(tvs5) and max(tvs5) < 0.46 and 0.2 < cC5["tv"] < min(tvs5) and cC5["support"] == 2240 and cC5["canc"] == 0)
+
+rows = []
+okt = True
+for tau in (0.1, 2.0):
+    cc = [RES[(r, tau)]["c"] for r in SITE_RULES]
+    tvo = RES[("C", tau)]["tvs"]
+    cD = RES[("D", tau)]["c"]
+    okt &= all(c["canc"] == 0 and c["support"] == 2240 and c["tv"] > 0.04 for c in cc) and all(t > 0.04 for t in tvo) \
+        and cD["tv"] < 1e-12 and cD["canc"] == 256
+    rows.append("tau %.1f: %s, orders %.4f-%.4f, D %.1e" % (
+        tau, " ".join("%s %.4f" % (r, c["tv"]) for r, c in zip(SITE_RULES, cc)), min(tvo), max(tvo), cD["tv"]))
+check("A5 T2 TV(sea) at %s; every site-wise law support 2240 with 0/256 cancellation at both; D 256/256 at both." % "; ".join(rows), okt)
+
+a1 = RES[("A1", 0.5)]["levels"]
+top = [int(np.argmax(L["q_w"])) for L in a1[:4]]
+a1v = RES[("A1v", 0.5)]["levels"]
+topv = [int(np.argmax(L["q_w"])) for L in a1v[:5]]
+check("A6 [1e-12] T4 cube A1 tau=0.5 forms %s (the z-matching): contrast %s, greedy odds %s, margerr %s then %.3f at step 4; residual "
+      "%s, diagonal displaced %s. A1v: star(0) then star(4) in 5 records (%s), residual %.3f after its 3rd."
+      % ("".join("(%d,%d)" % EnC.EDGES[q] for q in top), "/".join("%.2f" % L["contrast"] for L in a1[:4]),
+         "/".join("%.3f" % L["pch"] for L in a1[:4]), "/".join("%.0e" % L["margerr"] for L in a1[:3]), a1[3]["margerr"],
+         "/".join("%.2f" % L["res_w"] for L in a1[:4]), "/".join("%.3f" % L["dtv_w"] for L in a1[:4]),
+         "".join("(%d,%d)" % EnC.EDGES[q] for q in topv), a1v[2]["res_w"]),
+      top == [0, 5, 8, 11] and abs(a1[0]["contrast"] - 1) < 1e-9 and all(L["pch"] >= 0.44 for L in a1[1:4])
+      and all(L["margerr"] < 1e-12 for L in a1[:3]) and a1[3]["margerr"] > 0.1 and all(L["res_w"] > 0.4 for L in a1[:4])
+      and all(L["dtv_w"] > 0.05 for L in a1[:4]) and set(topv) == set(EnC.STAR[0]) | set(EnC.STAR[4]) and a1v[2]["res_w"] > 0.5)
+
+rs = dict(same_star=set_residual(SC, [0, 1], [0, 0])[0], parallel=set_residual(SC, [0, 5], [0, 0])[0],
+          far=set_residual(SC, [0, 11], [0, 0])[0], not_star=set_residual(SC, [0, 5, 8], [0, 0, 0])[0],
+          zmatch=set_residual(SC, [0, 5, 8, 11], [0, 0, 0, 0])[0])
+scan = []
+oks = True
+for tau in (0.5, 0.1, 2.0):
+    for key in ("A1", "Cid", "A1v", "B"):
+        Ls = RES[(key, tau)]["levels"]
+        res = np.concatenate([L["res_list"] for L in Ls])
+        dtv = np.concatenate([L["dtv_list"] for L in Ls])
+        non = res > 1e-6
+        n_inv = int((dtv[non] < 1e-9).sum())
+        n_mov = int((dtv[~non] > 1e-9).sum())
+        scan.append((tau, key, len(res), int(non.sum()), n_inv, int((~non).sum()), n_mov, float(dtv[non].min())))
+        oks &= n_inv == 0 and n_mov == 0 and float(dtv[non].min()) > 5e-5
+check("A7 T5 sea conditioned on two edges of one star %.6f, two parallel z-edges %.6f, two far edges %.6f=sqrt(2/3), a whole "
+      "star %.1e, three edges not a star %.6f, the z-matching %.6f. Scan of 12 trees (A1, identity, A1v, B x tau 0.5/0.1/2.0; %d-%d nodes): "
+      "non-eigenvector nodes (res > 1e-6) with invariant diagonal (< 1e-9) %d of %d; eigenvector nodes displaced %d of %d; min displacement "
+      "among non-eigenvector nodes %.1e/%.1e/%.1e at tau 0.1/0.5/2.0."
+      % (rs["same_star"], rs["parallel"], rs["far"], r_star0, rs["not_star"], rs["zmatch"],
+         min(s[2] for s in scan), max(s[2] for s in scan), sum(s[4] for s in scan), sum(s[3] for s in scan),
+         sum(s[6] for s in scan), sum(s[5] for s in scan),
+         min(s[7] for s in scan if s[0] == 0.1), min(s[7] for s in scan if s[0] == 0.5), min(s[7] for s in scan if s[0] == 2.0)),
+      oks and abs(rs["same_star"] - 1 / np.sqrt(3)) < 1e-9 and abs(rs["parallel"] - 1.0) < 1e-9
+      and abs(rs["far"] - np.sqrt(2 / 3)) < 1e-9 and rs["not_star"] > 1.2 and rs["zmatch"] > 1.3)
+
+eL = RES[("E", 0.5)]["levels"]
+e0c = RES[("E", 0.0)]["levels"]
+emins = [L["emin_min"] for L in eL]
+first0 = next((L["k"] for L in eL if L["emin_min"] < 1e-9), None)
+check("A8 rule E on the cube, best-site residual (min over all branches): tau=0.5 %s at steps 1-7 (min %.3f), first eigenvector site at step "
+      "%d (%d free edges left); tau=0 %s -- the third record completes star(0) exactly, but after one tau=0.5 tick that completion leaves "
+      "%.3f; E's final law at tau=0.5: TV %.6f, 0/256 cancellation."
+      % ("/".join("%.3f" % e for e in emins[:7]), min(emins[:7]), first0, 12 - first0 + 1,
+         "/".join("%.3f" % L["emin_min"] for L in e0c[:4]), eL[2]["emin_min"], c5["E"]["tv"]),
+      min(emins[:7]) > 0.45 and first0 is not None and first0 >= 8 and e0c[2]["emin_min"] < 1e-12 and e0c[0]["emin_min"] > 0.5
+      and e0c[1]["emin_min"] > 0.5 and eL[2]["emin_min"] > 0.5 and c5["E"]["canc"] == 0)
+
+# ==========================================================================
+# B. THE 2x2x3 SLAB (sparse on J)
+VS, EDGES_S, FACES_S, ETA_S = slab(2, 2, 3)
+EnS = Enc(VS, EDGES_S, FACES_S)
+AUDS = audit(EnS)
+ok_s = all(AUDS[k] for k in ("R0_welldef", "R0_antisym", "R1", "R2", "R3", "R4", "grp_ok"))
+FLUX_S = face_flux(FACES_S, EDGES_S, ETA_S)
+DEG = np.zeros(VS, dtype=int)
+for (i, j) in EDGES_S:
+    DEG[i] += 1
+    DEG[j] += 1
+ZS = np.arange(1 << 20, dtype=np.int64)
+NVS = np.zeros(1 << 20, dtype=np.int8)
+for v in range(VS):
+    NVS += parity(ZS & EnS.STARMASK[v])
+J = np.flatnonzero(NVS == 6).astype(np.int64)
+locS = -np.ones(1 << 20, dtype=np.int64)
+locS[J] = np.arange(len(J))
+del ZS, NVS
+SS = Space(EnS, ETA_S, J, locS, "slab")
+SS.set_gens(AUDS["gens"])
+tt = np.arange(SS.n, dtype=np.float64)
+v0 = SS.project_code(np.cos(0.7 * tt + 0.3) + 1j * np.cos(1.3 * tt + 1.1))
+v0 /= np.linalg.norm(v0)
+wS, US = spla.eigsh(SS.H, k=3, which="SA", v0=v0, tol=0, maxiter=20000)
+sea_s = SS.project_code(US[:, 0])
+sea_s /= np.linalg.norm(sea_s)
+sh = float(np.abs(wS).max()) + 6.0
+npol = 0
+for it in range(120):
+    sea_s = SS.project_code(sh * sea_s - SS.H @ sea_s)
+    sea_s /= np.linalg.norm(sea_s)
+    npol += 1
+    if it % 20 == 19:
+        Hs = SS.H @ sea_s
+        ev = math.fsum((np.conj(sea_s) * Hs).real) / math.fsum(np.abs(sea_s) ** 2)
+        if np.linalg.norm(Hs - ev * sea_s) < 1e-13:
+            break
+Hs = SS.H @ sea_s
+E_SEA_S = math.fsum((np.conj(sea_s) * Hs).real) / math.fsum(np.abs(sea_s) ** 2)
+sea_res_s = float(np.linalg.norm(Hs - E_SEA_S * sea_s))
+E_SEA_S_SEQ = float(np.real(np.vdot(sea_s, Hs)))
+del Hs, US, v0
+SS.set_sea(sea_s)
+t_sea = time.time() - T0
+eps_s = SS.EPS_SEA
+epsv_s = SS.EPSV_SEA
+r1s = np.array([set_residual(SS, [q], [0])[0] for q in range(20)])
+out_plane = [q for q, (i, j) in enumerate(EDGES_S) if DEG[i] == 3 and DEG[j] == 3]
+mid = [q for q in range(20) if q not in out_plane]
+E0S = -(8 + 2 * np.sqrt(2))
+check("B1 [exact; 1e-10] slab 2x2x3 open in z: degrees %s, 20 edges, %d faces, R0-R4 %s, k=%d, code %d, flux %s x%d, |J|=%d; "
+      "sea by Lanczos + %d polish steps: E=%.12f=-(8+2sqrt2) (%.1e; the sequential Rayleigh quotient is "
+      "off by %.1e), resid %.1e, support %d; eps(sea) %.6f x%d / %.6f=-(1+sqrt2)/4 x%d; corner %.4f (deg 4) / %.4f (deg 3); one-edge residual "
+      "%.6f=sqrt(3/8) / %.6f."
+      % ("".join(str(d) for d in DEG), len(FACES_S), ok_s, AUDS["k"], AUDS["code_dim"], set(FLUX_S), len(FLUX_S), SS.n, npol,
+         E_SEA_S, abs(E_SEA_S - E0S), abs(E_SEA_S_SEQ - E0S), sea_res_s, SS.SUPP, eps_s[mid].mean(), len(mid), eps_s[out_plane].mean(),
+         len(out_plane), epsv_s[DEG == 4].mean(), epsv_s[DEG == 3].mean(), r1s[mid].mean(), r1s[out_plane].mean()),
+      ok_s and AUDS["k"] == 9 and AUDS["code_dim"] == 2048 and set(FLUX_S) == {-1} and len(FLUX_S) == 11 and SS.n == 473088
+      and abs(E_SEA_S - E0S) < 1e-10 and sea_res_s < 1e-10 and SS.SUPP == 411648 and SS.xpart_ok
+      and np.ptp(eps_s[mid]) < 1e-8 and abs(eps_s[mid].mean() + 0.5) < 1e-8 and abs(eps_s[out_plane].mean() + (1 + np.sqrt(2)) / 4) < 1e-8
+      and abs(r1s[mid].mean() - np.sqrt(3 / 8)) < 1e-8 and np.ptp(r1s[mid]) < 1e-8 and abs(r1s[out_plane].mean() - 0.5638) < 2e-4)
+
+SLAB_RULES = ("A1", "A1v", "A2", "A2v", "B", "E", "C")
+KMAX = 6
+RS = {}
+for rule in SLAB_RULES:
+    RS[rule] = run_tree(SS, rule, 0.5, KMAX, order=list(range(KMAX)) if rule == "C" else None)
+RS2 = {rule: run_tree(SS, rule, 2.0, KMAX, order=list(range(KMAX)) if rule == "C" else None) for rule in ("A1", "C")}
+t_slab = time.time() - T0
+
+
+def sites_of(levels):
+    return "".join("(%d,%d)" % EDGES_S[int(np.argmax(L["q_w"]))] for L in levels)
+
+
+ft = {r: [L["full_tv"] for L in RS[r]["levels"]] for r in SLAB_RULES}
+lt = {r: [L["leaf_tv"] for L in RS[r]["levels"]] for r in SLAB_RULES}
+sup = {r: [L["support"] for L in RS[r]["levels"]] for r in SLAB_RULES}
+ft2 = {r: [L["full_tv"] for L in RS2[r]["levels"]] for r in RS2}
+check("B2 [1e-10] T3 %d records, tau=0.5, full 20-edge law vs the sea (A1/A1v/A2/A2v/B/E/C): after one %s "
+      "(support %d-%d > 411648), after six %s; order: A1 %s A1v %s A2v %s E %s. tau=2.0: A1/C %.4f/%.4f after one, %.3f/%.3f "
+      "after six."
+      % (KMAX, "/".join("%.4f" % ft[r][0] for r in SLAB_RULES), min(sup[r][0] for r in SLAB_RULES), max(sup[r][0] for r in SLAB_RULES),
+         "/".join("%.4f" % ft[r][-1] for r in SLAB_RULES), sites_of(RS["A1"]["levels"]), sites_of(RS["A1v"]["levels"]),
+         sites_of(RS["A2v"]["levels"]), sites_of(RS["E"]["levels"]),
+         ft2["A1"][0], ft2["C"][0], ft2["A1"][-1], ft2["C"][-1]),
+      all(ft[r][0] > 0.11 and sup[r][0] > 411648 for r in SLAB_RULES) and all(0.20 < ft[r][-1] < 0.42 for r in SLAB_RULES)
+      and all(min(ft[r]) > 0.11 for r in SLAB_RULES) and all(ft2[r][0] > 0.02 and ft2[r][-1] > 0.3 for r in RS2))
+
+blind3 = max(lt[r][2] for r in SLAB_RULES)
+check("B3 [1e-10] T3 leaf-TV on the formed sites is blind: <= %.1e at three records for every rule while the full law is "
+      "%.3f-%.3f away; A2/A2v stay at %.1e/%.1e through six (full law %.3f/%.3f); A1 %s at records 3-6, A1v %.3f at 5, B/E/C %.3f/%.3f/%.3f "
+      "at 6 only."
+      % (blind3, min(ft[r][2] for r in SLAB_RULES), max(ft[r][2] for r in SLAB_RULES), lt["A2"][5], lt["A2v"][5], ft["A2"][5], ft["A2v"][5],
+         "/".join("%.3f" % x for x in lt["A1"][2:6]), lt["A1v"][4], lt["B"][5], lt["E"][5], lt["C"][5]),
+      blind3 < 1e-10 and lt["A2"][5] < 1e-10 and lt["A2v"][5] < 1e-10 and lt["A1"][3] > 0.1 and lt["A1v"][4] > 0.1
+      and all(lt[r][k] < 1e-10 for r in SLAB_RULES for k in range(3)) and all(lt[r][4] < 1e-10 for r in ("B", "E", "C")))
+
+eS = RS["E"]["levels"]
+emS = [L["emin_min"] for L in eS]
+allres = [L["res_w"] for r in SLAB_RULES for L in RS[r]["levels"]]
+alldtv = [L["dtv_w"] for r in SLAB_RULES for L in RS[r]["levels"]]
+check("B4 [1e-9] rule E on the slab: best-site residual %s at records 1-6, identical across a level's branches (spread <= %.1e), never 0, "
+      "ending above where it began; residual along every path %.2f-%.2f, diagonal displaced per tick %.3f-%.3f."
+      % ("/".join("%.4f" % e for e in emS), max(L["emin_spread"] for L in eS), min(allres), max(allres), min(alldtv), max(alldtv)),
+      min(emS) > 0.5 and emS[-1] > emS[0] and max(L["emin_spread"] for L in eS) < 1e-9 and min(allres) > 0.4 and min(alldtv) > 0.05)
+
+a1s = RS["A1"]["levels"]
+a2v = RS["A2v"]["levels"]
+t1s = [int(np.argmax(L["q_w"])) for L in a1s[:4]]
+t2v = [int(np.argmax(L["q_w"])) for L in a2v[:3]]
+mid_edges = {q for q, (i, j) in enumerate(EDGES_S) if DEG[i] == 4 and DEG[j] == 4}
+check("B5 T4 slab A1: contrast %.6f at step 1, then %s with greedy odds %s at steps 2-6, the parallel z-edges %s first (a matching); "
+      "A2v forms the degree-4 corners' middle edges %s first and is worst at six records (%.4f = max of %s)."
+      % (a1s[0]["contrast"], "/".join("%.1f" % L["contrast"] for L in a1s[1:6]), "/".join("%.3f" % L["pch"] for L in a1s[1:6]),
+         "".join("(%d,%d)" % EDGES_S[q] for q in t1s), "".join("(%d,%d)" % EDGES_S[q] for q in t2v), ft["A2v"][5],
+         "/".join("%.3f" % ft[r][5] for r in SLAB_RULES)),
+      abs(a1s[0]["contrast"] - 1) < 1e-9 and all(0.43 <= L["pch"] <= 1.0 + 1e-12 for L in a1s[1:4])
+      and all(EDGES_S[q][1] - EDGES_S[q][0] == 1 for q in t1s) and len(set(t1s)) == 4 and set(t2v) <= mid_edges
+      and ft["A2v"][5] >= max(ft[r][5] for r in SLAB_RULES) - 1e-12)
+
+RE0 = run_tree(SS, "E", 0.0, KMAX)
+e0 = RE0["levels"]
+s0 = [int(np.argmax(L["q_w"])) for L in e0]
+star02 = EnS.STARMASK[0] | EnS.STARMASK[2]
+L02, law02 = joint_set(SS, star02, 0.5)
+L0, _ = joint_set(SS, EnS.STARMASK[0], 0.0)
+L2, _ = joint_set(SS, EnS.STARMASK[2], 0.0)
+RD = run_tree(SS, "D", 0.5, 2, sets=[EnS.STARMASK[4], EnS.STARMASK[7]])
+dS = RD["levels"]
+t_end = time.time() - T0
+check("B6 [1e-11] T6 tau=0: rule E on the sea forms %s = star(0) then star(2), best residuals %s; each degree-3 star alone leaves "
+      "%.6f=(sqrt2-1)/2 (%.6f/%.6f); the pair star(0) u star(2) restores the eigenvector property exactly: "
+      "residual max %.1e over its %d outcomes; control full-law TV <= %.1e."
+      % ("".join("(%d,%d)" % EDGES_S[q] for q in s0), "/".join("%.4f" % L["emin_min"] for L in e0), (np.sqrt(2) - 1) / 2, L0["res_max"],
+         L2["res_max"], e0[5]["res_max"], e0[5]["nalive"], max(L["full_tv"] for L in e0)),
+      set(s0[:3]) == set(EnS.STAR[0]) and set(s0[3:6]) == set(EnS.STAR[2]) and abs(e0[2]["emin_min"] - (np.sqrt(2) - 1) / 2) < 1e-6
+      and abs(L0["res_max"] - (np.sqrt(2) - 1) / 2) < 1e-6 and abs(L2["res_max"] - (np.sqrt(2) - 1) / 2) < 1e-6
+      and e0[5]["res_max"] < 1e-11 and e0[5]["nalive"] == 64 and max(L["full_tv"] for L in e0) < 1e-11)
+
+check("B7 [1e-11] T6 the six-record JOINT tick on star(0) u star(2) at tau=0.5: residual max %.1e (%d outcomes), diagonal displaced max %.1e, "
+      "full-law TV %.1e, support %d; the same six sites one at a time with tau=0.5 ticks (rule C): %.4f. D star(4) then star(7): "
+      "full-law TV %.1e/%.1e at 4/8 records, residual max %.1e/%.1e, support %d."
+      % (L02["res_max"], L02["nalive"], L02["dtv_max"], L02["full_tv"], L02["support"], ft["C"][5], dS[0]["full_tv"], dS[1]["full_tv"],
+         dS[0]["res_max"], dS[1]["res_max"], dS[1]["support"]),
+      L02["res_max"] < 1e-11 and L02["nalive"] == 64 and L02["dtv_max"] < 1e-11 and L02["full_tv"] < 1e-11 and L02["support"] == 411648
+      and ft["C"][5] > 0.2 and dS[0]["full_tv"] < 1e-11 and dS[1]["full_tv"] < 1e-11 and dS[1]["support"] == 411648
+      and dS[0]["res_max"] < 1e-10 and dS[1]["res_max"] < 1e-10 and dS[1]["nalive"] == 256)
+
+check("B8 [timing] cube 124 trees %.0f s, slab sea %.0f s, nine slab trees to %d records %.0f s, total %.0f s < %d s; no dense object "
+      "above 4096 x 4096, no seed."
+      % (t_cube, t_sea - t_cube, KMAX, t_slab - t_sea, t_end, AUDIT_TIMEOUT_SEC), t_end < AUDIT_TIMEOUT_SEC)
+
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on the tick's open content, the formation rule. On the BK cube and the open `2×2×3` slab at half filling in the pi-flux sector, with PR #7876's Model A tick (Lueders formation with Born odds, `H_R` evolution between formations): **no site-wise formation rule preserves the sea's registration once the state evolves between formations.** Energy-rate rules in the ruler's form, purity, uniform, each of 24 declared orders, and the eigenvector-seeking rule itself all give total-variation distance `0.29` to `0.46` from the sea's law on the cube and lose all 256 cancellation zeros at every declared `τ > 0`; on the slab the full-law distance is `0.11` to `0.14` after one record and `0.21` to `0.41` after six, while the leaf statistic on the formed sites is blind for three to six records (only the full law discriminates). A site rule can choose an order; the order moves the distance by a factor `1.6` at most and never the support. The energy-rate rule is uniform at the instant and at finite `τ` follows the evolution's own energy spread into a matching, neither the flat-band order nor a preserving one, so the formation rate is not the missing supplier of the sea's registration; the formation unit is. **The exact condition is per step and set-wise:** the conditioned state must be an `H_R` eigenvector after each formation (the sufficient condition proved), which holds when each formed set is a union of whole corner stars satisfying the two-mode condition; no single edge site meets it at any step, and the necessary dephasing condition is met by no non-eigenvector node in any tree computed (0 of 27,848 and 0 of 40,672 nodes), shown numerically and not proved impossible. The preserving rule therefore lives exactly where PRs #7900 and #7902 put it, whole corner stars formed jointly, and extends set-wise one step beyond the flat-band corners: the column pair of degree-3 stars on the slab is an exact eigen-set as a six-record joint tick (residual `2e-15` at all 64 outcomes).

- `docs/NO_SITE_WISE_FORMATION_RULE_PRESERVES_THE_SEA_UNDER_TICK_EVOLUTION_THE_EIGENVECTOR_CONDITION_IS_PER_STEP_AND_SET_WISE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.py` (`TOTAL: PASS=16 FAIL=0`, 36 s; 124 cube trees and nine slab trees to the full six-record depth via a Chebyshev propagator validated to `1e-16`; no seeds)
- `logs/runner-cache/no_site_wise_formation_rule_preserves_the_sea_check_2026_09_03.txt`

## Theorems

- **T1** at `τ → 0` every rule reproduces the sea exactly, so rate selection at the instant says nothing about rates.
- **T2** the cube at `τ ∈ {0.1, 0.5, 2.0}`: all site-wise rules and the 24 declared orders at `TV 0.29`-`0.46`, 256 zeros lost; the order average `0.239` with support 2,240, not the sea.
- **T3** the slab to six records: full-law `TV 0.11`-`0.41`; leaf statistic blind for three to six records.
- **T4** the energy-rate rule: uniform at step 1 exactly; the greedy site carries `0.50`-`1.00` of the odds on the cube and `0.44`-`0.61` on the slab at steps 2-4; the corner form completes stars only after the state has left the sea.
- **T5** the eigenvector condition per step; the best-site residual `≥ 0.496` for steps 1-7 under the eigenvector-seeking rule; scan of every tree node.
- **T6** `star(0) ∪ star(2)` is an exact eigen-set as a six-record joint tick.

## Boundary

- The two named clusters, `t = 1`, the declared `τ` values; greedy versions of the stochastic rules with the odds along the path quantified and the mixture bounded below by the support argument; 24 declared orders for the uniform-order average; no relaxation tick (PR #7895's model, already excluded there); not covered: rates depending on the record configuration, joint formation of sets other than corner stars, interacting or non-flat `H`. Nothing derived from the axioms; Admissibility supplies no formation site, probability or rate (reading note 2, quoted).

## Context

- Parents (all open PRs, none on main): #7876 (tick), #7895 (relaxation tick), #7900 / #7902 (corner-set condition), #7916 (rate ruler), #7925 (corner rate form).
- Part of the owner-authorised 24-hour readability campaign (2026-09-03/04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
