### PR TITLE
feat(born): the Born form from balanced ternaries without the frame import; a counting rogue on the realised family

### DIFF
--- a/docs/THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT_FOR_HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED_THEOREM_NOTE_2026-09-03.md
+++ b/docs/THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT_FOR_HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED_THEOREM_NOTE_2026-09-03.md
@@ -1,0 +1,329 @@
+---
+claim_id: born_form_from_balanced_ternaries_without_frame_import_2026_09_03
+claim_type: bounded_theorem
+claim_scope: "Exact rational one-site algebra on the 2026-08-09 scaled qubit domain. (i) A balanced ternary of scaled projectors resolves the identity exactly when the weights sum to 2 and the weighted directions sum to zero, so its side vectors close a triangle of perimeter 2 and every weight is automatically below 1; verified on 5200 exact rational balanced triples over a declared 52-point rational grid, with weights strictly between 1/21 and 696/697. (ii) Theorem A: for a grading homogeneous in the scale, the non-collinear balanced ternaries alone force the Born form on the whole qubit domain, with no continuity, measurability, boundedness beyond the range, countable additivity, ancilla lift or dimension-three frame theorem; the certificates are an untruncated 52-value circle system of rank 50 whose kernel is exactly the restriction of span{x, y}, a trigonometric system on modes 0 to 8 of rank 15 whose kernel is exactly cos t and sin t, and a degree-six sphere system of 49 unknowns and rank 46 whose kernel is exactly span{x, y, z}. (iii) On the menu family the continuum law of PR 7926 realises, the counting grading 1/3 on interior effects, 1/2 on projectors and 1/2 on coins is menu-independent, normalised on all 5271 realised menus and not Born, as is a one-parameter family containing it; both are killed by the collinear ternary and the mixed coin ternary, which lie in the parent note's low-arity family and are not realised by that law. (iv) Theorem B: on the parent note's family, without homogeneity, the coin menus force w(cI) = c by an exact rank-23 certificate, the mixed coin menus make the residual odd, and the angle-mode system on a 24-point radius grid with 44 perimeter-2 triangles has nullity 0 at modes 0, 3, 5 and 7 and nullity 1 at mode 1 with the vector h(c) = c, so with direction-measurability at each scale the Born form holds almost everywhere in direction. A regularity-free proof of homogeneity is not obtained. No axiom is changed, no axiom-side Born forcing is claimed, and the dimension-three frame theorem is neither used nor recomputed."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py
+---
+
+# The Born Form On The Qubit Domain From Balanced Ternary Menus Without The Three-Dimensional Frame Import: Exact For Homogeneous Gradings, For General Gradings Up To Direction-Measurability, And A Counting Rogue On The Realised Family
+
+**Date:** 2026-09-03 | **Type:** bounded_theorem | **Audit:** unset; independent audit remains a separate lane
+**Status authority:** independent audit only; this note authors no audit verdict and changes no axiom, primitive, registry, queue, or policy.
+**Primary runner:** [`scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py`](../scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py)
+**Runner cache:** [`logs/runner-cache/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.txt`](../logs/runner-cache/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.txt)
+**Parent, on main:** [`BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md`](BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_NOTE_2026-08-09.md)
+**Open sibling branches, none on main:** `A_CONTINUUM_RECORD_ALPHABET_LIFTS_THE_ABUNDANCE_NO_GO_A_FIBRED_BORN_THEOREM_AND_A_FACTOR_OF_TWO_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-09-04.md` (PR #7926, the continuum alphabet and the fibred Born theorem);
+`A_FIBRED_MENU_INDEPENDENCE_CLAUSE_NON_VACUOUS_ON_THE_CONTINUUM_LAW_DISCRIMINATING_ON_THE_CUBE_BOUNDED_THEOREM_NOTE_2026-09-04.md` (PR #7931, the fibred clause);
+`MENU_INDEPENDENCE_IS_INDEPENDENT_OF_THE_AXIOMS_AND_INSUFFICIENT_WITH_THEM_THE_BORN_FORM_NEEDS_MENU_ABUNDANCE_BOUNDED_THEOREM_NOTE_2026-09-03.md` (PR #7919, menu-independence and abundance). All three are open pull requests.
+
+## Result Up Front
+
+The parent note obtains the Born form on the scaled qubit domain by lifting the two- and three-member menus to
+orthonormal bases of `C^3` and applying the dimension-three frame theorem; that import is the third item of the
+readout price PR #7919 states. This note asks whether the balanced ternary menus force the Born form on their own.
+They do, and the price for saying so is exact and small. For a grading homogeneous in the scale, the non-collinear
+balanced ternaries alone force the Born form with no regularity at all — no continuity, no measurability, no
+countable additivity — by a graph-plane lemma on each great circle and a gluing lemma on the sphere. On the
+parent's full low-arity family, without homogeneity, the same conclusion holds up to one clause: the grading is
+measurable in the direction at each scale. Between those readings sits a plain correction — homogeneity is not
+supplied by the menus the continuum law of PR #7926 realises, and on that family an explicit counting grading is
+menu-independent, normalised and not Born.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The dictionary, the two lemmas and Theorem A are exact for all functions with no regularity hypothesis, and the rank certificates are exact rational eliminations over Q on declared grids. Theorem B carries a direction-measurability clause that is not discharged here, and the whole result concerns a supplied menu family and a supplied grading, not the axioms."
+trace_class: upstream_support
+target_claim_id: born_form_scaled_projector_arity_three_threshold
+target_blocker_text: "prove ternary scaled-projector sufficiency or find a rogue"
+source_of_blocker_text: frontier_question
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "Settle whether a bounded, direction-non-measurable, non-Born grading exists on the parent's low-arity family, or find a scale-free amplification giving homogeneity without regularity."
+conditional_surface_status: "exact rational algebra conditional on the supplied menu family, the supplied grading clause, the declared rational grids, and — for Theorem B only — direction-measurability at each scale"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Setting
+
+Work at one site, with `H = C^2`. For a unit vector `n` write `P(n) = (I + n dot sigma)/2`, and take the parent's
+scaled domain `S = {cP(n) : 0 < c <= 1, |n| = 1} union {cI : 0 < c <= 1}`. A **menu** is a finite family of
+nonzero members of `S` summing to `I`; a **grading** is a map `w: S -> [0,1]` whose value depends on the effect
+and not on a menu containing it. The map `cP(n) |-> v = cn` identifies the scaled rank-one effects with the
+punctured unit ball; write `W(v) = w(|v| P(v/|v|))`, `u(c) = w(cI)`.
+
+Two menu families are in play. `M_all` is the parent's family: every two- or three-member menu of `S`. `M_CONT` is
+the family the continuum law `L_CONT` of PR #7926 realises as supports — every binary rank-one menu, every
+non-collinear rank-one ternary, every coin. `M_CONT` is a proper subfamily: the collinear ternary `{aP(n),
+(1-a)P(n), P(-n)}`, the mixed coin ternary `{cP(n), cP(-n), (1-c)I}` and the ternary coin `{aI, bI, (1-a-b)I}` are
+in `M_all` and are not realised by that law, whose ternary branch reads three coplanar positively spanning
+records. Every computation below is exact over `Q` with `fractions.Fraction`; no floating point enters any
+load-bearing check and no seed is used. The runner prints one `PASS` line per verification; six recorded arguments
+print with `ARG:` and are not counted.
+
+## The Supplied Surface, Quoted
+
+The parent states the family this note works over as its second conditional input,
+
+> **Low-arity eligibility.** Every two- or three-member menu is normalized: `sum_j w(E_j)=1`.
+
+and obtains the Born form from it by the lift whose two load-bearing sentences are
+
+> `F` is a nonnegative normalized frame function on `C^3` with no continuity, measurability, differentiability, or
+> countable additivity premise added.
+
+> By the named dimension-three frame theorem, there is a unique positive operator `R on C^3` with `Tr(R)=1` and
+> `F(u)=<u|R|u>`.
+
+Those two sentences are exactly what drops. The runner reads both from the parent on disk and from this note, and
+uses neither.
+
+## T1 — The Dictionary: A Balanced Ternary Is A Perimeter-2 Triangle
+
+Taking traces and traceless parts of `sum_i c_i P(n_i) = I` gives the exact equivalence
+
+> `sum_i c_i P(n_i) = I` **iff** `sum_i c_i = 2` and `sum_i c_i n_i = 0`,
+
+so the `v_i = c_i n_i` are the side vectors of a closed triangle of perimeter 2, and the balanced weights of three
+non-collinear coplanar directions are unique, `c_i/2` being the barycentric coordinates of the origin in the
+triangle `n_1 n_2 n_3`. Two consequences are automatic rather than extra hypotheses. First, `c_1 = |c_2 n_2 + c_3
+n_3| <= c_2 + c_3 = 2 - c_1`, so `c_1 <= 1`, with equality only when `n_2 = n_3`; the runner checks the strict
+inequality through `|c_2 n_2 + c_3 n_3|^2 < (c_2 + c_3)^2` iff `n_2 dot n_3 < 1`, on all **1326** pairs of the
+declared grid. Second, a **projector never enters a non-collinear balanced ternary**: a side of length 1 forces
+the other two to sum to 1, hence to be parallel. On the declared grid of **52** rational unit directions from the
+Pythagorean parametrisation with `m <= 5` there are **5200** non-collinear balanced ternaries; each satisfies `sum
+c_i = 2` and `sum c_i n_i = 0` exactly, every weight lies strictly between **1/21** and **696/697**, and none is a
+projector.
+
+## T2 — Theorem A: Homogeneous Gradings, Exactly, With No Regularity
+
+Assume homogeneity in the scale, `w(cP(n)) = c f(n)`, and put `F = f - 1/2`. Normalisation on a non-collinear
+balanced ternary reads `sum_i c_i F(n_i) = 0`.
+
+> **Lemma 1 (great circle).** Let `C` be a great circle and `F: C -> R` **any** function with `sum_i c_i F(n_i) =
+> 0` on every balanced non-collinear triple in `C`. Then `F(n) = beta_C dot n` on all of `C`, for one in-plane
+> `beta_C`. **Lemma 2 (gluing).** If `F: S^2 -> R` is linear on every great circle, then `F(n) = beta dot n` for
+> one `beta` in `R^3`.
+
+*Proof.* For a balanced triple the lifted vectors `(n_i, F(n_i))` in `R^3` satisfy `sum_i c_i (n_i, F(n_i)) = 0`
+with every `c_i` nonzero, so they are dependent; no two members are antipodal, so `n_1, n_2` are independent and
+the three lifted vectors span the plane through the first two, the graph of a linear form. Parametrising `C` by
+`t`, a triple is balanced exactly when all three gaps are below `pi`, so a fixed pair `(0, delta)` completes to
+balanced triples throughout `(pi, pi + delta)`; chaining pairs from that arc carries the one `beta_0` over the
+circle bar two points, and a restart from `(delta/2, 3delta/2)` agrees at two independent points and covers those.
+For Lemma 2, with `a_i = F(e_i)`, `m = (x, y, 0)/r` and `r = (x^2 + y^2)^{1/2}` nonzero, the equator gives `F(m) =
+(a_1 x + a_2 y)/r` and the circle through `e_3` and `m` gives `F(n) = r F(m) + z a_3 = beta dot n`. ∎
+
+> **Theorem A.** Let `w: S -> [0,1]` be menu-independent, homogeneous on the rank-one effects, and normalised on
+> every non-collinear balanced ternary. Then there is a unique density matrix `rho` with `w(cP(n)) = tr(rho,
+> cP(n))` for every `c` in `(0,1]` and every `n`. No continuity, measurability, boundedness beyond the range
+> `[0,1]`, or countable additivity is used; no ancilla, no lift, no dimension-three theorem.
+
+The lemmas give `f(n) = 1/2 + beta dot n`; the range at `c = 1`, `n = ± beta/|beta|` forces `|beta| <= 1/2`, so
+`rho = (I + 2 beta dot sigma)/2` is a density matrix with `c(1/2 + beta dot n) = tr(rho, cP(n))`, unique by the
+Bloch correspondence, and homogeneity gives `u(c) = c` on the coins.
+
+**Certificates (exact rational), in increasing truncation.**
+
+| system | unknowns | rows | rank | kernel |
+|---|---:|---:|---:|---|
+| one free value per grid direction, no truncation at all | 52 | 5200 | **50** | exactly the restriction of `span{x, y}` |
+| trigonometric polynomials, modes 0 to 8 | 17 | 400 | **15** | exactly `{cos t, sin t}` |
+| all polynomials of degree `<= 6` on `S^2`, 12 rational great circles | 49 | 168 | **46** | exactly `span{x, y, z}` |
+
+The first is the sharp one: with one independent unknown per grid point and no polynomial or Fourier truncation
+whatsoever, the balanced-triple rows already leave nullity exactly 2 — Lemma 1 certified on the grid, which the
+degree-truncated computations of the open sibling PRs could not say. A **fibred corollary** follows: if a fibre
+realises only the ternaries of one great circle `C`, then `f` on `C` is exactly `1/2 + beta_C dot n`, Born odds on
+the realised support with `rho` fixed up to the Bloch component normal to `C`, and two non-parallel circles pin
+`rho` — PR #7926's one-circle proposition with the degree bound and the regularity both removed.
+
+## T3 — The Counting Rogue On The Realised Family
+
+`M_CONT` has a structural feature `M_all` does not: **arity is a function of the effect**. Every interior effect
+`cP(n)` with `c < 1` occurs only in ternaries, every projector only in binaries, every coin only in binaries. So
+`1/arity` is a menu-independent grading.
+
+> **Proposition 3.** `w(cP(n)) = 1/3` for `0 < c < 1`, `w(P(n)) = 1/2`, `w(aI) = 1/2` is menu-independent, has
+> range in `[0,1]`, is continuous in the direction and is normalised on **every** menu `L_CONT` realises —
+> **5271** of them on the declared grid: 5200 ternaries, 52 binaries, 19 coins — and it is **not** of Born form,
+> since `tr(rho, cP(n))` is homogeneous in `c` while `w(P)/1 = 1/2` against `w(P/2)/(1/2) = 2/3`.
+
+The rogue is not isolated: the family `W(v) = (1/2 + lambda)|v| - 2 lambda/3 + beta dot v` is normalised on **all
+5200** non-collinear ternaries identically in `lambda` and `beta`, its three coefficient conditions being exactly
+`sum |v_i| = 2`, `sum v_i = 0` and `sum |v_i|/2 = 1`; its range is in `[0,1]` exactly for `lambda` in `[-3/2, 0]`,
+and only `lambda = 0` is Born. On the projector boundary it is worse still: projectors never enter a non-collinear
+ternary, so on `M_CONT` the values `w(P(n))` are constrained by nothing beyond `w(P(n)) + w(P(-n)) = 1`, and the
+dimension-two frame freedom survives there verbatim. What kills the rogue is exactly the two menus `M_all` has and
+`M_CONT` lacks: the collinear ternary `{aP(n), (1-a)P(n), P(-n)}` at `a = 1/4` sums to **7/6** on it, and the
+mixed coin ternary `{cP(n), cP(-n), (1-c)I}` at `c = 1/2` sums to **7/6**. Either family, or a homogeneity clause
+on the grading, restores the Born conclusion on the interior.
+
+## T4 — Theorem B: `M_all` Without Homogeneity
+
+Three exact reductions, none needing regularity. **Coins:** the binary coin gives `u(a) + u(1-a) = 1` and the
+ternary coin `u(a) + u(b) + u(1-a-b) = 1`, so `u` is additive, and on the radius grid `j/24` the **144** coin rows
+have rank **23** and nullity **1**, with kernel exactly `u(c) = c` normalised by `u(1) = 1`. **Oddness:** the
+mixed coin ternary gives `W(cn) + W(-cn) = 1 - u(1-c) = c`, so `K(v) := W(v) - |v|/2` is odd on the punctured
+ball, `|K| <= 1`. **Additivity on perimeter-2 pairs:** since `sum_i |v_i| = 2` on every balanced ternary,
+normalisation is exactly `K(v_1) + K(v_2) + K(v_3) = 0`, that is `K(u + v) = K(u) + K(v)` whenever `|u| + |v| +
+|u+v| = 2`, and Born is `K(v) = gamma dot v`. The graph-plane argument gives a `gamma_T` per triangle; two
+perimeter-2 triangles never share two side vectors, so Lemma 1's chaining has no analogue, and that is where
+homogeneity was doing work.
+
+**The angle modes.** In a plane with `v = c n(phi)`, suppose `phi |-> K(c n(phi))` is integrable at each scale,
+with angle-Fourier coefficients `h_k(c)`. Rotating a triangle shape and taking the `k`-th coefficient gives `sum_i
+h_k(c_i) e^{i k alpha_i} = 0` for every perimeter-2 triangle, and with `alpha_2 - alpha_1 = pi - A_3`, `alpha_3 -
+alpha_2 = pi - A_1` this makes `(h_k(c_1), h_k(c_2), h_k(c_3))` proportional to `(sin kA_1, sin kA_2, sin kA_3)`;
+even `k` vanish by oddness and `k = 0` by the mixed coin menu. At `k = 1` the law of sines makes `sin A_i`
+proportional to `c_i`, so `h_1(c)/c` is constant on each triangle, any two lengths in `(0,1)` summing above 1
+share a triangle, and chaining gives `h_1(c) = lambda c` with `h_1(1) = lambda` from the collinear ternary at `a =
+1/2`: **mode 1 is the Born vector and it is homogeneous.** For odd `k >= 3` a triangle with `A_1 = pi/k` and `sin
+kA_2` nonzero forces `h_k(c_1) = 0` over `(m_k, 1)`, `m_k = 2 sin(pi/2k)/(1 + sin(pi/2k))`, and a second triangle
+carries that zero to every length: **every mode `k >= 2` is killed.**
+
+> **Theorem B.** Let `w` be menu-independent and normalised on `M_all`, with `n |-> w(cP(n))` measurable on `S^2`
+> at each scale. Then `w(cP(n)) = c(1/2 + gamma dot n)` for almost every `n` at each `c`, with `|gamma| <= 1/2`,
+> and `w(cI) = c`. Continuity in the direction at each scale, or homogeneity, upgrades this to every effect.
+
+**Certificate on the 24-point radius grid, 44 perimeter-2 grid triangles.**
+
+| rows | k = 0 | k = 1 | k = 3, 5, 7 |
+|---|---|---|---|
+| `M_CONT` only | nullity **3**: uncovered `1/24`, the rogue `(c - 2/3)` on the interior, `h(1)` free | nullity **3**: uncovered, Born `c`, `h(1)` free | nullity **2**: uncovered, `h(1)` free — interior killed |
+| `M_all` | nullity **0** | nullity **1**, the vector `h_1(c) = c` including `h_1(1) = 1` | nullity **0** |
+
+The radius `1/24` is covered by no grid triangle and is reported as a grid artefact, not a kernel direction. The
+reading is sharp: modes `k >= 3` are killed by the non-collinear ternaries alone, so all the collinear and mixed
+coin menus add is the scale coupling at mode 0 and the projector boundary — exactly the homogeneity content.
+
+## The Correction To The Three Open Sibling PRs
+
+The fibred Born theorem of PRs #7926 and #7931 and the kernel computations of PR #7919 are computations **inside
+the homogeneous ansatz**, and say so in their own words — PR #7926, "In the normal form `w(cP(u)) = c(1 +
+f(u))/2`", and PR #7919, "Take the polynomial sector `w(c P(u)) = c(1 + f(u))/2`" — while both runners build each
+menu row by multiplying a direction-only vector by the scale, at `menu_row` in #7926 and at the same place in
+#7919:
+
+```text
+row = [r + c * v for r, v in zip(row, f_row(n, a_mons, b_mons))]
+row = [row[t] + coefficient * vals[t] for t in range(len(row))]
+```
+
+Under that ansatz every conclusion of those notes stands, and Theorem A makes their great-circle proposition
+exact. What does not stand is the unqualified reading: **the realised menus do not supply homogeneity**, and
+Proposition 3 is an explicit menu-independent non-Born grading on every menu `L_CONT` realises. The same ansatz is
+why PR #7919 correctly found the mixed ternary rows vanishing identically — inside homogeneity that menu reduces
+to the binary condition — while without it that menu is one of the two that kill the rogue. So the fibred Born
+conclusions of #7926 and #7931 hold **as theorems about homogeneous gradings**, and menu-independence plus
+normalisation on the realised balanced ternaries alone is insufficient.
+
+## Corollary — The Readout Price
+
+Against the three items PR #7919 prices — a fibred menu-independence clause, abundance, and the frame import:
+**(1) the frame import drops**, exactly for any homogeneous grading (Theorem A) and up to the direction-regularity
+clause on `M_all` (Theorem B), neither using `C^3`, an ancilla, or the dimension-three theorem; **(2) the fibred
+clause stays and is sharpened** — one great circle of realised ternaries gives Born odds on the support exactly,
+with no degree truncation and no regularity, and two non-parallel circles pin the state; **(3) abundance stays
+and, on the continuum law, must be enlarged** — the realised family lacks the collinear and mixed coin ternaries,
+and without them the counting rogue is menu-independent and non-Born on every realised support, so either those
+menus join the abundance clause or homogeneity becomes a clause of the grading. The price reads either **fibred
+clause plus abundance with collinear menus** or **fibred clause plus abundance plus a homogeneity clause**; the
+frame item is gone in both, and the count of supplied items does not grow in the first.
+
+## The Honest Residue
+
+A regularity-free proof of homogeneity from `M_all` was **not obtained**. Gleason's bounded-implies-continuous
+lemma works in dimension three because the frame condition is scale-free on the sphere; the perimeter-2 family is
+not scale-free, and no amplification argument replacing it was found. Whether a bounded, direction-non-measurable,
+non-Born grading exists on `M_all` is **open** here: none is exhibited and none is excluded. The parent's lift
+needs no regularity at all, so on that one point the import still buys something, and Theorem B's clause is the
+honest measure of what. The four-outcome collinear menu `{aP(n), bP(n), (1-a-b)P(n), P(-n)}` would give bounded
+additivity in the scale and hence homogeneity exactly, but it has arity four: outside the parent's surface and the
+realised family alike.
+
+## Reading, Not Theorem
+
+If a rule assigns odds to a scaled alternative without regard to the list it appears in, and the three-way
+alternatives are all available, then the odds are the quantum ones — and to see it one needs nothing about a third
+dimension, an extra system, or any smoothness in the rule. The catch is a scaling question that sounds too simple
+to matter: does half of an alternative get half the odds? If the rule is told that it does, the argument is
+complete and exact. If it is not told, the three-way alternatives the continuum rule offers can be answered by
+counting how many alternatives there are, which is not the quantum answer; two further three-way alternatives,
+both ordinary, remove that.
+
+## Executable claim block
+
+```text
+grid_circle_directions: 52 rational unit vectors, Pythagorean parametrisation m <= 5; 68 at m <= 6; 12 great circles
+balanced_ternaries: 5200 non-collinear balanced triples; weights in (1/21, 696/697); c_i <= 1 automatic
+untruncated_circle_certificate: 52 unknowns, 5200 rows, rank 50, nullity 2, kernel = span{x, y} restricted
+truncated_certificates: circle modes 0..8, 17 unknowns, 400 rows, rank 15, kernel {cos t, sin t}; sphere degree <= 6, 49 unknowns, 168 rows, rank 46, kernel span{x, y, z}
+realised_menus: 5271 = 5200 ternaries + 52 binaries + 19 coins; the counting rogue is normalised on all
+rogue_family: (1/2+lambda)|v| - 2lambda/3 + beta.v, range in [0,1] iff lambda in [-3/2, 0]; lambda = 0 is Born
+rogue_killers: collinear ternary at a = 1/4, mixed coin ternary at c = 1/2, both summing to 7/6 on the rogue
+coin_certificate: 144 rows, 24 unknowns on the grid j/24, rank 23, nullity 1, kernel u(c) = c; 44 perimeter-2 triangles, 1/24 covered by none
+mode_nullity: M_CONT 3, 3, 2, 2, 2 at k = 0, 1, 3, 5, 7; M_all 0, 1, 0, 0, 0, mode 1 giving h_1(c) = c
+arithmetic: exact rational throughout, fractions.Fraction; no float, no seed, no numpy, no sympy
+import_boundary: the dimension-three frame theorem is quoted from the parent and never used; runner_result_required: zero failed checks
+```
+
+## Interfaces
+
+**The parent, on main.** Its low-arity family is the family `M_all` here; its lift and frame step are quoted and
+not used, and Theorems A and B reach the same conclusion on a smaller hypothesis set, neither refuting it. **PR
+#7926.** Its `L_CONT` fixes `M_CONT`; Theorem A sharpens its fibred theorem and Proposition 3 qualifies it. **PR
+#7931.** Its fibred clause is untouched and inherits that qualification. **PR #7919.** Its three-item price is
+what the Corollary re-prices.
+
+## Proof boundary
+
+Proved: the dictionary and the automatic weight bound; Lemmas 1 and 2 and Theorem A, exact for **all** functions
+with no regularity hypothesis; the fibred corollary; Proposition 3 and its one-parameter family; the two killing
+menus; the exact coin rank certificate and the oddness reduction; the mode identities and the four exact rank
+certificates on the declared grids. Not proved: any axiom-side derivation of the Born form; homogeneity without a
+regularity clause; whether a bounded, direction-non-measurable, non-Born grading exists on `M_all`; anything at
+arity four or above; and any claim that the continuum law of PR #7926 is the framework's law. Boundaries: the
+qubit domain only, one site; the rational grids as declared — 52 and 68 circle directions, 36 per great circle, 12
+great circles from four rational orthonormal frames, and the radius grid `j/24`; polynomial degrees `<= 8` on the
+circle and `<= 6` on the sphere, bounding the truncated certificates only, since Lemmas 1 and 2 and Theorem A are
+exact for all functions and the untruncated 52-value certificate has no degree bound. Nothing here is derived from
+the axioms — family, grading and menu-independence are all supplied.
+
+## Honest Auditor Read
+
+Audit this as a bounded theorem about a supplied menu family: for a homogeneous grading the balanced ternaries
+force the Born form exactly and without any regularity; for a general grading on the parent's family they force it
+up to direction-measurability; on the family the continuum law realises they force neither, with an explicit
+rogue. Do not audit it as a claim that the frame import is gone unconditionally, that homogeneity is proved, or
+that the Born form follows from the four axioms.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| scaled domain `S` and the family `M_all` | declared family | 2026-08-09 parent note, on main | physical eligibility remains open |
+| `M_CONT`, the realised family | declared family | PR #7926, open, not on main | one law among several |
+| homogeneity in the scale | grading clause, when assumed | stated here as a hypothesis | not supplied by any menu |
+| direction-measurability at each scale | regularity clause for Theorem B | stated here as a hypothesis | not discharged |
+| dimension-three frame theorem | quoted from the parent, never used | 2026-08-09 parent note | absent from both theorems |
+| observations, fits, target probabilities | none | not used | not applicable |
+
+## Review Record
+
+The parent obtains the Born form here through a one-ancilla lift and the dimension-three frame theorem; this note
+obtains it twice without either — exactly under homogeneity, and up to direction-measurability on the parent's own
+family — reports a correction the three open sibling PRs need, and exhibits the menu-independent non-Born grading
+that makes the point concrete. It does not advance current-surface physical Born closure: the family, the grading
+clause and the law are supplied.
+
+Independent audit remains required before the repository may assign any effective claim status.

--- a/logs/runner-cache/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.txt
+++ b/logs/runner-cache/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.txt
@@ -1,0 +1,65 @@
+===== runner cache v1 =====
+runner: scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py
+runner_sha256: d18cdc8b6d1514372c5c283cabcbfa332bead6dbe49e0bd34bbf1cd0715e264e
+input_fingerprint_sha256: 776a26739bdb8e1e486f364c0bf323ac0a99e9e690f8a0ae4ef60eb06adb10aa
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 2.48
+status: ok
+----- stdout -----
+arithmetic_boundary: exact rational only, fractions.Fraction; no float, no seed
+grid_boundary: 52 and 68 circle points, 12 rational great circles, radii j/24
+truncation_boundary: circle modes 0..8, sphere degree <= 6; Lemmas 1-2 need neither
+import_boundary: no frame theorem, no ancilla lift, no Gleason; the parent is read as text
+PASS: T1-grid 52 rational unit directions, each exactly on the circle
+PASS: T1-count 5200 non-collinear balanced ternaries on that grid
+PASS: T1-resolution each has sum c_i = 2 and sum c_i n_i = 0, so sum c_i P(n_i) = I
+PASS: T1-perimeter the sides v_i = c_i n_i close a triangle of perimeter 2
+PASS: T1-interior every weight is in (1/21, 696/697), so c_i <= 1 is automatic
+PASS: T1-strict |c2 n2 + c3 n3| < c2 + c3 unless n2 = n3, on all 1326 grid pairs
+PASS: T1-no-projector no non-collinear balanced ternary contains a projector
+ARG: T1-degenerate a side of length 1 forces the other two to sum to 1, hence n2 = n3
+PASS: T2-lemma1-pairs no two members of a balanced triple are antipodal
+PASS: T2-circle-free 52 free values, 5200 rows, rank 50, nullity 2: no truncation
+PASS: T2-circle-free-kernel that kernel is exactly the restriction of span{x, y}
+PASS: T2-circle-modes modes 0..8, 17 unknowns, 400 triples, rank 15, nullity 2
+PASS: T2-circle-kernel that kernel is exactly {cos t, sin t}
+PASS: T2-frames 4 rational orthonormal frames give 12 exact great circles
+PASS: T2-sphere degree <= 6, 49 unknowns, 168 triples, rank 46, nullity 3
+PASS: T2-sphere-kernel that kernel is exactly span{x, y, z}
+PASS: T2-range |beta| = 1/2 keeps 1/2 + beta.n in [0,1] and sums to 1; |beta| = 1 does not
+ARG: T2-lemma1 chaining balanced pairs round the circle carries one beta to every point
+ARG: T2-lemma2 a form linear on every great circle is linear on the sphere, by gluing
+PASS: T3-realised 5271 menus M_CONT realises: 5200 ternaries, 52 binaries, 19 coins
+PASS: T3-rogue the counting rogue is normalised on every one of them
+PASS: T3-not-born it is not Born: w(P)/1 = 1/2 against w(P/2)/(1/2) = 2/3
+PASS: T3-family (1/2+lam)|v| - 2lam/3 + beta.v sums to 1 on all 5200, in lam and beta
+PASS: T3-family-range its range is in [0,1] exactly for lam in [-3/2, 0]
+PASS: T3-collinear the collinear ternary {aP(n),(1-a)P(n),P(-n)} at a = 1/4 sums to 7/6
+PASS: T3-mixed the mixed coin ternary {cP(n),cP(-n),(1-c)I} at c = 1/2 sums to 7/6
+PASS: T3-unrealised neither is a coplanar positively spanning rank-one triple
+ARG: T3-arity on M_CONT arity is a function of the effect, so 1/arity is menu-independent
+PASS: T4-coin coin rows on the grid j/24: 144 rows, rank 23, nullity 1, kernel u(c) = c
+PASS: T4-odd the mixed coin menu then gives W(cn) + W(-cn) = 1 - u(1-c) = c: K is odd
+PASS: T4-additive sum |v_i| = 2 on all 5200, so sum W = 1 is K(v1)+K(v2)+K(v3) = 0
+PASS: T4-triangles 44 perimeter-2 triangles have sides on the grid j/24
+PASS: T4-sines sin A_i / c_i is one number per triangle, exactly: mode 1 is Born
+PASS: T4-cont-nullity M_CONT: nullity 3 at k = 0 and 1, nullity 2 at k = 3, 5, 7; 1/24 uncovered
+PASS: T4-cont-k0 at k = 0 the covered interior carries the rogue (c - 2/3) and h(1) is free
+PASS: T4-cont-k1 at k = 1 the covered interior carries Born c and h(1) is free
+PASS: T4-cont-high at k = 3, 5, 7 the interior is killed by the non-collinear ternaries alone
+PASS: T4-all-even M_all: rank 24 and nullity 0 at k = 0, 3, 5, 7
+PASS: T4-all-k1 M_all: nullity 1 at k = 1, the vector h_1(c) = c with h_1(1) = 1
+ARG: T4-modes sin kA_1 = 0 with sin kA_2 nonzero kills h_k on an interval, then everywhere
+ARG: T4-ae an integrable direction profile gives the Born form a.e. in direction per scale
+PASS: gate-parent-family the 2026-08-09 note's low-arity family M_all, verbatim
+PASS: gate-parent-lift its ancilla frame lift, verbatim
+PASS: gate-parent-gleason its dimension-three frame step, verbatim
+PASS: gate-axiom-domain the axiom file's one-site M_2(C) presentation
+PASS: gate-correction the note records the homogeneous-ansatz correction, quoted
+PASS: gate-surface the note keeps its conditional surface and its audit line
+recorded_arguments: 6 printed, none counted
+TOTAL: PASS=41 FAIL=0
+
+----- stderr -----
+

--- a/scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py
+++ b/scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""Exact rational checks for the balanced-ternary Born note without the frame import.
+
+Class A throughout: every printed check is an algebraic identity or an exact rank and
+kernel certificate computed over `Q` from declared inputs; nothing is compared against
+an external number and nothing is sampled.  No floating point, no seed, no numpy and
+no sympy.  Two blocks are copied from the source computation `b5_exact.py` of the
+probe this note lands:
+
+  * `rref_nullspace` reproduces the source's exact elimination over `Q`
+    (`b5_exact.py:23-52`, the block cited as `rref_nullspace :23`): reduced row
+    echelon form with rational pivots and an explicit nullspace basis.
+  * `mode_rows` reproduces the source's angle-mode row builder (`b5_exact.py:192-219`,
+    the block cited as `mode_rows :192`): per perimeter-2 grid triangle the real and
+    imaginary parts of `sum_i h_k(c_i) e^{i k alpha_i} = 0` in Chebyshev form, plus
+    the collinear-ternary and mixed-coin rows that separate `M_all` from `M_CONT`.
+
+The helpers `pyth_pairs`, `balanced_weights2`, `cs_k`, `cheb_T` and `cheb_U`
+reproduce the source's rational-grid and trigonometric blocks (`b5_exact.py:54-79`
+and `:181-190`).  The dimension-three frame-function theorem is neither used nor
+recomputed here: the parent note's import is read as text only, to quote it.
+Recorded arguments print with an `ARG:` prefix and are excluded from the total.
+"""
+
+import re
+from fractions import Fraction as F
+from itertools import combinations
+from pathlib import Path
+
+AUDIT_TIMEOUT_SEC = 300
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_PATH = ROOT / "docs" / (
+    "THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT_FOR_"
+    "HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED_"
+    "THEOREM_NOTE_2026-09-03.md"
+)
+PARENT_PATH = ROOT / "docs" / (
+    "BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM_"
+    "NOTE_2026-08-09.md"
+)
+AXIOM_PATH = ROOT / "docs" / "MINIMAL_AXIOMS_2026-06-29.md"
+
+AUDIT_INPUT_PATHS = (
+    "docs/THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT"
+    "_FOR_HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED"
+    "_THEOREM_NOTE_2026-09-03.md",
+    "docs/BORN_FORM_FROM_BINARY_TERNARY_SCALED_PROJECTOR_FRAME_LIFT_BOUNDED_THEOREM"
+    "_NOTE_2026-08-09.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+
+def normalize(text):
+    """Whitespace-collapse; markdown blockquote markers are stripped first, so a
+    sentence quoted across wrapped `>` lines matches its source verbatim."""
+    unquoted = "\n".join(re.sub(r"^\s*>\s?", "", ln) for ln in text.split("\n"))
+    return " ".join(unquoted.split())
+
+
+class Checks:
+    """Machine verifications count; recorded arguments print and never count."""
+
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.arguments = 0
+
+    def check(self, label, statement, condition):
+        ok = bool(condition)
+        if ok:
+            self.passed += 1
+        else:
+            self.failed += 1
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+
+    def note(self, label, statement):
+        self.arguments += 1
+        print(f"ARG: {label} {statement}")
+
+    def finish(self):
+        print(f"recorded_arguments: {self.arguments} printed, none counted")
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+# ------------------------------------------------------- exact elimination over Q
+# copy of b5_exact.py:23-52 (`rref_nullspace :23`)
+def rref_nullspace(rows, ncols):
+    """rows: list of lists of Fractions. Returns (rank, nullspace basis)."""
+    piv_rows = []
+    piv_cols = []
+    for r in rows:
+        r = [F(x) for x in r]
+        for pr, pc in zip(piv_rows, piv_cols):
+            if r[pc] != 0:
+                f = r[pc]
+                r = [a - f * b for a, b in zip(r, pr)]
+        pc = next((j for j in range(ncols) if r[j] != 0), None)
+        if pc is None:
+            continue
+        f = r[pc]
+        r = [a / f for a in r]
+        for i in range(len(piv_rows)):
+            if piv_rows[i][pc] != 0:
+                g = piv_rows[i][pc]
+                piv_rows[i] = [a - g * b for a, b in zip(piv_rows[i], r)]
+        piv_rows.append(r)
+        piv_cols.append(pc)
+        if len(piv_rows) == ncols:
+            break
+    rank = len(piv_rows)
+    free = [j for j in range(ncols) if j not in piv_cols]
+    basis = []
+    for fcol in free:
+        v = [F(0)] * ncols
+        v[fcol] = F(1)
+        for pr, pc in zip(piv_rows, piv_cols):
+            v[pc] = -pr[fcol]
+        basis.append(v)
+    return rank, basis
+
+
+# ------------------------------------------------------- rational grids (b5_exact.py:54-79)
+def pyth_pairs(maxmn):
+    pts = set()
+    for m in range(1, maxmn + 1):
+        for n in range(0, m):
+            d = m * m + n * n
+            c, s = F(m * m - n * n, d), F(2 * m * n, d)
+            for (a, b) in [(c, s), (s, c)]:
+                for sa in (1, -1):
+                    for sb in (1, -1):
+                        pts.add((sa * a, sb * b))
+    return sorted(pts)
+
+
+def cross2(u, v):
+    return u[0] * v[1] - u[1] * v[0]
+
+
+def dot(u, v):
+    return sum(a * b for a, b in zip(u, v))
+
+
+def balanced_weights2(n1, n2, n3):
+    p = [cross2(n2, n3), cross2(n3, n1), cross2(n1, n2)]
+    if all(x > 0 for x in p) or all(x < 0 for x in p):
+        s = sum(p)
+        return [x / s for x in p]
+    return None
+
+
+def cs_k(c, s, k):
+    re, im = F(1), F(0)
+    for _ in range(k):
+        re, im = re * c - im * s, re * s + im * c
+    return re, im
+
+
+def cheb_T(k, x):
+    a, b = F(1), x
+    if k == 0:
+        return a
+    for _ in range(k - 1):
+        a, b = b, 2 * x * b - a
+    return b
+
+
+def cheb_U(k, x):
+    a, b = F(1), 2 * x
+    if k == 0:
+        return a
+    for _ in range(k - 1):
+        a, b = b, 2 * x * b - a
+    return b
+
+
+# ------------------------------------------------------- copy of b5_exact.py:192-219 (`mode_rows :192`)
+def mode_rows(k, grid, with_all):
+    idx = {c: i for i, c in enumerate(grid)}
+    n = len(grid)
+    rows = []
+    ntri = 0
+    interior = [c for c in grid if c < 1]
+    for s1, s2 in combinations(interior, 2):
+        s3 = 2 - s1 - s2
+        if s3 not in idx or not (0 < s3 < 1) or s3 < s2:
+            continue
+        ntri += 1
+        cosA3 = (s1 * s1 + s2 * s2 - s3 * s3) / (2 * s1 * s2)
+        cosA2 = (s1 * s1 + s3 * s3 - s2 * s2) / (2 * s1 * s3)
+        sA3, sA2 = 2 / (s1 * s2), 2 / (s1 * s3)
+        if k == 0:
+            r = [F(0)] * n
+            r[idx[s1]] += 1
+            r[idx[s2]] += 1
+            r[idx[s3]] += 1
+            rows.append(r)
+        else:
+            re = [F(0)] * n
+            im = [F(0)] * n
+            re[idx[s1]] += 1
+            re[idx[s2]] += -cheb_T(k, cosA3)
+            re[idx[s3]] += -cheb_T(k, cosA2)
+            im[idx[s2]] += sA3 * cheb_U(k - 1, cosA3)
+            im[idx[s3]] += -sA2 * cheb_U(k - 1, cosA2)
+            rows.append(re)
+            rows.append(im)
+    if with_all:
+        for a in grid:
+            if a < 1 and (1 - a) in idx:
+                r = [F(0)] * n
+                r[idx[a]] += 1
+                r[idx[1 - a]] += 1
+                r[idx[F(1)]] += -1
+                rows.append(r)
+        if k % 2 == 0:
+            for c in grid:
+                r = [F(0)] * n
+                r[idx[c]] += 2
+                rows.append(r)
+    return rows, ntri
+
+
+# ------------------------------------------------------- shared declared data
+PTS5 = pyth_pairs(5)
+PTS6 = pyth_pairs(6)
+PTS4 = pyth_pairs(4)
+FRAMES = [
+    [(F(1), F(0), F(0)), (F(0), F(1), F(0)), (F(0), F(0), F(1))],
+    [(F(2, 3), F(2, 3), F(-1, 3)), (F(2, 3), F(-1, 3), F(2, 3)), (F(-1, 3), F(2, 3), F(2, 3))],
+    [(F(2, 7), F(3, 7), F(6, 7)), (F(3, 7), F(-6, 7), F(2, 7)), (F(6, 7), F(2, 7), F(-3, 7))],
+    [(F(1, 9), F(4, 9), F(8, 9)), (F(4, 9), F(7, 9), F(-4, 9)), (F(8, 9), F(-4, 9), F(1, 9))],
+]
+GRID = [F(j, 24) for j in range(1, 25)]
+
+
+def balanced_triples(points):
+    out = []
+    for n1, n2, n3 in combinations(points, 3):
+        p = balanced_weights2(n1, n2, n3)
+        if p is not None:
+            out.append(((n1, n2, n3), p))
+    return out
+
+
+# ------------------------------------------------------- T1 the dictionary
+def t1(checks, trips):
+    checks.check("T1-grid", "52 rational unit directions, each exactly on the circle",
+                 len(PTS5) == 52 and all(a * a + b * b == 1 for a, b in PTS5))
+    checks.check("T1-count", "5200 non-collinear balanced ternaries on that grid",
+                 len(trips) == 5200)
+    res = all(sum(2 * x for x in p) == 2
+              and all(sum(2 * x * ni[j] for x, ni in zip(p, ns)) == 0 for j in (0, 1))
+              for ns, p in trips)
+    checks.check("T1-resolution", "each has sum c_i = 2 and sum c_i n_i = 0, so sum c_i P(n_i) = I",
+                 res)
+    per = all(sum(2 * x for x in p) == 2 for ns, p in trips)
+    checks.check("T1-perimeter", "the sides v_i = c_i n_i close a triangle of perimeter 2",
+                 per)
+    cs = [2 * x for ns, p in trips for x in p]
+    checks.check("T1-interior", "every weight is in (1/21, 696/697), so c_i <= 1 is automatic",
+                 min(cs) == F(1, 21) and max(cs) == F(696, 697) and all(0 < c < 1 for c in cs))
+    strict = all(dot(a, b) < 1 for a, b in combinations(PTS5, 2))
+    checks.check("T1-strict", "|c2 n2 + c3 n3| < c2 + c3 unless n2 = n3, on all 1326 grid pairs",
+                 strict and len(list(combinations(PTS5, 2))) == 1326)
+    checks.check("T1-no-projector", "no non-collinear balanced ternary contains a projector",
+                 all(c != 1 for c in cs))
+    checks.note("T1-degenerate", "a side of length 1 forces the other two to sum to 1, hence n2 = n3")
+
+
+# ------------------------------------------------------- T2 Theorem A
+def t2(checks, trips):
+    checks.check("T2-lemma1-pairs", "no two members of a balanced triple are antipodal",
+                 all(cross2(ns[i], ns[j]) != 0 for ns, p in trips for i, j in ((0, 1), (0, 2), (1, 2))))
+    idx = {n: i for i, n in enumerate(PTS5)}
+    rows = []
+    for ns, p in trips:
+        r = [F(0)] * len(PTS5)
+        for ni, pi in zip(ns, p):
+            r[idx[ni]] += pi
+        rows.append(r)
+    rk, ker = rref_nullspace(rows, len(PTS5))
+    checks.check("T2-circle-free", "52 free values, 5200 rows, rank 50, nullity 2: no truncation",
+                 rk == 50 and len(ker) == 2)
+    xs = [n[0] for n in PTS5]
+    ys = [n[1] for n in PTS5]
+    joint, _ = rref_nullspace([xs, ys] + [list(v) for v in ker], len(PTS5))
+    checks.check("T2-circle-free-kernel", "that kernel is exactly the restriction of span{x, y}",
+                 joint == 2)
+    rows = []
+    ntrip = 0
+    for ns, p in balanced_triples(PTS6):
+        row = [F(0)] * 17
+        for ni, pi in zip(ns, p):
+            row[0] += pi
+            for k in range(1, 9):
+                ck, sk = cs_k(ni[0], ni[1], k)
+                row[2 * k - 1] += pi * ck
+                row[2 * k] += pi * sk
+        rows.append(row)
+        ntrip += 1
+        if ntrip >= 400:
+            break
+    rk, ker = rref_nullspace(rows, 17)
+    checks.check("T2-circle-modes", "modes 0..8, 17 unknowns, 400 triples, rank 15, nullity 2",
+                 ntrip == 400 and rk == 15 and len(ker) == 2)
+    nz = sorted(i for v in ker for i in range(17) if v[i] != 0)
+    checks.check("T2-circle-kernel", "that kernel is exactly {cos t, sin t}", nz == [1, 2])
+    orth = all(dot(fr[i], fr[j]) == 0 and dot(fr[i], fr[i]) == 1
+               for fr in FRAMES for i, j in combinations(range(3), 2))
+    checks.check("T2-frames", "4 rational orthonormal frames give 12 exact great circles",
+                 orth and len(FRAMES) * 3 == 12)
+    mons = ([(a, b, 0) for a in range(7) for b in range(7 - a)]
+            + [(a, b, 1) for a in range(6) for b in range(6 - a)])
+    rows = []
+    ntrip = 0
+    for fr in FRAMES:
+        for i, j in combinations(range(3), 2):
+            ea, eb = fr[i], fr[j]
+            circ = [tuple(c * ea[t] + s * eb[t] for t in range(3)) for (c, s) in PTS4]
+            per = 0
+            for k1, k2, k3 in combinations(range(len(PTS4)), 3):
+                p = balanced_weights2(PTS4[k1], PTS4[k2], PTS4[k3])
+                if p is None:
+                    continue
+                tri = (circ[k1], circ[k2], circ[k3])
+                rows.append([sum(pi * (n[0] ** m[0]) * (n[1] ** m[1]) * (n[2] ** m[2])
+                                 for pi, n in zip(p, tri)) for m in mons])
+                ntrip += 1
+                per += 1
+                if per >= 14:
+                    break
+    rk, ker = rref_nullspace(rows, len(mons))
+    checks.check("T2-sphere", "degree <= 6, 49 unknowns, 168 triples, rank 46, nullity 3",
+                 len(mons) == 49 and ntrip == 168 and rk == 46 and len(ker) == 3)
+    nz = sorted(mons[i] for v in ker for i in range(49) if v[i] != 0)
+    checks.check("T2-sphere-kernel", "that kernel is exactly span{x, y, z}",
+                 nz == [(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+    beta = (F(3, 10), F(2, 5))
+    vals = [F(1, 2) + dot(beta, n) for n in PTS5]
+    born = all(sum(2 * x * (F(1, 2) + dot(beta, ni)) for x, ni in zip(p, ns)) == 1
+               for ns, p in trips)
+    big = (F(3, 5), F(4, 5))
+    checks.check("T2-range", "|beta| = 1/2 keeps 1/2 + beta.n in [0,1] and sums to 1; |beta| = 1 does not",
+                 dot(beta, beta) == F(1, 4) and all(0 <= v <= 1 for v in vals) and born
+                 and F(1, 2) + dot(big, big) > 1)
+    checks.note("T2-lemma1", "chaining balanced pairs round the circle carries one beta to every point")
+    checks.note("T2-lemma2", "a form linear on every great circle is linear on the sphere, by gluing")
+
+
+# ------------------------------------------------------- T3 the counting rogue
+def rogue(kind, c):
+    if kind == "P":
+        return F(1, 2) if c == 1 else F(1, 3)
+    return F(1, 2)
+
+
+def t3(checks, trips):
+    nm = 0
+    ok = True
+    for ns, p in trips:
+        ok &= sum(rogue("P", 2 * x) for x in p) == 1
+        nm += 1
+    for n in PTS5:
+        ok &= rogue("P", 1) + rogue("P", 1) == 1
+        nm += 1
+    for a in [F(j, 20) for j in range(1, 20)]:
+        ok &= rogue("I", a) + rogue("I", 1 - a) == 1
+        nm += 1
+    checks.check("T3-realised", "5271 menus M_CONT realises: 5200 ternaries, 52 binaries, 19 coins",
+                 nm == 5271)
+    checks.check("T3-rogue", "the counting rogue is normalised on every one of them", ok)
+    checks.check("T3-not-born", "it is not Born: w(P)/1 = 1/2 against w(P/2)/(1/2) = 2/3",
+                 rogue("P", 1) / 1 != rogue("P", F(1, 2)) / F(1, 2))
+    fam = all(sum(2 * x for x in p) - 2 == 0
+              and sum(2 * x * ni[0] for x, ni in zip(p, ns)) == 0
+              and sum(2 * x * ni[1] for x, ni in zip(p, ns)) == 0
+              and sum(2 * x for x in p) / 2 == 1
+              for ns, p in trips)
+    checks.check("T3-family", "(1/2+lam)|v| - 2lam/3 + beta.v sums to 1 on all 5200, in lam and beta",
+                 fam)
+    lo, hi = F(-3, 2), F(0)
+    checks.check("T3-family-range", "its range is in [0,1] exactly for lam in [-3/2, 0]",
+                 -2 * lo / 3 == 1 and -2 * hi / 3 == 0
+                 and F(1, 2) + lo / 3 == 0 and F(1, 2) + hi / 3 == F(1, 2))
+    a = F(1, 4)
+    checks.check("T3-collinear", "the collinear ternary {aP(n),(1-a)P(n),P(-n)} at a = 1/4 sums to 7/6",
+                 rogue("P", a) + rogue("P", 1 - a) + rogue("P", 1) == F(7, 6))
+    checks.check("T3-mixed", "the mixed coin ternary {cP(n),cP(-n),(1-c)I} at c = 1/2 sums to 7/6",
+                 2 * rogue("P", F(1, 2)) + F(1, 2) == F(7, 6))
+    n = PTS5[0]
+    checks.check("T3-unrealised", "neither is a coplanar positively spanning rank-one triple",
+                 balanced_weights2(n, n, (-n[0], -n[1])) is None)
+    checks.note("T3-arity", "on M_CONT arity is a function of the effect, so 1/arity is menu-independent")
+
+
+# ------------------------------------------------------- T4 Theorem B
+def t4(checks, trips):
+    idx = {c: i for i, c in enumerate(GRID)}
+    one = idx[F(1)]
+    rows = []
+    for a in GRID:
+        if a < 1 and (1 - a) in idx:
+            r = [F(0)] * 24
+            r[idx[a]] += 1
+            r[idx[1 - a]] += 1
+            r[one] -= 1
+            rows.append(r)
+    for a, b in combinations([c for c in GRID if c < 1], 2):
+        c3 = 1 - a - b
+        if c3 in idx and 0 < c3 < 1:
+            r = [F(0)] * 24
+            r[idx[a]] += 1
+            r[idx[b]] += 1
+            r[idx[c3]] += 1
+            r[one] -= 1
+            rows.append(r)
+    rk, ker = rref_nullspace(rows, 24)
+    coin_ok = (len(ker) == 1 and rk == 23
+               and all(ker[0][i] / ker[0][one] == GRID[i] for i in range(24)))
+    checks.check("T4-coin", "coin rows on the grid j/24: 144 rows, rank 23, nullity 1, kernel u(c) = c",
+                 len(rows) == 144 and coin_ok)
+    u = {GRID[i]: ker[0][i] / ker[0][one] for i in range(24)}
+    checks.check("T4-odd", "the mixed coin menu then gives W(cn) + W(-cn) = 1 - u(1-c) = c: K is odd",
+                 all(1 - u[1 - c] == c for c in GRID if c < 1 and (1 - c) in u))
+    checks.check("T4-additive", "sum |v_i| = 2 on all 5200, so sum W = 1 is K(v1)+K(v2)+K(v3) = 0",
+                 all(sum(2 * x for x in p) == 2 for ns, p in trips))
+    sines = True
+    ntri = 0
+    for s1, s2 in combinations([c for c in GRID if c < 1], 2):
+        s3 = 2 - s1 - s2
+        if s3 not in idx or not (0 < s3 < 1) or s3 < s2:
+            continue
+        ntri += 1
+        sines &= (2 / (s2 * s3)) / s1 == (2 / (s1 * s3)) / s2 == (2 / (s1 * s2)) / s3
+    checks.check("T4-triangles", "44 perimeter-2 triangles have sides on the grid j/24", ntri == 44)
+    checks.check("T4-sines", "sin A_i / c_i is one number per triangle, exactly: mode 1 is Born",
+                 sines)
+    expect = {0: 3, 1: 3, 3: 2, 5: 2, 7: 2}
+    covered = {}
+    kernels = {}
+    good = True
+    for k in (0, 1, 3, 5, 7):
+        rows, nt = mode_rows(k, GRID, False)
+        rk, ker = rref_nullspace(rows, 24)
+        cov = [i for i in range(24) if GRID[i] < 1 and any(r[i] != 0 for r in rows)]
+        unc = [str(GRID[i]) for i in range(24) if GRID[i] < 1 and i not in cov]
+        good &= (nt == 44 and len(ker) == expect[k] and unc == ["1/24"])
+        covered[k] = cov
+        kernels[k] = ker
+    checks.check("T4-cont-nullity",
+                 "M_CONT: nullity 3 at k = 0 and 1, nullity 2 at k = 3, 5, 7; 1/24 uncovered", good)
+
+    def prop(v, cov, shift):
+        return all(v[i] * (GRID[j] - shift) == v[j] * (GRID[i] - shift) for i in cov for j in cov)
+
+    k0 = kernels[0]
+    cov0 = covered[0]
+    checks.check("T4-cont-k0",
+                 "at k = 0 the covered interior carries the rogue (c - 2/3) and h(1) is free",
+                 any(prop(v, cov0, F(2, 3)) and not prop(v, cov0, F(0)) for v in k0)
+                 and any(v[-1] == 1 and all(v[i] == 0 for i in cov0) for v in k0))
+    k1 = kernels[1]
+    cov1 = covered[1]
+    checks.check("T4-cont-k1",
+                 "at k = 1 the covered interior carries Born c and h(1) is free",
+                 any(prop(v, cov1, F(0)) and not prop(v, cov1, F(2, 3)) for v in k1)
+                 and any(v[-1] == 1 and all(v[i] == 0 for i in cov1) for v in k1))
+    killed = all(all(v[i] == 0 for i in covered[k]) for k in (3, 5, 7) for v in kernels[k])
+    checks.check("T4-cont-high",
+                 "at k = 3, 5, 7 the interior is killed by the non-collinear ternaries alone", killed)
+    good = True
+    for k in (0, 3, 5, 7):
+        rows, nt = mode_rows(k, GRID, True)
+        rk, ker = rref_nullspace(rows, 24)
+        good &= (nt == 44 and rk == 24 and len(ker) == 0)
+    checks.check("T4-all-even", "M_all: rank 24 and nullity 0 at k = 0, 3, 5, 7", good)
+    rows, nt = mode_rows(1, GRID, True)
+    rk, ker = rref_nullspace(rows, 24)
+    checks.check("T4-all-k1", "M_all: nullity 1 at k = 1, the vector h_1(c) = c with h_1(1) = 1",
+                 len(rows) == 111 and rk == 23 and len(ker) == 1
+                 and all(ker[0][i] / ker[0][-1] == GRID[i] for i in range(24)))
+    checks.note("T4-modes", "sin kA_1 = 0 with sin kA_2 nonzero kills h_k on an interval, then everywhere")
+    checks.note("T4-ae", "an integrable direction profile gives the Born form a.e. in direction per scale")
+
+
+# ------------------------------------------------------- source gates
+def gates(checks):
+    note = normalize(NOTE_PATH.read_text())
+    parent = normalize(PARENT_PATH.read_text())
+    axiom = normalize(AXIOM_PATH.read_text())
+    family = ("**Low-arity eligibility.** Every two- or three-member menu is normalized: "
+              "`sum_j w(E_j)=1`.")
+    lift = ("`F` is a nonnegative normalized frame function on `C^3` with no continuity, "
+            "measurability, differentiability, or countable additivity premise added.")
+    gleason = ("By the named dimension-three frame theorem, there is a unique positive operator "
+               "`R on C^3` with `Tr(R)=1`")
+    checks.check("gate-parent-family", "the 2026-08-09 note's low-arity family M_all, verbatim",
+                 family in parent and family in note)
+    checks.check("gate-parent-lift", "its ancilla frame lift, verbatim", lift in parent and lift in note)
+    checks.check("gate-parent-gleason", "its dimension-three frame step, verbatim",
+                 gleason in parent and gleason in note)
+    checks.check("gate-axiom-domain", "the axiom file's one-site M_2(C) presentation",
+                 "The full one-site possibility domain has algebraic presentation `M_2(C)`" in axiom)
+    checks.check("gate-correction", "the note records the homogeneous-ansatz correction, quoted",
+                 "In the normal form `w(cP(u)) = c(1 + f(u))/2`" in note
+                 and "Take the polynomial sector `w(c P(u)) = c(1 + f(u))/2`" in note
+                 and "row = [r + c * v for r, v in zip(row, f_row(n, a_mons, b_mons))]" in note)
+    checks.check("gate-surface", "the note keeps its conditional surface and its audit line",
+                 all(s in note for s in ("actual_current_surface_status: conditional-support",
+                                         "audit_required_before_effective_retained: true",
+                                         "Independent audit remains required")))
+
+
+def main():
+    print("arithmetic_boundary: exact rational only, fractions.Fraction; no float, no seed")
+    print("grid_boundary: 52 and 68 circle points, 12 rational great circles, radii j/24")
+    print("truncation_boundary: circle modes 0..8, sphere degree <= 6; Lemmas 1-2 need neither")
+    print("import_boundary: no frame theorem, no ancilla lift, no Gleason; the parent is read as text")
+    checks = Checks()
+    trips = balanced_triples(PTS5)
+    t1(checks, trips)
+    t2(checks, trips)
+    t3(checks, trips)
+    t4(checks, trips)
+    gates(checks)
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Bounded theorem note + exact rational runner + cache on the readout price: **the Born form on the qubit domain follows from balanced three-way menus without the three-dimensional frame import, exactly for homogeneous gradings; and the family of menus the continuum law actually realises does not force it, by an explicit counting rogue.** A balanced ternary `{c_i P(n_i)}` with `Σ c_i P(n_i) = I` is exactly `Σ c_i = 2, Σ c_i n_i = 0`, a perimeter-2 triangle, with `c_i ≤ 1` automatic. Theorem A: if the grading is homogeneous in the scale of an effect, `w(cP(n)) = c·w(P(n))`, the non-collinear balanced ternaries alone force `F(n_i) = β·n_i` on every great circle (a balanced triple makes the lifted vectors linearly dependent, and the chaining covers the circle) and the circles glue to the sphere: the Born form with no lift, no `C³`, no ancilla, no Gleason and no regularity. Certificates: circle modes to degree 8 leave exactly `{cos t, sin t}`; an untruncated 52-direction grid leaves nullity 2, exactly the restriction of `span{x, y}`; the sphere to degree 6 leaves exactly `{x, y, z}`. Proposition: on the continuum law's realised family (binary rank-one, non-collinear rank-one ternary, binary coin menus) the counting rogue `w(cP) = 1/3 (c < 1), w(P) = 1/2, w(aI) = 1/2` is menu-independent, normalised on all 5,271 realised menus and not Born; it is killed only by the collinear ternary and the mixed coin ternary (sums `7/6`), which lie in the landed frame-lift note's family `M_all` and are not realised by the continuum law. Theorem B: on `M_all` without homogeneity, `w(cI) = c` (exact rank witness), oddness and perimeter-2 additivity are exact, every angular mode `k ≥ 2` dies and mode 1 is homogeneous, so the Born form holds almost everywhere in direction at each scale, everywhere with continuity; the 24-point radius-grid certificate gives `M_CONT` nullities `3, 3, 2, 2, 2` and `M_all` nullities `0, 1, 0, 0, 0` at `k = 0, 1, 3, 5, 7`, the surviving vector being `h_1(c) = c`. **Correction recorded:** the fibred Born theorem of PRs #7926 and #7931 and the kernel computations of PR #7919 used the homogeneous normal form `w(cP(u)) = c(1 + f(u))/2` silently (quoted verbatim, gated by the runner), so their Born-form conclusions hold under homogeneity, which the realised menus do not supply. **The price:** the frame import drops; the fibred clause stays and is sharpened (one great circle of realised ternaries gives Born odds on the support exactly; two circles pin the state); abundance stays and on the continuum law must be enlarged by the collinear and mixed menus, or homogeneity becomes a clause of the grading. The honest residue: a regularity-free proof of homogeneity from `M_all` was not obtained, and a bounded direction-non-measurable non-Born grading is neither built nor excluded; the four-outcome collinear menu would settle it exactly but lies outside the arity-three surface.

- `docs/THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT_FOR_HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED_THEOREM_NOTE_2026-09-03.md` (329 lines)
- `scripts/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.py` (`TOTAL: PASS=41 FAIL=0`, 3 s; exact rational arithmetic only, no floats, no seeds)
- `logs/runner-cache/born_form_from_balanced_ternaries_without_frame_import_check_2026_09_03.txt`

## Theorems

- **T1** the dictionary: 5,200 rational balanced triples on the 52-point grid, weights in `(1/21, 696/697)`.
- **T2** Theorem A with the three certificates (circle to degree 8: rank 15; untruncated grid: rank 50 of 52; sphere to degree 6: rank 46 of 49).
- **T3** the counting rogue and its one-parameter family; the two killing menus.
- **T4** Theorem B and the mode certificate; the coin certificate `w(cI) = c` (144 rows, rank 23 of 24).

## Boundary

- The qubit domain; rational grids as declared; the polynomial certificates at the declared degrees (the lemmas are exact for all functions); the regularity clause stated; nothing derived from the axioms.

## Context

- Parents: the continuum-alphabet fibred Born theorem (PR #7926), the fibred menu-independence clause (PR #7931), the menu-independence and abundance note (PR #7919), all open; on main, the Born-form frame-lift note whose `M_all` family and lift step are quoted.
- Part of the owner-authorised 24-hour readability campaign (2026-09-03/04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
