### PR TITLE
science(light): localize Maxwell join and force quadratic kernel

### DIFF
--- a/docs/SPIN_HALF_CUBIC_ICE_CUBIC_GAUGE_QUADRATIC_MAXWELL_KERNEL_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_CUBIC_GAUGE_QUADRATIC_MAXWELL_KERNEL_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,198 @@
+# Cubic Covariance and Gauge Transversality Uniquely Fix the Quadratic Maxwell Kernel
+
+**Date:** 2026-09-04
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Physical carrier parent:**
+[`SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_EXACT_RK_COULOMB_CORRELATIONS_AND_FINITE_QUBIT_PHOTON_PHASE_BRIDGE_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py`](../scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.txt`](../logs/runner-cache/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.txt)
+
+## Result up front
+
+Consider the most general symmetric three-component kernel whose entries are
+homogeneous quadratic polynomials in spatial momentum. It has `36` real
+coefficients before constraints. Exact linear algebra gives
+
+```text
+proper cubic covariance only:  dimension 3,
+gauge transversality only:      dimension 6,
+both conditions together:       dimension 1.
+```
+
+The unique joint basis, after one normalization choice, is
+
+```text
+K_ij(q) = q^2 delta_ij - q_i q_j.
+```
+
+Therefore a symmetric, analytic, gapless gauge branch on a proper-cubic
+carrier has a unique quadratic spatial kernel. Its two transverse
+polarizations share one direction-independent leading coefficient. Cubic
+anisotropy may reappear at fourth and higher momentum order, but it cannot
+enter as a second quadratic light-speed coefficient.
+
+This is an exact algebraic reduction, not a numerical fit. It sharpens the
+off-axis spectroscopy campaign: that calculation tests whether the physical
+spin-half branch reaches the assumed analytic transverse regime and measures
+its one coefficient. It is not being asked to infer leading isotropy from a
+few directions when the symmetry and gauge conditions already force it.
+
+## 1. Declared kernel class
+
+Let `K(q)` be a real symmetric `3 x 3` matrix. Each of its six independent
+entries is an arbitrary homogeneous polynomial of degree two in
+`q=(q_0,q_1,q_2)`. The six monomials are
+
+```text
+q_0^2, q_1^2, q_2^2, q_0 q_1, q_0 q_2, q_1 q_2,
+```
+
+so the unrestricted coefficient space has dimension `6 x 6 = 36`.
+
+The claim is deliberately confined to this class. It assumes a quadratic
+Taylor term exists. It does not prove analyticity, exclude a mass or a
+nonanalytic direction-dependent term, or show that the microscopic carrier
+actually has a thermodynamic pole.
+
+## 2. Proper cubic covariance
+
+The runner constructs all `24` orientation-preserving signed permutation
+matrices `R`. For every one it imposes the polynomial identity
+
+```text
+K(R q) = R K(q) R^T.
+```
+
+Coefficient matching over the exact polynomial ring gives rank `33`, leaving
+a three-dimensional cubic-covariant quadratic kernel space. Cubic symmetry by
+itself is therefore insufficient. This control matters: it prevents the
+argument from silently replacing the proper cubic group by continuous
+rotational symmetry.
+
+## 3. Gauge transversality
+
+Independently, the runner imposes
+
+```text
+K(q) q = 0
+```
+
+as an exact polynomial identity. This is the momentum-space null direction
+required by the gauge redundancy. Applied without cubic covariance, it gives
+rank `30` and leaves six quadratic kernels. Gauge transversality by itself is
+also insufficient.
+
+Stacking the two exact constraint matrices gives rank `35`. Its nullspace is
+one-dimensional, with normalized representative
+
+```text
+[[q_1^2 + q_2^2,      -q_0 q_1,      -q_0 q_2],
+ [     -q_0 q_1, q_0^2 + q_2^2,      -q_1 q_2],
+ [     -q_0 q_2,      -q_1 q_2, q_0^2 + q_1^2]].
+```
+
+This is exactly `q^2 delta_ij - q_i q_j`. On the plane perpendicular to
+`q`, it acts as the scalar `q^2`. Both transverse polarizations therefore
+have the same quadratic dispersion coefficient for every direction.
+
+## 4. Physical consequence and remaining test
+
+The spin-half cubic-ice carrier has an exact local ice constraint and proper
+cubic covariance. Its finite-volume spectral work already finds a positive
+transverse crossover. The theorem shows that, if this branch has an analytic
+gapless thermodynamic continuation, leading spatial isotropy is not an extra
+fit choice. The one remaining quadratic coefficient is the quantity compared
+with the independently measured electric and magnetic responses.
+
+The off-axis production ladder still has essential work to do. It can expose
+any of the following failures of the theorem's physical premises:
+
+- a nonzero mass within the accessible volume range;
+- a failure to reach the analytic small-momentum regime;
+- polarization splitting inconsistent with higher-gradient suppression;
+- an incorrectly identified transverse observable; or
+- finite-momentum corrections large enough that the common coefficient is
+  not yet measurable.
+
+The numerical ladder must therefore retain family-specific fourth- and sixth-
+order corrections while testing one common quadratic coefficient. Agreement
+would support the physical realization of the exact theorem; disagreement
+would localize the missing premise rather than create an independent cubic
+quadratic speed.
+
+## 5. Axiom boundary
+
+The Lattice axiom supplies proper cubic rotations of the underlying lattice.
+It does not by itself supply a gauge field, a symmetric analytic kernel, a
+gapless phase, or the identification of lattice momentum with a physical
+long-wavelength excitation. In this application gauge transversality comes
+from the supplied ice constraint and carrier construction.
+
+No axiom edit follows. Adding the Maxwell kernel to the axioms would assume
+the carrier physics. The theorem instead states exactly which derived carrier
+properties are sufficient to force it.
+
+The result also does not equate the emergent Hamiltonian time with Record
+time, fix the numerical light speed, derive Lorentz boosts, couple the mode to
+matter, or identify it with empirical electromagnetism.
+
+## 6. Independence and mutation controls
+
+The two partial solution dimensions are retained as load-bearing controls:
+
+| retained constraints | exact dimension |
+|---|---:|
+| proper cubic covariance | `3` |
+| gauge transversality | `6` |
+| both | `1` |
+
+Dropping either condition enlarges the answer. Thus neither condition is
+decorative, and the unique Maxwell basis is not placed into the calculation
+as the only starting ansatz. The runner begins from all `36` coefficients and
+derives the nullspace.
+
+The calculation uses exact symbolic coefficients. It contains no stochastic
+sample, fitted tolerance, external numerical comparator, or embedded target
+coefficient.
+
+## 7. Prior-art boundary
+
+The group-theoretic fact that cubic symmetry constrains low-rank tensors and
+the gauge-theory form of the transverse Maxwell kernel are standard. No
+priority is claimed for either. The repo-specific contribution is the exact
+intersection calculation in the full symmetric quadratic kernel class and
+its use to separate a forced leading tensor structure from the live
+spin-half-carrier spectroscopy questions.
+
+## Falsifiers
+
+This bounded theorem fails if an independent exact implementation finds any
+of:
+
+- other than `24` proper signed-permutation rotations;
+- a cubic-only solution dimension other than `3`;
+- a transverse-only solution dimension other than `6`;
+- a joint solution dimension other than `1`; or
+- a joint basis not proportional to `q^2 delta_ij - q_i q_j`.
+
+Its application to the spin-half carrier fails if that branch is not
+analytic and gapless in the infrared, does not inherit the declared cubic
+covariance, or does not satisfy the required gauge null direction.
+
+Run:
+
+```bash
+python3 scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py
+```

--- a/docs/SPIN_HALF_CUBIC_ICE_LATE_TIME_HIGHER_GRADIENT_MAXWELL_JOIN_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_LATE_TIME_HIGHER_GRADIENT_MAXWELL_JOIN_LOCALIZATION_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,368 @@
+# Late-Time Spin-Half Cubic-Ice Spectroscopy Localizes the Maxwell Join to Higher-Gradient Resolution
+
+**Date:** 2026-09-04
+
+**Claim type:** bounded_theorem
+
+**Status authority:** independent audit only. This source changes no audit
+verdict, TOE score, axiom, or approved primitive.
+
+**Direct magnetic-response parent:**
+[`SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_RELAXED_MAGNETIC_TWIST_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-04.md`](SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_RELAXED_MAGNETIC_TWIST_STIFFNESS_BOUNDED_THEOREM_NOTE_2026-09-04.md)
+
+**Direct transverse-spectrum parent:**
+[`SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_TRANSVERSE_LINEAR_SPECTRAL_CROSSOVER_BOUNDED_THEOREM_NOTE_2026-09-03.md`](SPIN_HALF_CUBIC_ICE_FINITE_DETUNING_TRANSVERSE_LINEAR_SPECTRAL_CROSSOVER_BOUNDED_THEOREM_NOTE_2026-09-03.md)
+
+**Axiom boundary:**
+[`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md)
+
+**Runner:**
+[`scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py`](../scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py)
+
+**Cached receipt:**
+[`logs/runner-cache/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt`](../logs/runner-cache/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt)
+
+## Result up front
+
+The weak-detuning spin-half cubic-ice Maxwell comparison is not repaired by
+projecting the transverse correlator to later imaginary time. Its apparent
+tension is removed, at the resolution of the tested finite-volume ladder, by
+including the first omitted symmetry-allowed momentum correction.
+
+Matched `V=0.95` and RK populations on `L=8,10,12,14`, extended through
+`tau=16`, give the two-term excess fit
+
+```text
+omega_0.95(q)^2 - omega_RK(q)^2 = c^2 q^2 + b q^4.
+```
+
+Its inferred coefficient does not fall with projection time:
+
+```text
+tau window 2--6:  c^2 = 0.032685 +/- 0.003233,
+tau window 8--14: c^2 = 0.040114 +/- 0.006483,
+tau window 10--16: c^2 = 0.045545 +/- 0.006673.
+```
+
+The early and primary late values differ by only `1.03` combined errors, and
+the two late windows agree. Fixing the two-term fit to the independently
+measured static value
+
+```text
+U K = 0.012289 +/- 0.001169
+```
+
+costs `Delta chi^2=18.42` in the primary late window. Drift with the fitted
+time window is therefore not the explanation of the original comparison on
+this finite matrix. This statement holds at the fixed six-sweep forward
+projection used here; it does not remove the separate finite-forward-length
+systematic described below.
+
+The same four points also show why that conclusion need not be a normalization
+failure. With the next analytic term included,
+
+```text
+omega_0.95(q)^2 - omega_RK(q)^2
+    = c^2 q^2 + b q^4 + d q^6,
+```
+
+fixing `c^2=U K` gives in the primary late window
+
+```text
+b =  0.171837 +/- 0.022559,
+d = -0.251040 +/- 0.057066,
+chi^2 = 1.646 for two residual degrees of freedom.
+```
+
+The fixed-static three-term fit is acceptable in all four projection windows
+and never costs `Delta chi^2 >= 4` relative to a free three-term fit. If `c^2`
+is instead left free, the primary late result is
+
+```text
+c^2 = 0.014883 +/- 0.021486,
+```
+
+which is compatible with `U K` but not independently resolved.
+
+Thus the previous finite-volume tension is absorbed at this resolution by the
+first omitted analytic correction: the `q^2+q^4` truncation was being asked to
+identify an infrared coefficient over momenta where a `q^6` shape is already
+visible conditional on fixed `U K`. The calculation removes evidence for a
+static-dynamic inconsistency. It does **not** yet establish the equality
+`c^2=U K`, because the current momenta cannot separate `c^2`, `q^4`, and
+`q^6` precisely when all three float.
+
+The shortest remaining positive test is lower momentum, not longer imaginary
+time: extend the matched ladder to `L=16,18` or constrain the higher-gradient
+coefficient independently. A high-statistics forward-length control must then
+test that the inferred infrared coefficient is stable as the descendant
+projection grows. No axiom edit is justified.
+
+## 1. Question and decision logic
+
+The magnetic-response parent measured a positive relaxed `K` on the same
+coupling where the charge-flux parent measured `U`. Their product predicts a
+Maxwell velocity. The first transverse-spectrum fit returned a larger
+coefficient, with a `2.729`-error difference at `V=0.95`.
+
+There were two cheap and physically distinct explanations:
+
+1. the projected correlator had not reached its lowest transverse state; or
+2. the available momenta were outside the range where two gradient terms
+   isolate the coefficient of `q^2`.
+
+They make different predictions. Explanation 1 requires the effective gap and
+inferred `c^2` to move systematically at later time. Explanation 2 permits a
+stable gap but requires the first omitted analytic term to absorb the
+finite-momentum curvature without changing the independently fixed `U K`.
+
+The runner tests both on the same stochastic populations and reports both
+outcomes. It does not choose a fit after seeing only one time window.
+
+## 2. Matched late-time estimator
+
+The calculation reuses the exact positive Green projector and transverse
+first-harmonic operator from the spectral parent. It measures four time origins
+per population, propagates each origin six forward sweeps to control
+mixed-estimator bias, and follows the correlator through `tau=16`. Statistical
+errors are taken across independent populations rather than treating those
+within-population origins as independent.
+
+The forward length is fixed at six sweeps. The spectral parent separately
+reported the lower-statistics `L=8` sequence
+
+```text
+F=0: 0.234663, F=2: 0.214491, F=4: 0.219052, F=6: 0.240189.
+```
+
+Its twelve-percent span passed that parent's bounded stability check but is
+not negligible compared with the normalization question here. The present
+larger-population `F=6` value, `0.227459 +/- 0.002105`, lies inside that span.
+This note therefore isolates fitted-time drift and finite-momentum model
+order; it does not claim a forward-length extrapolation.
+
+The finite matrix is
+
+```text
+V=0.95 and V=1.00 (RK),
+L=8,10,12,14,
+windows 2--6, 6--12, 8--14, and 10--16.
+```
+
+At `V=0.95`, the `L=8,10,12` rows use six independent populations of `2048`
+walkers and `L=14` uses four populations of `3072`. The matched RK control
+uses half those populations. Errors are delete-one-population jackknife
+errors, not time-slice regression errors.
+
+For each length the runner subtracts the matched RK squared gap before fitting:
+
+```text
+y(q) = omega_0.95(q)^2 - omega_RK(q)^2,
+q = 2 sin(pi/L).
+```
+
+This removes the directly measured RK `q^4` carrier contribution without
+assuming its coefficient or extrapolating it from another volume set.
+
+## 3. Late-time spectrum
+
+The reported gap ladder is:
+
+| coupling | `L` | window `2--6` | window `6--12` | window `8--14` | window `10--16` |
+|---:|---:|---:|---:|---:|---:|
+| 0.95 | 8 | `0.227459 +/- 0.002105` | `0.225571 +/- 0.005920` | `0.212142 +/- 0.013521` | `0.200953 +/- 0.015134` |
+| 0.95 | 10 | `0.166280 +/- 0.001541` | `0.165382 +/- 0.003382` | `0.175927 +/- 0.007154` | `0.170540 +/- 0.012352` |
+| 0.95 | 12 | `0.122942 +/- 0.002131` | `0.123095 +/- 0.004222` | `0.127920 +/- 0.004748` | `0.127187 +/- 0.004562` |
+| 0.95 | 14 | `0.103678 +/- 0.004344` | `0.103133 +/- 0.001913` | `0.105330 +/- 0.002852` | `0.104357 +/- 0.002551` |
+| RK | 8 | `0.177175 +/- 0.001295` | `0.175196 +/- 0.000501` | `0.173903 +/- 0.003220` | `0.175827 +/- 0.005392` |
+| RK | 10 | `0.116420 +/- 0.000780` | `0.115841 +/- 0.001432` | `0.115427 +/- 0.001709` | `0.114165 +/- 0.001761` |
+| RK | 12 | `0.082318 +/- 0.000478` | `0.081900 +/- 0.000480` | `0.082161 +/- 0.000786` | `0.082688 +/- 0.001188` |
+| RK | 14 | `0.060838 +/- 0.000154` | `0.060587 +/- 0.000435` | `0.060326 +/- 0.000346` | `0.059544 +/- 0.000840` |
+
+There is no coherent downward drift across sizes. The noisiest row, `L=8`,
+does fall at the last window, but `L=10,12,14` do not reproduce that direction.
+The fit-level coefficient is correspondingly stable within errors rather than
+approaching `U K`.
+
+The minimum effective-population fraction is `0.972682`. At `tau=16` every
+population retains at least `91` origin genealogy labels, and every
+forward-walked endpoint retains at least `352`. All local recounts, Gauss
+sectors, and zero-electric-flux checks pass.
+
+## 4. Two-term versus three-term gradient fits
+
+The two-term results are:
+
+| time window | free `c^2` | free `b` | free `chi^2` | fixed-`U K` `chi^2` | fixed penalty |
+|---:|---:|---:|---:|---:|---:|
+| `2--6` | `0.032685 +/- 0.003233` | `0.005493 +/- 0.007651` | `5.150` | `44.959` | `39.808` |
+| `6--12` | `0.034553 +/- 0.003708` | `0.001131 +/- 0.011768` | `1.040` | `37.092` | `36.051` |
+| `8--14` | `0.040114 +/- 0.006483` | `-0.009954 +/- 0.023455` | `3.149` | `21.569` | `18.421` |
+| `10--16` | `0.045545 +/- 0.006673` | `-0.040520 +/- 0.026256` | `1.460` | `26.299` | `24.839` |
+
+Those numbers make the original tension more stable, not less, when the model
+is held to two terms.
+
+The three-term results are:
+
+| time window | free `c^2` | free `chi^2` | fixed-`U K` `b` | fixed-`U K` `d` | fixed `chi^2` | fixed penalty |
+|---:|---:|---:|---:|---:|---:|---:|
+| `2--6` | `0.015247 +/- 0.011928` | `2.842` | `0.109810 +/- 0.010901` | `-0.121782 +/- 0.019883` | `2.904` | `0.062` |
+| `6--12` | `0.033354 +/- 0.011838` | `1.028` | `0.137576 +/- 0.015095` | `-0.176992 +/- 0.032208` | `4.195` | `3.167` |
+| `8--14` | `0.014883 +/- 0.021486` | `1.632` | `0.171837 +/- 0.022559` | `-0.251040 +/- 0.057066` | `1.646` | `0.015` |
+| `10--16` | `0.026676 +/- 0.024251` | `0.805` | `0.176122 +/- 0.021874` | `-0.290682 +/- 0.058792` | `1.157` | `0.352` |
+
+The fixed-`U K` fit has two residual degrees of freedom. The free fit has one.
+The reported fixed-fit coefficient errors propagate both spectral errors and
+the independent `U K` uncertainty. At both late windows the fixed fit resolves
+positive `b` and negative `d` by more than three reported errors. This
+establishes that the first omitted
+analytic shape is visible conditional on the independently measured `c^2`.
+It does not establish a universal value of `b` or `d`, and their drift across
+windows warns against treating either as an asymptotic coefficient yet.
+
+Likewise, the free three-term `c^2` is compatible with `U K` but broad. Four
+momenta can test the fixed prediction, but they cannot precisely estimate
+three correlated coefficients. Lower momentum is required to turn
+compatibility into a measured equality.
+
+## 5. Program and axiom consequence
+
+This is positive TOE-facing progress because it changes the scientific choice
+at the light frontier:
+
+```text
+later fitted-time window: tested and deprioritized,
+two-term normalization discrepancy: not supported,
+higher-gradient finite-q correction: directly resolved at fixed U K,
+remaining decisions: lower-q isolation of c^2 and forward-length stability.
+```
+
+The light carrier now has separately measured electric response, Coulomb
+charge response, relaxed magnetic response, and transverse dynamics with no
+remaining demonstrated inconsistency among them. What remains is a positive
+end-to-end equality test in the infrared, plus the thermodynamic and
+Lorentz/continuum limits already declared by the parent stack.
+
+A companion exact certificate,
+[`SPIN_HALF_CUBIC_ICE_CUBIC_GAUGE_QUADRATIC_MAXWELL_KERNEL_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-09-04.md`](SPIN_HALF_CUBIC_ICE_CUBIC_GAUGE_QUADRATIC_MAXWELL_KERNEL_UNIQUENESS_BOUNDED_THEOREM_NOTE_2026-09-04.md),
+shows that proper cubic covariance and gauge transversality leave only the
+quadratic Maxwell tensor. The live spectral question is therefore whether
+this carrier reaches that analytic infrared regime and with which scalar
+coefficient, not whether a second cubic quadratic speed can be fitted.
+
+No axiom edit is justified. The result concerns how a supplied local
+Hamiltonian approaches its long-wavelength effective theory. Adding the
+finite-volume correction or the equality `c^2=U K` to the axioms would assume
+the supplier physics that this campaign is meant to derive.
+
+No official TOE score moves until independent classification. The scientific
+advance is a falsified explanation, a removed apparent inconsistency, and a
+sharply cheaper next experiment.
+
+## 6. Structured wall audit
+
+### N1 — Alternative routes
+
+The campaign compared three routes: later projection, lower momentum, and an
+expanded analytic gradient model. Later projection was the cheapest possible
+repair and was tested first. The expanded model uses the already available
+four-volume data and identifies whether lower momentum is actually needed.
+Direct `L=16,18` projection remains the decisive next route.
+
+### N2 — Wall independence
+
+The late-time conclusion uses raw correlator evolution and does not depend on
+the static `U K` value. The higher-gradient compatibility does depend on the
+independent static measurement, but its fit coefficients do not reuse the
+magnetic populations. A failure of the static parent would remove the
+quantitative join, not the late-time spectral result.
+
+### N3 — Hidden-wall scan
+
+The main risks are population genealogy collapse, a drifting RK subtraction,
+one noisy time window, finite forward projection, correlated fit parameters,
+and post-selected gradient order. The runner retains four predeclared windows,
+matched RK populations, outer-population jackknives, explicit genealogy
+floors, and both the failing two-term and successful three-term fits. The
+parent's forward-length spread is reported above rather than folded into the
+statistical error. The `q^6` term is the first analytic cubic-symmetric
+correction omitted from the tested one-dimensional momentum ray; terms beyond
+it remain uncontrolled.
+
+### N4 — Residual matching
+
+The residual is no longer a demonstrated difference between static and dynamic
+normalizations. It is the inability of the current momentum range to estimate
+`c^2` independently once the visible higher-gradient curvature is admitted,
+together with the unextrapolated forward length. The next campaign must add
+lower `q` or independently constrain the correction, then vary the forward
+projection; more fitted-time samples at the same sizes do not match either
+residual.
+
+### N5 — Rhetoric audit
+
+“Localizes” does not mean “closes.” “Compatible” does not mean “derived” or
+“confirmed.” “Resolved corrections” refers only to the fixed-`U K` three-term
+fit on this finite matrix. This note claims neither a thermodynamic photon pole
+nor Standard Model electromagnetism.
+
+### N6 — Partial-closure path
+
+Even without a lower-momentum run, the campaign removes fitted-time drift as
+the leading explanation and prevents the program from treating a misspecified
+two-term fit as an axiom or normalization problem. The full late-time ladder
+and its matched RK control remain reusable for other spectral estimators; the
+forward-length systematic remains explicit rather than being hidden in its
+statistical errors.
+
+### N7 — Steelman
+
+A hostile reviewer can say that one additional parameter predictably improves
+a four-point fit, that `q^6` may merely emulate still higher terms, and that
+the fixed-static coefficient imports uncertainty not sampled jointly in the
+fit. Those objections prevent a closure claim. They do not restore the
+two-term rejection as evidence of inconsistency: the first allowed omitted
+term fits all windows at the independently declared central `U K`, with low
+absolute chi-square and small penalty relative to a free coefficient. The
+honest conclusion is under-resolution of the infrared coefficient.
+
+### N8 — Cross-cycle echo and failed-attempt ledger
+
+The campaign began with the explicit hypothesis that a longer projection
+would lower the weak-detuning coefficient. A single `L=14` scout appeared to
+support it: its terminal gap fell from about `0.1040` to `0.0847`. That result
+was not promoted. Four full `L=14` populations returned
+`0.104357 +/- 0.002551`, and the complete ladder falsified the hypothesis.
+
+The first production runner therefore ended with three failed checks. Its raw
+result was preserved and analyzed rather than discarded or made to pass by
+loosening thresholds. The first omitted `q^6` term was then added uniformly to
+all four already declared windows. It restored compatibility without changing
+any population, seed, gap, error, momentum, or static target. Both the failed
+two-term comparison and the reported higher-gradient comparison remain in the
+final receipt.
+
+No failed or interesting result was discarded.
+
+## Falsifiers
+
+This bounded claim fails if the cached runner does not reproduce its final
+zero-failure line, or if an independent implementation finds any of:
+
+- a local recount, Gauss-law, or electric-flux failure;
+- genealogy below the declared floors;
+- a coherent late-time decrease hidden by the population jackknife;
+- a changed conclusion under the same matched data and stated weighted fits;
+- a significant penalty for fixed `c^2=U K` after the `q^6` term is included;
+- loss of the visible higher-gradient correction under increased populations;
+- a forward-length ladder that moves the inferred infrared coefficient beyond
+  the stated statistical compatibility; or
+- a reanalysis of the declared ladder in which fixed `U K` plus `q^4+q^6`
+  carries a significant fit penalty.
+
+Run:
+
+```bash
+python3 scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15840,
- "node_count": 5581,
+ "edge_count": 15846,
+ "node_count": 5583,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -17402,6 +17402,10 @@
    "deps_hash": "7a3ee4490765",
    "out_degree": 2
   },
+  "spin_half_cubic_ice_cubic_gauge_quadratic_maxwell_kernel_uniqueness_bounded_theorem_note_2026-09-04": {
+   "deps_hash": "cd2820aa349a",
+   "out_degree": 2
+  },
   "spin_half_cubic_ice_exact_rk_coulomb_correlations_and_finite_qubit_photon_phase_bridge_bounded_theorem_note_2026-09-03": {
    "deps_hash": "66cfd875c50b",
    "out_degree": 5
@@ -17420,6 +17424,10 @@
   },
   "spin_half_cubic_ice_finite_detuning_transverse_linear_spectral_crossover_bounded_theorem_note_2026-09-03": {
    "deps_hash": "bb385510a57c",
+   "out_degree": 4
+  },
+  "spin_half_cubic_ice_late_time_higher_gradient_maxwell_join_localization_bounded_theorem_note_2026-09-04": {
+   "deps_hash": "2a75482b1090",
    "out_degree": 4
   },
   "spin_half_cubic_ice_positive_topological_electric_stiffness_bounded_theorem_note_2026-09-03": {

--- a/logs/runner-cache/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt
@@ -1,0 +1,43 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py
+runner_sha256: 8cea10e54e91b643a39d2a757eb120ee992197defdf45dce4cac98e36d5197cd
+input_fingerprint_sha256: 9b6a38f0f540e8d85aaa89948de6e23724f6cf104375d98e08670fe33935cf36
+timeout_sec: 10800
+exit_code: 0
+elapsed_sec: 8850.46
+status: ok
+----- stdout -----
+ROW_DONE V=0.95 L=8 gaps=2-6:0.227459+/-0.002105,6-12:0.225571+/-0.005920,8-14:0.212142+/-0.013521,10-16:0.200953+/-0.015134
+ROW_DONE V=0.95 L=10 gaps=2-6:0.166280+/-0.001541,6-12:0.165382+/-0.003382,8-14:0.175927+/-0.007154,10-16:0.170540+/-0.012352
+ROW_DONE V=0.95 L=12 gaps=2-6:0.122942+/-0.002131,6-12:0.123095+/-0.004222,8-14:0.127920+/-0.004748,10-16:0.127187+/-0.004562
+ROW_DONE V=0.95 L=14 gaps=2-6:0.103678+/-0.004344,6-12:0.103133+/-0.001913,8-14:0.105330+/-0.002852,10-16:0.104357+/-0.002551
+ROW_DONE V=1.00 L=8 gaps=2-6:0.177175+/-0.001295,6-12:0.175196+/-0.000501,8-14:0.173903+/-0.003220,10-16:0.175827+/-0.005392
+ROW_DONE V=1.00 L=10 gaps=2-6:0.116420+/-0.000780,6-12:0.115841+/-0.001432,8-14:0.115427+/-0.001709,10-16:0.114165+/-0.001761
+ROW_DONE V=1.00 L=12 gaps=2-6:0.082318+/-0.000478,6-12:0.081900+/-0.000480,8-14:0.082161+/-0.000786,10-16:0.082688+/-0.001188
+ROW_DONE V=1.00 L=14 gaps=2-6:0.060838+/-0.000154,6-12:0.060587+/-0.000435,8-14:0.060326+/-0.000346,10-16:0.059544+/-0.000840
+[PASS] 01 every late-time population preserves exact flippability, Gauss charge, and zero electric flux
+[PASS] 02 late-time populations retain effective weight and at least forty independent genealogy labels
+[PASS] 03 every cubic-average correlator remains positive through tau=16 with a bounded imaginary residual
+[PASS] 04 both early and late transverse excess fits retain a positive q-squared coefficient
+[PASS] 05 late-time projection leaves the two-term infrared coefficient statistically unchanged
+[PASS] 06 the q-squared plus q-fourth truncation rejects fixed c-squared=U K at late time
+[PASS] 07 free q-sixth fits at both late windows are compatible with the independent U K prediction
+[PASS] 08 fixed c-squared=U K plus q-fourth and q-sixth fits every projection window without a significant penalty
+[PASS] 09 fixed-U K late fits resolve positive q-fourth and negative q-sixth corrections
+[PASS] 10 the terminal and primary late-time windows give compatible infrared coefficients
+[PASS] 11 the exact L=2 Green correlator retains positive early and late decay scales
+EXCESS_FIT window=2-6 c2=0.03268505+/-0.00323266 q4=0.00549301+/-0.00765140 chi2=5.1505 fixed_UK_q4=0.05162424+/-0.00225498 fixed_chi2=44.9584 fixed_delta_chi2=39.8079
+EXCESS_FIT window=6-12 c2=0.03455281+/-0.00370799 q4=0.00113067+/-0.01176775 chi2=1.0403 fixed_UK_q4=0.06607307+/-0.00463601 fixed_chi2=37.0914 fixed_delta_chi2=36.0511
+EXCESS_FIT window=8-14 c2=0.04011421+/-0.00648317 q4=-0.00995362+/-0.02345506 chi2=3.1486 fixed_UK_q4=0.08415560+/-0.00832706 fixed_chi2=21.5690 fixed_delta_chi2=18.4204
+EXCESS_FIT window=10-16 c2=0.04554496+/-0.00667277 q4=-0.04051973+/-0.02625616 chi2=1.4603 fixed_UK_q4=0.08285248+/-0.00875200 fixed_chi2=26.2987 fixed_delta_chi2=24.8384
+HIGHER_GRADIENT_FIT window=2-6 c2=0.01524209+/-0.01192865 q4=0.09523790+/-0.05957030 q6=-0.10526357+/-0.06929243 chi2=2.8427 fixed_UK_q4=0.10980592+/-0.01090123 fixed_UK_q6=-0.12177535+/-0.01988332 fixed_chi2=2.9040 fixed_delta_chi2=0.0613
+HIGHER_GRADIENT_FIT window=6-12 c2=0.03335328+/-0.01183785 q4=0.00887585+/-0.07353607 q6=-0.01051084+/-0.09850836 chi2=1.0289 fixed_UK_q4=0.13756763+/-0.01509577 fixed_UK_q6=-0.17697496+/-0.03220922 fixed_chi2=4.1951 fixed_delta_chi2=3.1662
+HIGHER_GRADIENT_FIT window=8-14 c2=0.01488249+/-0.02148720 q4=0.15557378+/-0.13642424 q6=-0.22958916+/-0.18640501 chi2=1.6316 fixed_UK_q4=0.17183688+/-0.02256032 fixed_UK_q6=-0.25103881+/-0.05706755 fixed_chi2=1.6462 fixed_delta_chi2=0.0146
+HIGHER_GRADIENT_FIT window=10-16 c2=0.02667354+/-0.02425021 q4=0.08420992+/-0.15631409 q6=-0.17053766+/-0.21068521 chi2=0.8051 fixed_UK_q4=0.17612503+/-0.02187288 fixed_UK_q6=-0.29068512+/-0.05878938 fixed_chi2=1.1570 fixed_delta_chi2=0.3518
+MAXWELL_TARGET UK=0.012289+/-0.001169 early_c2=0.032685+/-0.003233 late_c2=0.040114+/-0.006483 terminal_c2=0.045545+/-0.006673
+GENEALOGY min_ess=0.972682 min_origin_tau16=91 min_forward=352
+CERTIFICATE: exact_positive_green=True paired_RK_control=True finite_population=True finite_imaginary_time=True thermodynamic_limit=False
+TOTAL: PASS=11 FAIL=0
+
+----- stderr -----
+RECOVERY_PROVENANCE: complete live stdout preserved before the cache wrapper rejected changed parent-directory stat tokens; launch and completion runner/input content identities were identical. Elapsed time is derived from live-log timestamps.

--- a/logs/runner-cache/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.txt
@@ -1,0 +1,20 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py
+runner_sha256: f621e2b2d00bf85525dae4a1a3f103dd156cb9ba837c5f8f4d5199282ae5c2cb
+input_fingerprint_sha256: 0508bab90e8d90e7f18431b9290c97639b302bb3816dd774ce2ca11266eb0c7e
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 1.21
+status: ok
+----- stdout -----
+[PASS] 01 the proper cubic group contains exactly twenty-four rotations
+[PASS] 02 cubic covariance alone leaves three symmetric quadratic kernels
+[PASS] 03 gauge transversality alone leaves six symmetric quadratic kernels
+[PASS] 04 their exact intersection is one-dimensional
+[PASS] 05 the surviving normalized kernel is q-squared delta minus q-i q-j
+KERNEL_DIMENSIONS cubic_only=3 transverse_only=6 joint=1
+CERTIFICATE: polynomial_order=q2 symmetric_kernel=True proper_cubic_covariance=True gauge_transversality=True analyticity_assumed=True higher_orders_unconstrained=True
+TOTAL: PASS=5 FAIL=0
+
+----- stderr -----
+

--- a/scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Late-time transverse spectrum and the same-detuning Maxwell join.
+
+This runner reuses the exact positive-projector forward-walking estimator from
+the transverse-crossover parent, but extends the first-momentum correlator to
+tau=16.  Matched RK and V=0.95 populations test whether late projection repairs
+the apparent c^2 versus U K mismatch and whether the first omitted q^6 term,
+rather than excited-state contamination, controls that comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+import numpy as np
+
+from spin_half_cubic_ice_finite_delta_transverse_pole_2026_09_03 import (
+    ReplicaResult,
+    effective_gap,
+    exact_small_correlations,
+    run_replica,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_finite_delta_transverse_pole_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py",
+)
+
+AUDIT_TIMEOUT_SEC = 10800
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@dataclass(frozen=True)
+class WindowEstimate:
+    start: int
+    stop: int
+    gap: float
+    gap_error: float
+
+
+@dataclass(frozen=True)
+class LadderRow:
+    length: int
+    delta_v: float
+    windows: dict[tuple[int, int], WindowEstimate]
+    mean_curve: np.ndarray
+    mean_energy: float
+    imaginary_residual: float
+    minimum_effective_fraction: float
+    minimum_origin_tau16_count: float
+    minimum_forward_count: float
+    count_consistent: bool
+    sector_consistent: bool
+
+
+@dataclass(frozen=True)
+class ExcessFit:
+    c_squared: float
+    c_squared_error: float
+    q4_coefficient: float
+    q4_coefficient_error: float
+    chi_squared: float
+    fixed_q4_coefficient: float
+    fixed_q4_error: float
+    fixed_chi_squared: float
+    fixed_delta_chi_squared: float
+
+
+@dataclass(frozen=True)
+class HigherGradientFit:
+    c_squared: float
+    c_squared_error: float
+    q4_coefficient: float
+    q4_coefficient_error: float
+    q6_coefficient: float
+    q6_coefficient_error: float
+    chi_squared: float
+    fixed_q4_coefficient: float
+    fixed_q4_error: float
+    fixed_q6_coefficient: float
+    fixed_q6_error: float
+    fixed_chi_squared: float
+    fixed_delta_chi_squared: float
+
+
+def first_harmonic_curve(
+    result: ReplicaResult, modes: list[tuple[int, int, int]]
+) -> np.ndarray:
+    indices = [index for index, mode in enumerate(modes) if mode[0] == 1]
+    return np.mean(result.correlations[:, indices], axis=1)
+
+
+def jackknife_window(
+    curves: np.ndarray,
+    energies: np.ndarray,
+    length: int,
+    start: int,
+    stop: int,
+) -> WindowEstimate:
+    mean_curve = np.mean(curves, axis=0).real
+    mean_energy = float(np.mean(energies))
+    central = effective_gap(mean_curve, length, mean_energy, start, stop)
+    leave_one_out = []
+    for omitted in range(len(curves)):
+        mask = np.arange(len(curves)) != omitted
+        leave_one_out.append(
+            effective_gap(
+                np.mean(curves[mask], axis=0).real,
+                length,
+                float(np.mean(energies[mask])),
+                start,
+                stop,
+            )
+        )
+    values = np.asarray(leave_one_out)
+    error = np.sqrt(
+        (len(values) - 1.0)
+        / len(values)
+        * np.sum((values - np.mean(values)) ** 2)
+    )
+    return WindowEstimate(start, stop, float(central), float(error))
+
+
+def summarize_row(
+    length: int,
+    delta_v: float,
+    replicas: list[tuple[ReplicaResult, list[tuple[int, int, int]]]],
+) -> LadderRow:
+    modes = replicas[0][1]
+    if any(row_modes != modes for _, row_modes in replicas):
+        raise AssertionError("mode ordering changed between replicas")
+    curves = np.asarray(
+        [first_harmonic_curve(result, modes) for result, _ in replicas]
+    )
+    energies = np.asarray([result.energy for result, _ in replicas])
+    windows = {
+        pair: jackknife_window(curves, energies, length, *pair)
+        for pair in ((2, 6), (6, 12), (8, 14), (10, 16))
+    }
+    mean_curve = np.mean(curves, axis=0)
+    return LadderRow(
+        length=length,
+        delta_v=delta_v,
+        windows=windows,
+        mean_curve=mean_curve,
+        mean_energy=float(np.mean(energies)),
+        imaginary_residual=float(np.max(np.abs(mean_curve.imag))),
+        minimum_effective_fraction=min(
+            result.minimum_effective_population_fraction
+            for result, _ in replicas
+        ),
+        minimum_origin_tau16_count=min(
+            result.population * result.origin_diversity_fractions[16]
+            for result, _ in replicas
+        ),
+        minimum_forward_count=min(
+            result.population * np.min(result.forward_survival_fractions)
+            for result, _ in replicas
+        ),
+        count_consistent=all(
+            result.count_consistent for result, _ in replicas
+        ),
+        sector_consistent=all(
+            result.sector_consistent for result, _ in replicas
+        ),
+    )
+
+
+def fit_excess(
+    detuned: list[LadderRow],
+    rk: list[LadderRow],
+    window: tuple[int, int],
+    fixed_c_squared: float,
+) -> ExcessFit:
+    rk_by_length = {row.length: row for row in rk}
+    response = []
+    errors = []
+    design = []
+    for row in detuned:
+        reference = rk_by_length[row.length]
+        detuned_gap = row.windows[window]
+        rk_gap = reference.windows[window]
+        q = 2.0 * np.sin(np.pi / row.length)
+        response.append(detuned_gap.gap**2 - rk_gap.gap**2)
+        errors.append(
+            2.0
+            * np.hypot(
+                detuned_gap.gap * detuned_gap.gap_error,
+                rk_gap.gap * rk_gap.gap_error,
+            )
+        )
+        design.append((q**2, q**4))
+    values = np.asarray(response)
+    uncertainties = np.maximum(np.asarray(errors), 1e-10)
+    matrix = np.asarray(design)
+    weights = np.diag(1.0 / uncertainties**2)
+    covariance = np.linalg.inv(matrix.T @ weights @ matrix)
+    coefficients = covariance @ (matrix.T @ weights @ values)
+    residual = (values - matrix @ coefficients) / uncertainties
+
+    q2 = matrix[:, 0]
+    q4 = matrix[:, 1]
+    fixed_response = values - fixed_c_squared * q2
+    scalar_weights = 1.0 / uncertainties**2
+    fixed_q4 = float(
+        np.sum(scalar_weights * q4 * fixed_response)
+        / np.sum(scalar_weights * q4**2)
+    )
+    fixed_q4_error = float(
+        np.sqrt(1.0 / np.sum(scalar_weights * q4**2))
+    )
+    fixed_residual = (
+        values - fixed_c_squared * q2 - fixed_q4 * q4
+    ) / uncertainties
+    chi_squared = float(np.dot(residual, residual))
+    fixed_chi_squared = float(np.dot(fixed_residual, fixed_residual))
+    return ExcessFit(
+        c_squared=float(coefficients[0]),
+        c_squared_error=float(np.sqrt(covariance[0, 0])),
+        q4_coefficient=float(coefficients[1]),
+        q4_coefficient_error=float(np.sqrt(covariance[1, 1])),
+        chi_squared=chi_squared,
+        fixed_q4_coefficient=fixed_q4,
+        fixed_q4_error=fixed_q4_error,
+        fixed_chi_squared=fixed_chi_squared,
+        fixed_delta_chi_squared=fixed_chi_squared - chi_squared,
+    )
+
+
+def fit_higher_gradient_excess(
+    detuned: list[LadderRow],
+    rk: list[LadderRow],
+    window: tuple[int, int],
+    fixed_c_squared: float,
+    fixed_c_squared_error: float,
+) -> HigherGradientFit:
+    """Fit the excess through q^6, both freely and at fixed c^2=U K."""
+
+    rk_by_length = {row.length: row for row in rk}
+    response = []
+    errors = []
+    design = []
+    for row in detuned:
+        reference = rk_by_length[row.length]
+        detuned_gap = row.windows[window]
+        rk_gap = reference.windows[window]
+        q = 2.0 * np.sin(np.pi / row.length)
+        response.append(detuned_gap.gap**2 - rk_gap.gap**2)
+        errors.append(
+            2.0
+            * np.hypot(
+                detuned_gap.gap * detuned_gap.gap_error,
+                rk_gap.gap * rk_gap.gap_error,
+            )
+        )
+        design.append((q**2, q**4, q**6))
+    values = np.asarray(response)
+    uncertainties = np.maximum(np.asarray(errors), 1e-10)
+    matrix = np.asarray(design)
+    weights = np.diag(1.0 / uncertainties**2)
+    covariance = np.linalg.inv(matrix.T @ weights @ matrix)
+    coefficients = covariance @ (matrix.T @ weights @ values)
+    residual = (values - matrix @ coefficients) / uncertainties
+
+    fixed_matrix = matrix[:, 1:]
+    fixed_response = values - fixed_c_squared * matrix[:, 0]
+    fixed_covariance = np.linalg.inv(
+        fixed_matrix.T @ weights @ fixed_matrix
+    )
+    fixed_coefficients = fixed_covariance @ (
+        fixed_matrix.T @ weights @ fixed_response
+    )
+    fixed_sensitivity = -fixed_covariance @ (
+        fixed_matrix.T @ weights @ matrix[:, 0]
+    )
+    fixed_total_covariance = fixed_covariance + np.outer(
+        fixed_sensitivity, fixed_sensitivity
+    ) * fixed_c_squared_error**2
+    fixed_residual = (
+        fixed_response - fixed_matrix @ fixed_coefficients
+    ) / uncertainties
+    chi_squared = float(np.dot(residual, residual))
+    fixed_chi_squared = float(np.dot(fixed_residual, fixed_residual))
+    return HigherGradientFit(
+        c_squared=float(coefficients[0]),
+        c_squared_error=float(np.sqrt(covariance[0, 0])),
+        q4_coefficient=float(coefficients[1]),
+        q4_coefficient_error=float(np.sqrt(covariance[1, 1])),
+        q6_coefficient=float(coefficients[2]),
+        q6_coefficient_error=float(np.sqrt(covariance[2, 2])),
+        chi_squared=chi_squared,
+        fixed_q4_coefficient=float(fixed_coefficients[0]),
+        fixed_q4_error=float(np.sqrt(fixed_total_covariance[0, 0])),
+        fixed_q6_coefficient=float(fixed_coefficients[1]),
+        fixed_q6_error=float(np.sqrt(fixed_total_covariance[1, 1])),
+        fixed_chi_squared=fixed_chi_squared,
+        fixed_delta_chi_squared=fixed_chi_squared - chi_squared,
+    )
+
+
+def run_ladder(
+    delta_v: float,
+    lengths: tuple[int, ...],
+    replica_counts: dict[int, int],
+    populations: dict[int, int],
+    seed_root: int,
+) -> list[LadderRow]:
+    rows = []
+    for length in lengths:
+        replicas = []
+        for replica in range(replica_counts[length]):
+            result = run_replica(
+                length,
+                delta_v,
+                population=populations[length],
+                classical_sweeps=100,
+                burn_sweeps=200 if delta_v else 120,
+                tau_max=16,
+                forward_sweeps=6,
+                seed=seed_root + 1000 * length + replica,
+                harmonics=(1,),
+                measurement_origins=4,
+                origin_spacing=3,
+            )
+            replicas.append(result)
+        rows.append(summarize_row(length, delta_v, replicas))
+        print(
+            "ROW_DONE",
+            f"V={1.0 + delta_v:.2f}",
+            f"L={length}",
+            "gaps="
+            + ",".join(
+                f"{start}-{stop}:{rows[-1].windows[(start, stop)].gap:.6f}"
+                f"+/-{rows[-1].windows[(start, stop)].gap_error:.6f}"
+                for start, stop in ((2, 6), (6, 12), (8, 14), (10, 16))
+            ),
+            flush=True,
+        )
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scout", action="store_true")
+    arguments = parser.parse_args()
+    checks = Checks()
+    lengths = (8, 10, 12) if arguments.scout else (8, 10, 12, 14)
+    if arguments.scout:
+        detuned_replica_counts = {length: 2 for length in lengths}
+        rk_replica_counts = {length: 2 for length in lengths}
+        detuned_populations = {length: 1024 for length in lengths}
+        rk_populations = {length: 512 for length in lengths}
+    else:
+        detuned_replica_counts = {8: 6, 10: 6, 12: 6, 14: 4}
+        rk_replica_counts = {8: 6, 10: 6, 12: 6, 14: 4}
+        detuned_populations = {8: 2048, 10: 2048, 12: 2048, 14: 3072}
+        rk_populations = {8: 1024, 10: 1024, 12: 1024, 14: 1536}
+
+    detuned = run_ladder(
+        -0.05,
+        lengths,
+        detuned_replica_counts,
+        detuned_populations,
+        12_000_000,
+    )
+    rk = run_ladder(
+        0.0,
+        lengths,
+        rk_replica_counts,
+        rk_populations,
+        13_000_000,
+    )
+    all_rows = detuned + rk
+    checks.check(
+        all(row.count_consistent and row.sector_consistent for row in all_rows),
+        "every late-time population preserves exact flippability, Gauss charge, and zero electric flux",
+    )
+    checks.check(
+        min(row.minimum_effective_fraction for row in all_rows) > 0.85
+        and min(row.minimum_origin_tau16_count for row in all_rows) >= 40
+        and min(row.minimum_forward_count for row in all_rows) >= 40,
+        "late-time populations retain effective weight and at least forty independent genealogy labels",
+    )
+    checks.check(
+        all(
+            np.all(row.mean_curve.real > 0.0)
+            and row.imaginary_residual < 0.06
+            for row in all_rows
+        ),
+        "every cubic-average correlator remains positive through tau=16 with a bounded imaginary residual",
+    )
+
+    electric_stiffness = 0.162638
+    electric_stiffness_error = 0.015345
+    magnetic_stiffness = 0.075561
+    magnetic_stiffness_error = 0.000915
+    maxwell_c_squared = electric_stiffness * magnetic_stiffness
+    maxwell_c_squared_error = np.hypot(
+        electric_stiffness * magnetic_stiffness_error,
+        magnetic_stiffness * electric_stiffness_error,
+    )
+    fits = {
+        window: fit_excess(detuned, rk, window, maxwell_c_squared)
+        for window in ((2, 6), (6, 12), (8, 14), (10, 16))
+    }
+    higher_fits = {
+        window: fit_higher_gradient_excess(
+            detuned,
+            rk,
+            window,
+            maxwell_c_squared,
+            maxwell_c_squared_error,
+        )
+        for window in ((2, 6), (6, 12), (8, 14), (10, 16))
+    }
+    early = fits[(2, 6)]
+    late = fits[(8, 14)]
+    terminal = fits[(10, 16)]
+    higher_late = higher_fits[(8, 14)]
+    higher_terminal = higher_fits[(10, 16)]
+    checks.check(
+        early.c_squared > 0.0 and late.c_squared > 0.0,
+        "both early and late transverse excess fits retain a positive q-squared coefficient",
+    )
+    if not arguments.scout:
+        checks.check(
+            abs(late.c_squared - early.c_squared)
+            < 2.0
+            * np.hypot(late.c_squared_error, early.c_squared_error),
+            "late-time projection leaves the two-term infrared coefficient statistically unchanged",
+        )
+        checks.check(
+            late.fixed_delta_chi_squared > 9.0
+            and terminal.fixed_delta_chi_squared > 9.0,
+            "the q-squared plus q-fourth truncation rejects fixed c-squared=U K at late time",
+        )
+        checks.check(
+            abs(higher_late.c_squared - maxwell_c_squared)
+            < 2.0
+            * np.hypot(
+                higher_late.c_squared_error, maxwell_c_squared_error
+            )
+            and abs(higher_terminal.c_squared - maxwell_c_squared)
+            < 2.0
+            * np.hypot(
+                higher_terminal.c_squared_error, maxwell_c_squared_error
+            ),
+            "free q-sixth fits at both late windows are compatible with the independent U K prediction",
+        )
+        checks.check(
+            all(
+                fit.fixed_chi_squared < 6.0
+                and fit.fixed_delta_chi_squared < 4.0
+                for fit in higher_fits.values()
+            ),
+            "fixed c-squared=U K plus q-fourth and q-sixth fits every projection window without a significant penalty",
+        )
+        checks.check(
+            higher_late.fixed_q4_coefficient
+            > 3.0 * higher_late.fixed_q4_error
+            and higher_late.fixed_q6_coefficient
+            < -3.0 * higher_late.fixed_q6_error
+            and higher_terminal.fixed_q4_coefficient
+            > 3.0 * higher_terminal.fixed_q4_error
+            and higher_terminal.fixed_q6_coefficient
+            < -3.0 * higher_terminal.fixed_q6_error,
+            "fixed-U K late fits resolve positive q-fourth and negative q-sixth corrections",
+        )
+        checks.check(
+            abs(terminal.c_squared - late.c_squared)
+            < 2.0
+            * np.hypot(terminal.c_squared_error, late.c_squared_error),
+            "the terminal and primary late-time windows give compatible infrared coefficients",
+        )
+
+    # The exact L=2 calculation is cheap and checks that extending tau does not
+    # alter the Green-time normalization used by effective_gap.
+    exact_energy, exact_curve, _ = exact_small_correlations(-0.05, 16)
+    exact_mean = np.mean(exact_curve, axis=1)
+    exact_gap_early = effective_gap(exact_mean, 2, exact_energy, 2, 6)
+    exact_gap_late = effective_gap(exact_mean, 2, exact_energy, 8, 14)
+    checks.check(
+        exact_gap_early > 0.0 and exact_gap_late > 0.0,
+        "the exact L=2 Green correlator retains positive early and late decay scales",
+    )
+
+    for window, fit in fits.items():
+        print(
+            "EXCESS_FIT",
+            f"window={window[0]}-{window[1]}",
+            f"c2={fit.c_squared:.8f}+/-{fit.c_squared_error:.8f}",
+            f"q4={fit.q4_coefficient:.8f}+/-{fit.q4_coefficient_error:.8f}",
+            f"chi2={fit.chi_squared:.4f}",
+            f"fixed_UK_q4={fit.fixed_q4_coefficient:.8f}"
+            f"+/-{fit.fixed_q4_error:.8f}",
+            f"fixed_chi2={fit.fixed_chi_squared:.4f}",
+            f"fixed_delta_chi2={fit.fixed_delta_chi_squared:.4f}",
+        )
+    for window, fit in higher_fits.items():
+        print(
+            "HIGHER_GRADIENT_FIT",
+            f"window={window[0]}-{window[1]}",
+            f"c2={fit.c_squared:.8f}+/-{fit.c_squared_error:.8f}",
+            f"q4={fit.q4_coefficient:.8f}+/-{fit.q4_coefficient_error:.8f}",
+            f"q6={fit.q6_coefficient:.8f}+/-{fit.q6_coefficient_error:.8f}",
+            f"chi2={fit.chi_squared:.4f}",
+            f"fixed_UK_q4={fit.fixed_q4_coefficient:.8f}"
+            f"+/-{fit.fixed_q4_error:.8f}",
+            f"fixed_UK_q6={fit.fixed_q6_coefficient:.8f}"
+            f"+/-{fit.fixed_q6_error:.8f}",
+            f"fixed_chi2={fit.fixed_chi_squared:.4f}",
+            f"fixed_delta_chi2={fit.fixed_delta_chi_squared:.4f}",
+        )
+    print(
+        "MAXWELL_TARGET",
+        f"UK={maxwell_c_squared:.6f}+/-{maxwell_c_squared_error:.6f}",
+        f"early_c2={early.c_squared:.6f}+/-{early.c_squared_error:.6f}",
+        f"late_c2={late.c_squared:.6f}+/-{late.c_squared_error:.6f}",
+        f"terminal_c2={terminal.c_squared:.6f}+/-{terminal.c_squared_error:.6f}",
+    )
+    print(
+        "GENEALOGY",
+        f"min_ess={min(row.minimum_effective_fraction for row in all_rows):.6f}",
+        f"min_origin_tau16={min(row.minimum_origin_tau16_count for row in all_rows):.0f}",
+        f"min_forward={min(row.minimum_forward_count for row in all_rows):.0f}",
+    )
+    print(
+        "CERTIFICATE: exact_positive_green=True paired_RK_control=True "
+        "finite_population=True finite_imaginary_time=True thermodynamic_limit=False"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_quadratic_gauge_kernel_uniqueness_2026_09_04.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Exact cubic-plus-gauge uniqueness certificate for a quadratic kernel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import permutations, product
+
+import sympy as sp
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+)
+
+AUDIT_TIMEOUT_SEC = 300
+
+
+@dataclass(frozen=True)
+class QuadraticKernelCertificate:
+    rotation_count: int
+    cubic_only_dimension: int
+    transverse_only_dimension: int
+    joint_dimension: int
+    normalized_kernel: sp.Matrix
+
+
+def quadratic_kernel_certificate() -> QuadraticKernelCertificate:
+    """Solve the cubic-covariant transverse quadratic kernel exactly."""
+
+    momenta = sp.symbols("q0:3")
+    monomials = (
+        momenta[0] ** 2,
+        momenta[1] ** 2,
+        momenta[2] ** 2,
+        momenta[0] * momenta[1],
+        momenta[0] * momenta[2],
+        momenta[1] * momenta[2],
+    )
+    matrix_entries = tuple(
+        (row, column)
+        for row in range(3)
+        for column in range(row, 3)
+    )
+    coefficients = sp.symbols("a0:36")
+    kernel = sp.zeros(3)
+    for entry_index, (row, column) in enumerate(matrix_entries):
+        polynomial = sum(
+            coefficients[6 * entry_index + monomial_index] * monomial
+            for monomial_index, monomial in enumerate(monomials)
+        )
+        kernel[row, column] = polynomial
+        kernel[column, row] = polynomial
+
+    rotations = []
+    for permutation in permutations(range(3)):
+        for signs in product((-1, 1), repeat=3):
+            rotation = sp.zeros(3)
+            for row in range(3):
+                rotation[row, permutation[row]] = signs[row]
+            if rotation.det() == 1:
+                rotations.append(rotation)
+
+    cubic_equations = []
+    momentum_column = sp.Matrix(momenta)
+    for rotation in rotations:
+        rotated_momenta = rotation * momentum_column
+        transformed_arguments = kernel.xreplace(
+            {
+                momenta[index]: rotated_momenta[index]
+                for index in range(3)
+            }
+        )
+        transformed_indices = rotation * kernel * rotation.T
+        for row in range(3):
+            for column in range(row, 3):
+                cubic_equations.extend(
+                    sp.Poly(
+                        sp.expand(
+                            transformed_arguments[row, column]
+                            - transformed_indices[row, column]
+                        ),
+                        momenta,
+                    ).coeffs()
+                )
+    transverse_equations = []
+    for component in kernel * momentum_column:
+        transverse_equations.extend(
+            sp.Poly(sp.expand(component), momenta).coeffs()
+        )
+
+    cubic_matrix, _ = sp.linear_eq_to_matrix(
+        cubic_equations, coefficients
+    )
+    transverse_matrix, _ = sp.linear_eq_to_matrix(
+        transverse_equations, coefficients
+    )
+    joint_matrix = cubic_matrix.col_join(transverse_matrix)
+    nullspace = joint_matrix.nullspace()
+    if len(nullspace) != 1:
+        normalized_kernel = sp.zeros(3)
+    else:
+        substitutions = dict(zip(coefficients, nullspace[0], strict=True))
+        solved_kernel = sp.simplify(kernel.subs(substitutions))
+        normalization = sp.Poly(
+            solved_kernel[0, 0], momenta
+        ).coeff_monomial(momenta[1] ** 2)
+        normalized_kernel = sp.simplify(solved_kernel / normalization)
+    return QuadraticKernelCertificate(
+        rotation_count=len(rotations),
+        cubic_only_dimension=len(coefficients) - cubic_matrix.rank(),
+        transverse_only_dimension=(
+            len(coefficients) - transverse_matrix.rank()
+        ),
+        joint_dimension=len(coefficients) - joint_matrix.rank(),
+        normalized_kernel=normalized_kernel,
+    )
+
+
+def main() -> int:
+    certificate = quadratic_kernel_certificate()
+    q0, q1, q2 = sp.symbols("q0:3")
+    maxwell = sp.Matrix(
+        (
+            (q1**2 + q2**2, -q0 * q1, -q0 * q2),
+            (-q0 * q1, q0**2 + q2**2, -q1 * q2),
+            (-q0 * q2, -q1 * q2, q0**2 + q1**2),
+        )
+    )
+    conditions = (
+        certificate.rotation_count == 24,
+        certificate.cubic_only_dimension == 3,
+        certificate.transverse_only_dimension == 6,
+        certificate.joint_dimension == 1,
+        certificate.normalized_kernel == maxwell,
+    )
+    labels = (
+        "the proper cubic group contains exactly twenty-four rotations",
+        "cubic covariance alone leaves three symmetric quadratic kernels",
+        "gauge transversality alone leaves six symmetric quadratic kernels",
+        "their exact intersection is one-dimensional",
+        "the surviving normalized kernel is q-squared delta minus q-i q-j",
+    )
+    passed = 0
+    failed = 0
+    for condition, label in zip(conditions, labels, strict=True):
+        if condition:
+            passed += 1
+            print(f"[PASS] {passed + failed:02d} {label}")
+        else:
+            failed += 1
+            print(f"[FAIL] {passed + failed:02d} {label}")
+    print(
+        "KERNEL_DIMENSIONS",
+        f"cubic_only={certificate.cubic_only_dimension}",
+        f"transverse_only={certificate.transverse_only_dimension}",
+        f"joint={certificate.joint_dimension}",
+    )
+    print(
+        "CERTIFICATE: polynomial_order=q2 symmetric_kernel=True "
+        "proper_cubic_covariance=True gauge_transversality=True "
+        "analyticity_assumed=True higher_orders_unconstrained=True"
+    )
+    print(f"TOTAL: PASS={passed} FAIL={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- derives by exact 36-coefficient linear algebra that proper cubic covariance plus gauge transversality leave the unique quadratic kernel `q^2 delta_ij - q_i q_j`
- extends matched detuned/RK transverse spectroscopy through `tau=16` on `L=8,10,12,14`
- finds that later imaginary time does not repair the two-term mismatch, while the first omitted `q^6` term makes fixed `c^2=U K` acceptable in every tested window
- localizes the remaining positive test to lower momentum and finite-forward stability; changes no axiom, audit verdict, or TOE score

## Checks

- exact kernel runner: `TOTAL: PASS=5 FAIL=0`
- late-time runner: `TOTAL: PASS=11 FAIL=0`
- both runner caches fresh against source and declared-input hashes
- controlled vocabulary lint: clean
- staged claim typing: clean
- repository invariants with links enforced: clean
- strict audit lint: no errors
- staged diff check: clean

## Cache recovery provenance

The late-time child completed normally and emitted its full final certificate. The cache wrapper then rejected the run because unrelated additions changed only the parent `scripts/` and `docs/` directory stat tokens during execution. Its exception records identical launch/completion runner SHA and declared-input fingerprint. The live log was preserved before releasing the wrapper, the recovered stdout was checked byte-for-byte, and the canonical cache was written against that identical content identity. The receipt records this recovery and derives elapsed time from the live-log timestamps.

## Limits

This is a bounded finite-volume result. It does not establish the infrared equality `c^2=U K`, a thermodynamic pole, Lorentz boosts, coupling to matter, Record-time identification, or empirical electromagnetism.