### PR TITLE
feat(law): dest=hop face plant occupies HOLDING sandwich cubes

### DIFF
--- a/docs/DEST_HOP_FACE_PLANT_OCCUPIES_HOLDING_SANDWICH_CUBES_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/DEST_HOP_FACE_PLANT_OCCUPIES_HOLDING_SANDWICH_CUBES_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,137 @@
+---
+claim_id: dest_hop_face_plant_occupies_holding_sandwich_cubes_bounded_theorem_note_2026-09-04
+claim_type: bounded_theorem
+claim_scope: "On Z^3 with the L2 ball B_r = {p : p·p <= r^2}, a unit cube is named by its min-corner. The geometric y=0 sandwich in B_r is the set of unit cubes whose eight vertices lie in B_r and whose min-corner has y=0. Curl grow is first-arrival BFS with dest update L' = L × s when that product is a signed axis. Inherit+perp grow is first-arrival BFS with dest copied along perpendicular steps. For r in {4,6,8}, with grow radius r+4: (A) curl grow from seeds {(0,0,0): +e1, (0,1,0): +e2} occupies exactly the geometric y=0 sandwich cubes; (B) inherit+perp grow from the four HOLDING seeds occupies exactly those same cubes; (C) curl grow from {(0,0,0): +e1, (0,-1,0): -e2} occupies exactly the geometric y=-1 sandwich; (D) those two sandwiches are disjoint and curl grow from both face plants occupies their union; (E) curl grow from {(0,0,0): +e1, (1,0,0): +e2} occupies exactly the geometric x=0 slab. At r=6 the dest=hop and HOLDING occupancy *sets* differ; every y=0 sandwich vertex is occupied in both; dests agree on exactly 26 of 218 of those vertices; 1-seed curl and dest=copy plant +e2 occupy no 8/8 cube in B_6. The seeds, dest rules, ball, and cube predicate are declared finite constructions. Nothing is claimed about formation, uniqueness, Standard Model content, or a=ℓ_P."
+upstream_dependencies: []
+runner: scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py
+---
+
+# Dest=hop face plant occupies the HOLDING sandwich 3-cells
+
+**Date:** 2026-09-04
+**Type:** bounded_theorem
+**Audit:** independent audit required
+**Status:** proposed_retained
+**Status authority:** effective status is pipeline-derived after independent audit ratification and dependency closure.
+**Primary runner:**
+`scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py`
+**Runner cache:**
+`logs/runner-cache/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.txt`
+**Parents:** none. The finite lattice constructions used by the claim are declared here.
+
+Two displayed occupancy members fill the same 8-vertex cubes in a finite ball,
+while occupying different vertex sets and writing different dests on the shared
+cube vertices. The identity is a finite integer check. It is not a derivation
+of a formation law, not a Standard Model claim, and not a TOE.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite occupancy identities on named L2 balls: occupied 8-vertex cubes of two declared grows equal a geometric sandwich, with an exact dest-agreement count on the shared vertices."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Submit the finite occupancy identity to the independent audit lane. Do not treat sandwich 3-cells as SM+gravity or as a forced seed."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+On `Z^3`, write `B_r = {p : p·p <= r^2}`. A unit cube is named by its
+min-corner `(i,j,k)` and has vertices `{i,i+1} × {j,j+1} × {k,k+1}`.
+The geometric `y=0` sandwich in `B_r` is the set of unit cubes whose eight
+vertices all lie in `B_r` and whose min-corner has `y=0`. Analogous slabs
+are defined for min-corner `y=-1` and min-corner `x=0`.
+
+Curl grow is first-arrival BFS: from an occupied site `p` with dest `L`,
+a nearest-neighbour step `s` is allowed when `L × s` is a signed axis, and
+the new dest is `L × s`. Inherit+perp grow is first-arrival BFS: a step `s`
+is allowed when `L · s = 0`, and the new dest is `L`.
+
+HOLDING seeds are the four sites
+
+```text
+(0,0,0): +e1
+(0,1,0): -e1
+(0,0,1): +e2
+(0,1,1): -e2
+```
+
+Dest=hop plant `+e2` is the two-seed curl grow from `{(0,0,0): +e1, (0,1,0): +e2}`.
+
+For each `r ∈ {4,6,8}`, occupancy is grown in `B_{r+4}` and cubes are scored
+in `B_r`. The runner proves:
+
+1. Dest=hop plant `+e2` occupies exactly the geometric `y=0` sandwich cubes
+   (`32`, `88`, `164` cubes at `r=4,6,8`).
+2. HOLDING inherit+perp occupies exactly those same cubes.
+3. Dest=hop plant `-e2` occupies exactly the geometric `y=-1` sandwich.
+4. The two sandwiches are disjoint. Curl grow from both face plants occupies
+   their union (`64`, `176`, `328` cubes).
+5. Dest=`⊥L` plant `+e1` dest=`+e2` occupies exactly the geometric `x=0` slab
+   (same counts as the `y=0` sandwich, by cubic symmetry of `B_r`).
+
+At `r=6` the runner additionally proves:
+
+6. The dest=hop and HOLDING occupancy *sets* differ.
+7. All `218` vertices of the `y=0` sandwich cubes are occupied in both grows.
+8. Dests on those vertices agree at exactly `26` sites and disagree at `192`.
+9. One-seed curl from `{(0,0,0): +e1}` occupies no 8/8 cube in `B_6`.
+10. Dest=copy plant `{(0,0,0): +e1, (0,1,0): +e1}` occupies no 8/8 cube in `B_6`.
+
+So the sandwich 3-cells are not inherit-only: a two-seed dest=hop face plant
+on the curl grow fills the same cubes. The face dest at the plant is supplied.
+The 4-seed HOLDING inherit grow is a different dest field on the same 3-cells.
+
+## Imports, declared inputs, and authority
+
+- **Declared lattice objects:** `Z^3`, 6-NN steps, the L2 ball, and the unit-cube
+  predicate are this note's finite geometry. Their role is to define the scored
+  cubes. Infinite-volume, other norms, and other cell shapes remain outside.
+- **Declared grows:** curl `L' = L × s` on axis-valued dests, inherit+perp dest
+  copy on perpendicular steps, first-arrival BFS, grow radius `r+4`, and the
+  named seeds are supplied constructions. Their provenance is this note. The
+  four axioms do not select these dest rules or these seeds.
+- **HOLDING seed tuple:** the four sites and dests are a declared 4-seed. They
+  are not derived from Admissibility or Record.
+- **Face plant:** dest=`+e2` at `(0,1,0)` (and the minus and `⊥L` plants) are
+  supplied extra seeds. The 1-seed curl control occupies no 8/8 cube, so the
+  plant is load-bearing for the sandwich identity.
+- **Standard methodology:** integer arithmetic on a finite ball, set equality
+  of cube min-corners, and first-arrival BFS are proof methods. The runner
+  checks the identities; their role is methodology.
+- **Observational inputs:** none. No `⟨P⟩`, hop-cost, `L_phys`, Born weights,
+  Gleason, Einstein, or Standard Model data enter the checks.
+
+## What this does not show
+
+- It does not derive dest=hop or HOLDING inherit from the four axioms.
+- It does not force the face plant. Without it, 1-seed curl has `n8=0` in `B_6`.
+- It does not identify dests: on the shared `218` vertices dests agree at `26`
+  sites only.
+- It does not produce a `(4,2,2)` fermion marker, chirality, colour, or
+  `a=ℓ_P`.
+- It does not occupy `Z^3`. Sandwich cubes at `r=6` all have min-corner `y=0`.
+- Cauchy `A/4 = C` language is not used as a selector; the cube counts are
+  the geometric sandwich enumerations in `B_r`.
+
+## Runner
+
+`scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py`
+
+Exact integer checks, `AUDIT_TIMEOUT_SEC = 60`.
+
+```text
+TOTAL: PASS=25 FAIL=0
+```
+
+Cache: `logs/runner-cache/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.txt`.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15764,
- "node_count": 5577,
+ "node_count": 5578,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3095,6 +3095,10 @@
    "out_degree": 0
   },
   "depth_laurent_root_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dest_hop_face_plant_occupies_holding_sandwich_cubes_bounded_theorem_note_2026-09-04": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },

--- a/logs/runner-cache/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.txt
+++ b/logs/runner-cache/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.txt
@@ -1,0 +1,41 @@
+===== runner cache v1 =====
+runner: scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py
+runner_sha256: 95c4e6c6578b1afaef1ac9442110921811fe5eb0500f5d84d406755e35f00e0f
+timeout_sec: 60
+exit_code: 0
+elapsed_sec: 0.29
+status: ok
+----- stdout -----
+r=4 |geom_y0|=32 inherit=32 hop+e2=32 hop-e2=32 face=64 perpL=32 geom_x0=32
+PASS r=4 dest=hop +e2 cubes == geometric y=0 sandwich
+PASS r=4 HOLDING inherit cubes == geometric y=0 sandwich
+PASS r=4 dest=hop -e2 cubes == geometric y=-1 sandwich
+PASS r=4 y=0 and y=-1 sandwiches disjoint
+PASS r=4 face ±e2 cubes == disjoint union of ±e2 sandwiches
+PASS r=4 dest=perpL cubes == geometric x=0 slab
+r=6 |geom_y0|=88 inherit=88 hop+e2=88 hop-e2=88 face=176 perpL=88 geom_x0=88
+PASS r=6 dest=hop +e2 cubes == geometric y=0 sandwich
+PASS r=6 HOLDING inherit cubes == geometric y=0 sandwich
+PASS r=6 dest=hop -e2 cubes == geometric y=-1 sandwich
+PASS r=6 y=0 and y=-1 sandwiches disjoint
+PASS r=6 face ±e2 cubes == disjoint union of ±e2 sandwiches
+PASS r=6 dest=perpL cubes == geometric x=0 slab
+r=8 |geom_y0|=164 inherit=164 hop+e2=164 hop-e2=164 face=328 perpL=164 geom_x0=164
+PASS r=8 dest=hop +e2 cubes == geometric y=0 sandwich
+PASS r=8 HOLDING inherit cubes == geometric y=0 sandwich
+PASS r=8 dest=hop -e2 cubes == geometric y=-1 sandwich
+PASS r=8 y=0 and y=-1 sandwiches disjoint
+PASS r=8 face ±e2 cubes == disjoint union of ±e2 sandwiches
+PASS r=8 dest=perpL cubes == geometric x=0 slab
+PASS r=6 dest=hop occupancy set != HOLDING inherit occupancy set
+PASS r=6 every y=0 sandwich vertex occupied by dest=hop
+PASS r=6 every y=0 sandwich vertex occupied by HOLDING inherit
+r=6 dest agree on sandwich vertices 26/218
+PASS r=6 dests on sandwich vertices are not identical
+PASS r=6 dests on sandwich vertices agree somewhere
+PASS r=6 1-seed curl occupies no 8/8 cube
+PASS r=6 dest=copy plant +e2 occupies no 8/8 cube
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py
+++ b/scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Dest=hop face plant occupies the HOLDING sandwich 3-cells.
+
+Class-A finite integer check. No floats. No external solver.
+
+Declared objects (all defined here):
+
+  * Sites are Z^3. A unit cube is named by its min-corner (i,j,k) and has
+    the eight vertices {i,i+1} x {j,j+1} x {k,k+1}.
+  * L2 ball B_r = {p : p·p <= r^2}.
+  * Geometric y=0 sandwich cubes in B_r: those unit cubes whose eight
+    vertices lie in B_r and whose min-corner has y=0.
+  * Curl grow: first-arrival BFS. From occupied p with dest L, a 6-NN step
+    s is allowed when L x s is a signed axis; the new dest is L x s.
+  * Inherit+perp grow: first-arrival BFS. A 6-NN step s is allowed when
+    L · s = 0; the new dest is L (copied).
+  * HOLDING seeds: four sites on the y=0 and y=1 planes with dests
+    +e1, -e1, +e2, -e2 as written below.
+  * dest=hop plant +e2: two seeds {(0,0,0): +e1, (0,1,0): +e2} grown by curl.
+
+Checks, for r in {4,6,8} with grow radius r+4 (margin against ball cutoff):
+
+  [A] dest=hop plant +e2 occupies exactly the geometric y=0 sandwich cubes
+  [B] HOLDING inherit+perp occupies exactly those same cubes
+  [C] dest=hop plant -e2 occupies exactly the geometric y=-1 sandwich
+  [D] those two sandwiches are disjoint; face ±e2 is their union
+  [E] dest=perpL plant +e1 dest=+e2 occupies exactly the geometric x=0 slab
+
+At r=6 additionally:
+
+  [F] occupancy *sets* of dest=hop +e2 and HOLDING inherit differ
+  [G] every sandwich-cube vertex is occupied in both
+  [H] dests on those vertices are not identical
+  [I] 1-seed curl and dest=copy plant +e2 occupy no 8/8 cube in B_6
+
+Prints one line per check; ends with TOTAL: PASS=N FAIL=0.
+"""
+from __future__ import annotations
+
+from collections import deque
+from itertools import product
+import sys
+
+AUDIT_TIMEOUT_SEC = 60
+
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+E1, E2, E3 = (1, 0, 0), (0, 1, 0), (0, 0, 1)
+ORIGIN = (0, 0, 0)
+HOLDING = {
+    (0, 0, 0): (1, 0, 0),
+    (0, 1, 0): (-1, 0, 0),
+    (0, 0, 1): (0, 1, 0),
+    (0, 1, 1): (0, -1, 0),
+}
+
+PASS = 0
+FAIL = 0
+
+
+def pr(*a):
+    sys.stdout.write(" ".join(str(x) for x in a) + "\n")
+    sys.stdout.flush()
+
+
+def check(label, ok):
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        pr(f"PASS {label}")
+    else:
+        FAIL += 1
+        pr(f"FAIL {label}")
+
+
+def add(a, b):
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def neg(a):
+    return (-a[0], -a[1], -a[2])
+
+
+def dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def cross(a, b):
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def is_axis(v):
+    return sum(abs(x) for x in v) == 1
+
+
+def in_ball(p, r):
+    return p[0] * p[0] + p[1] * p[1] + p[2] * p[2] <= r * r
+
+
+def grow_curl(seeds, r):
+    formed = dict(seeds)
+    q = deque(seeds.keys())
+    while q:
+        p = q.popleft()
+        L = formed[p]
+        for s in STEPS:
+            Lp = cross(L, s)
+            if not is_axis(Lp):
+                continue
+            v = add(p, s)
+            if not in_ball(v, r):
+                continue
+            if v not in formed:
+                formed[v] = Lp
+                q.append(v)
+    return formed
+
+
+def grow_inherit_perp(seeds, r):
+    formed = dict(seeds)
+    q = deque(seeds.keys())
+    while q:
+        p = q.popleft()
+        L = formed[p]
+        for s in STEPS:
+            if dot(L, s) != 0:
+                continue
+            v = add(p, s)
+            if not in_ball(v, r):
+                continue
+            if v not in formed:
+                formed[v] = L
+                q.append(v)
+    return formed
+
+
+def cube_vertices(corner):
+    i, j, k = corner
+    return tuple(product((i, i + 1), (j, j + 1), (k, k + 1)))
+
+
+def geometric_slab_cubes(r, axis, lo):
+    """Unit cubes in B_r whose min-corner has coordinate `axis` equal to `lo`."""
+    out = set()
+    R = r + 1
+    for corner in product(range(-R, R), repeat=3):
+        if corner[axis] != lo:
+            continue
+        verts = cube_vertices(corner)
+        if all(in_ball(v, r) for v in verts):
+            out.add(corner)
+    return out
+
+
+def occupied_cubes(formed, r):
+    out = set()
+    R = r + 1
+    for corner in product(range(-R, R), repeat=3):
+        verts = cube_vertices(corner)
+        if not all(in_ball(v, r) for v in verts):
+            continue
+        if all(v in formed for v in verts):
+            out.add(corner)
+    return out
+
+
+def cube_vertex_set(corners):
+    verts = set()
+    for c in corners:
+        verts.update(cube_vertices(c))
+    return verts
+
+
+def main() -> None:
+    radii = (4, 6, 8)
+    for r in radii:
+        grow_r = r + 4
+        geom_y0 = geometric_slab_cubes(r, 1, 0)
+        geom_ym1 = geometric_slab_cubes(r, 1, -1)
+        geom_x0 = geometric_slab_cubes(r, 0, 0)
+        inh = grow_inherit_perp(HOLDING, grow_r)
+        hop = grow_curl({ORIGIN: E1, E2: E2}, grow_r)
+        hopm = grow_curl({ORIGIN: E1, neg(E2): neg(E2)}, grow_r)
+        face = grow_curl({ORIGIN: E1, E2: E2, neg(E2): neg(E2)}, grow_r)
+        perp = grow_curl({ORIGIN: E1, E1: E2}, grow_r)
+        ci = occupied_cubes(inh, r)
+        cp = occupied_cubes(hop, r)
+        cm = occupied_cubes(hopm, r)
+        cf = occupied_cubes(face, r)
+        cx = occupied_cubes(perp, r)
+        pr(
+            f"r={r} |geom_y0|={len(geom_y0)} inherit={len(ci)} hop+e2={len(cp)} "
+            f"hop-e2={len(cm)} face={len(cf)} perpL={len(cx)} geom_x0={len(geom_x0)}"
+        )
+        check(f"r={r} dest=hop +e2 cubes == geometric y=0 sandwich", cp == geom_y0)
+        check(f"r={r} HOLDING inherit cubes == geometric y=0 sandwich", ci == geom_y0)
+        check(f"r={r} dest=hop -e2 cubes == geometric y=-1 sandwich", cm == geom_ym1)
+        check(f"r={r} y=0 and y=-1 sandwiches disjoint", not (geom_y0 & geom_ym1))
+        check(f"r={r} face ±e2 cubes == disjoint union of ±e2 sandwiches", cf == geom_y0 | geom_ym1)
+        check(f"r={r} dest=perpL cubes == geometric x=0 slab", cx == geom_x0)
+
+    r = 6
+    grow_r = r + 4
+    inh = grow_inherit_perp(HOLDING, grow_r)
+    hop = grow_curl({ORIGIN: E1, E2: E2}, grow_r)
+    one = grow_curl({ORIGIN: E1}, grow_r)
+    copy = grow_curl({ORIGIN: E1, E2: E1}, grow_r)
+    geom_y0 = geometric_slab_cubes(r, 1, 0)
+    verts = cube_vertex_set(geom_y0)
+    check("r=6 dest=hop occupancy set != HOLDING inherit occupancy set", set(hop) != set(inh))
+    check("r=6 every y=0 sandwich vertex occupied by dest=hop", all(v in hop for v in verts))
+    check("r=6 every y=0 sandwich vertex occupied by HOLDING inherit", all(v in inh for v in verts))
+    n_agree = sum(1 for v in verts if hop[v] == inh[v])
+    pr(f"r=6 dest agree on sandwich vertices {n_agree}/{len(verts)}")
+    check("r=6 dests on sandwich vertices are not identical", n_agree < len(verts))
+    check("r=6 dests on sandwich vertices agree somewhere", n_agree > 0)
+    check("r=6 1-seed curl occupies no 8/8 cube", occupied_cubes(one, r) == set())
+    check("r=6 dest=copy plant +e2 occupies no 8/8 cube", occupied_cubes(copy, r) == set())
+
+    pr(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    raise SystemExit(0 if FAIL == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A two-seed curl grow (origin dest `+e1`, face plant `(0,1,0)` dest `+e2`) occupies **exactly the same 8-vertex cubes** as four-seed HOLDING inherit+perp, in L2 balls `r=4,6,8`. Those cubes are the geometric `y=0` sandwich (every in-ball unit cube with min-corner `y=0`).

Plant `-e2` fills the disjoint `y=-1` sandwich. Both face plants fill their union. Dest=`⊥L` plant along `+e1` fills the `x=0` slab (same counts by cubic symmetry).

At `r=6`: occupancy *sets* differ; all 218 sandwich vertices are occupied in both; dests agree at 26/218 sites. One-seed curl and dest=copy plant occupy **no** 8/8 cube.

Runner: `TOTAL: PASS=25 FAIL=0` (exact integer, no floats).

## Why this is in the repo

This occupancy identity was pack-only. It is not on `origin/main` (searched `faa8b12efc` for HOLDING inherit / sandwich cube / dest=hop). It reduces the displayed sandwich 3-cells from a 4-seed inherit member to a 2-seed dest=hop face plant on the unique bilinear curl grow.

## What this is not

Not a formation law. Not SM. Not `a=ℓ_P`. Not a TOE. The face dest at the plant is supplied; without it, 1-seed curl has `n8=0`. Dests on the shared cubes are not the same field.

## Files

- `docs/DEST_HOP_FACE_PLANT_OCCUPIES_HOLDING_SANDWICH_CUBES_BOUNDED_THEOREM_NOTE_2026-09-04.md`
- `scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py`
- `logs/runner-cache/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.txt`
- `docs/audit/data/citation_graph_manifest.json` (new note node)

## Verify

```bash
python3 scripts/dest_hop_face_plant_occupies_holding_sandwich_cubes_check_2026_09_04.py
# TOTAL: PASS=25 FAIL=0
```