### PR TITLE
feat(law): sandwich cubes select dest ±hop at occupied perp NN

### DIFF
--- a/docs/DEST_OVERWRITE_AT_PERP_NN_SANDWICH_SELECTS_HOP_AXIS_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/DEST_OVERWRITE_AT_PERP_NN_SANDWICH_SELECTS_HOP_AXIS_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,91 @@
+---
+claim_id: dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_bounded_theorem_note_2026-09-04
+claim_type: bounded_theorem
+claim_scope: "On Z^3, curl grow is first-arrival BFS with dest L' = L × s when that product is a signed axis. One-seed curl from {(0,0,0): +e1} occupies +e2 with dest +e3 = e1 × e2 and does not occupy +e1. Overwrite dest at +e2 to each of the six signed axes, then continue curl grow. For r in {4,6,8} with grow radius r+4: overwrite dest = ±e2 occupies exactly the geometric y=0 sandwich cubes in B_r (unit cubes with min-corner y=0 and all eight vertices in B_r); overwrite dest = ±e1 or ±e3 occupies no 8/8 cube; +e2 and -e2 overwrite occupancy sets are equal; +e2 is already occupied in the one-seed grow (dest overwrite, not occupancy-extra). The grows, seeds, ball, and cube predicate are declared. The overwrite itself is supplied. Sign ± is not selected. Nothing is claimed about formation from the four axioms, Standard Model content, or a=ℓ_P."
+upstream_dependencies: []
+runner: scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py
+---
+
+# Sandwich 3-cells select dest ±hop at the already-occupied perp neighbour
+
+**Date:** 2026-09-04
+**Type:** bounded_theorem
+**Audit:** independent audit required
+**Status:** proposed_retained
+**Status authority:** effective status is pipeline-derived after independent audit ratification and dependency closure.
+**Primary runner:**
+`scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py`
+**Runner cache:**
+`logs/runner-cache/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.txt`
+**Parents:** none. Finite constructions are declared here.
+
+One-seed curl already occupies the hop-neighbour of the seed. Filling the
+geometric sandwich 3-cells is a dest overwrite at that site, not a new
+occupied vertex. Among the six signed-axis dests, only dest parallel to the
+hop fills those cubes.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact finite census: six dest overwrites at an already-occupied perp NN; only ±hop occupies the geometric y=0 sandwich cubes in named L2 balls."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "The overwrite dest=±hop is still supplied. Next is whether Record or Admissibility forces that overwrite, or the sign, without a new axiom."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+Curl grow: first-arrival BFS; dest updates as `L' = L × s` when that product
+is a signed axis. One-seed: `{(0,0,0): +e1}`.
+
+The runner proves, for `r ∈ {4,6,8}`:
+
+1. One-seed occupies `+e2` with dest `+e3 = e1 × e2`, and does not occupy `+e1`.
+2. Overwrite dest at `+e2` to `+e2` or to `-e2`, then curl-grow: occupied 8-vertex
+   cubes in `B_r` are exactly the geometric `y=0` sandwich (`32`, `88`, `164` cubes).
+3. Overwrite dest at `+e2` to `±e1` or to `±e3`: no 8/8 cube in `B_r`.
+4. Occupancy *sets* of the `+e2` and `-e2` overwrites are equal. Sign is not
+   selected by 3-cell occupancy.
+5. `+e2` is not occupancy-extra versus one-seed. The sandwich identity is dest
+   overwrite at a site the unique bilinear 1-seed already occupies.
+
+So: if curl grow after a dest at `+e2` is to occupy the sandwich 3-cells, that
+dest must be parallel to the hop. Copy dest and curl dest are ruled out among
+the six axes. The overwrite remains a supplied change of dest, not a Record or
+Admissibility derivation. The sign `±` remains free.
+
+## Imports, declared inputs, and authority
+
+- **Declared geometry:** `Z^3`, 6-NN, L2 ball, unit cubes. Role: scoring set.
+- **Declared grow:** curl first-arrival `L × s`. Role: the member class.
+- **Declared overwrite:** dest at `+e2` set to each signed axis before grow.
+  Role: the census. Not derived from the four axioms.
+- **Standard methodology:** integer BFS and set equality. Role: proof method.
+- **Observational inputs:** none.
+
+## What this does not show
+
+- It does not force dest overwrite from Record or Admissibility.
+- It does not select the sign `+e2` versus `-e2`.
+- It does not occupy `+e1` (along the seed dest) from this overwrite.
+- It does not yield SM content or `a=ℓ_P`.
+- It does not make sandwich cubes a TOE.
+
+## Runner
+
+`scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py`
+
+```text
+TOTAL: PASS=34 FAIL=0
+```

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
  "edge_count": 15764,
- "node_count": 5577,
+ "node_count": 5578,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -3095,6 +3095,10 @@
    "out_degree": 0
   },
   "depth_laurent_root_closed_form_bounded_theorem_note_2026-06-12": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
+  "dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_bounded_theorem_note_2026-09-04": {
    "deps_hash": "e3b0c44298fc",
    "out_degree": 0
   },

--- a/logs/runner-cache/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.txt
+++ b/logs/runner-cache/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.txt
@@ -1,0 +1,64 @@
+===== runner cache v1 =====
+runner: scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py
+runner_sha256: 3792a2273f4b56c5f25b5c5ccc709245d3f23c4d5b364d14fdf4fcc7a45ae1c2
+timeout_sec: 60
+exit_code: 0
+elapsed_sec: 0.36
+status: ok
+----- stdout -----
+PASS e1 × e2 is +e3
+PASS r=4 1-seed occupies +e2
+PASS r=4 1-seed dest at +e2 is +e3
+PASS r=4 1-seed does not occupy +e1
+r=4 overwrite dest=(1, 0, 0) n8=0 fills_y0=0
+PASS r=4 overwrite dest=(1, 0, 0) fills no 8/8 cube
+r=4 overwrite dest=(-1, 0, 0) n8=0 fills_y0=0
+PASS r=4 overwrite dest=(-1, 0, 0) fills no 8/8 cube
+r=4 overwrite dest=(0, 1, 0) n8=32 fills_y0=1
+PASS r=4 overwrite dest=(0, 1, 0) fills geometric y=0 sandwich
+r=4 overwrite dest=(0, -1, 0) n8=32 fills_y0=1
+PASS r=4 overwrite dest=(0, -1, 0) fills geometric y=0 sandwich
+r=4 overwrite dest=(0, 0, 1) n8=0 fills_y0=0
+PASS r=4 overwrite dest=(0, 0, 1) fills no 8/8 cube
+r=4 overwrite dest=(0, 0, -1) n8=0 fills_y0=0
+PASS r=4 overwrite dest=(0, 0, -1) fills no 8/8 cube
+PASS r=4 +hop and -hop overwrite occupancy sets equal
+PASS r=4 +e2 is not occupancy-extra vs 1-seed
+PASS r=6 1-seed occupies +e2
+PASS r=6 1-seed dest at +e2 is +e3
+PASS r=6 1-seed does not occupy +e1
+r=6 overwrite dest=(1, 0, 0) n8=0 fills_y0=0
+PASS r=6 overwrite dest=(1, 0, 0) fills no 8/8 cube
+r=6 overwrite dest=(-1, 0, 0) n8=0 fills_y0=0
+PASS r=6 overwrite dest=(-1, 0, 0) fills no 8/8 cube
+r=6 overwrite dest=(0, 1, 0) n8=88 fills_y0=1
+PASS r=6 overwrite dest=(0, 1, 0) fills geometric y=0 sandwich
+r=6 overwrite dest=(0, -1, 0) n8=88 fills_y0=1
+PASS r=6 overwrite dest=(0, -1, 0) fills geometric y=0 sandwich
+r=6 overwrite dest=(0, 0, 1) n8=0 fills_y0=0
+PASS r=6 overwrite dest=(0, 0, 1) fills no 8/8 cube
+r=6 overwrite dest=(0, 0, -1) n8=0 fills_y0=0
+PASS r=6 overwrite dest=(0, 0, -1) fills no 8/8 cube
+PASS r=6 +hop and -hop overwrite occupancy sets equal
+PASS r=6 +e2 is not occupancy-extra vs 1-seed
+PASS r=8 1-seed occupies +e2
+PASS r=8 1-seed dest at +e2 is +e3
+PASS r=8 1-seed does not occupy +e1
+r=8 overwrite dest=(1, 0, 0) n8=0 fills_y0=0
+PASS r=8 overwrite dest=(1, 0, 0) fills no 8/8 cube
+r=8 overwrite dest=(-1, 0, 0) n8=0 fills_y0=0
+PASS r=8 overwrite dest=(-1, 0, 0) fills no 8/8 cube
+r=8 overwrite dest=(0, 1, 0) n8=164 fills_y0=1
+PASS r=8 overwrite dest=(0, 1, 0) fills geometric y=0 sandwich
+r=8 overwrite dest=(0, -1, 0) n8=164 fills_y0=1
+PASS r=8 overwrite dest=(0, -1, 0) fills geometric y=0 sandwich
+r=8 overwrite dest=(0, 0, 1) n8=0 fills_y0=0
+PASS r=8 overwrite dest=(0, 0, 1) fills no 8/8 cube
+r=8 overwrite dest=(0, 0, -1) n8=0 fills_y0=0
+PASS r=8 overwrite dest=(0, 0, -1) fills no 8/8 cube
+PASS r=8 +hop and -hop overwrite occupancy sets equal
+PASS r=8 +e2 is not occupancy-extra vs 1-seed
+TOTAL: PASS=34 FAIL=0
+
+----- stderr -----
+

--- a/scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py
+++ b/scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Sandwich 3-cells select dest ±hop at the already-occupied perp NN.
+
+Class-A finite integer check. No floats.
+
+One-seed curl from {(0,0,0): +e1} occupies +e2 with dest = e1 × e2 = +e3.
+Overwrite dest at +e2 to each of the six signed axes, then continue curl
+first-arrival grow. Score occupied 8-vertex cubes in B_r against the
+geometric y=0 sandwich (min-corner y=0, all eight vertices in B_r).
+
+Checks for r in {4,6,8}, grow radius r+4:
+
+  [A] 1-seed occupies +e2; dest there is +e3; +e1 is vacant
+  [B] overwrite dest=+e2 occupies exactly the y=0 sandwich cubes
+  [C] overwrite dest=-e2 occupies exactly those same cubes
+  [D] overwrite dest=±e1 or dest=±e3 occupies no 8/8 cube
+  [E] +e2 and -e2 overwrite occupancy *sets* are equal
+  [F] +e2 is not occupancy-extra vs 1-seed (dest overwrite, not a new site)
+
+Prints one line per check; ends with TOTAL: PASS=N FAIL=0.
+"""
+from __future__ import annotations
+
+from collections import deque
+from itertools import product
+import sys
+
+AUDIT_TIMEOUT_SEC = 60
+
+STEPS = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+E1, E2, E3 = (1, 0, 0), (0, 1, 0), (0, 0, 1)
+ORIGIN = (0, 0, 0)
+AXES = (E1, (-1, 0, 0), E2, (0, -1, 0), E3, (0, 0, -1))
+
+PASS = 0
+FAIL = 0
+
+
+def pr(*a):
+    sys.stdout.write(" ".join(str(x) for x in a) + "\n")
+    sys.stdout.flush()
+
+
+def check(label, ok):
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        pr(f"PASS {label}")
+    else:
+        FAIL += 1
+        pr(f"FAIL {label}")
+
+
+def add(a, b):
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def cross(a, b):
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def is_axis(v):
+    return sum(abs(x) for x in v) == 1
+
+
+def in_ball(p, r):
+    return p[0] * p[0] + p[1] * p[1] + p[2] * p[2] <= r * r
+
+
+def grow_curl(seeds, r):
+    formed = dict(seeds)
+    q = deque(seeds.keys())
+    while q:
+        p = q.popleft()
+        L = formed[p]
+        for s in STEPS:
+            Lp = cross(L, s)
+            if not is_axis(Lp):
+                continue
+            v = add(p, s)
+            if not in_ball(v, r):
+                continue
+            if v not in formed:
+                formed[v] = Lp
+                q.append(v)
+    return formed
+
+
+def cube_vertices(corner):
+    i, j, k = corner
+    return tuple(product((i, i + 1), (j, j + 1), (k, k + 1)))
+
+
+def geometric_y0(r):
+    out = set()
+    R = r + 1
+    for i, k in product(range(-R, R), repeat=2):
+        corner = (i, 0, k)
+        verts = cube_vertices(corner)
+        if all(in_ball(v, r) for v in verts):
+            out.add(corner)
+    return out
+
+
+def occupied_cubes(formed, r):
+    out = set()
+    R = r + 1
+    for corner in product(range(-R, R), repeat=3):
+        verts = cube_vertices(corner)
+        if not all(in_ball(v, r) for v in verts):
+            continue
+        if all(v in formed for v in verts):
+            out.add(corner)
+    return out
+
+
+def main() -> None:
+    curl_at_e2 = cross(E1, E2)
+    check("e1 × e2 is +e3", curl_at_e2 == E3)
+
+    for r in (4, 6, 8):
+        grow_r = r + 4
+        one = grow_curl({ORIGIN: E1}, grow_r)
+        check(f"r={r} 1-seed occupies +e2", E2 in one)
+        check(f"r={r} 1-seed dest at +e2 is +e3", one.get(E2) == E3)
+        check(f"r={r} 1-seed does not occupy +e1", E1 not in one)
+        geom = geometric_y0(r)
+        by_dest = {}
+        for d in AXES:
+            occ = grow_curl({ORIGIN: E1, E2: d}, grow_r)
+            by_dest[d] = occ
+            cubes = occupied_cubes(occ, r)
+            fills = cubes == geom
+            pr(
+                f"r={r} overwrite dest={d} n8={len(cubes)} fills_y0={int(fills)}"
+            )
+            if d in (E2, (0, -1, 0)):
+                check(f"r={r} overwrite dest={d} fills geometric y=0 sandwich", fills)
+            else:
+                check(f"r={r} overwrite dest={d} fills no 8/8 cube", cubes == set())
+        occ_plus = by_dest[E2]
+        occ_minus = by_dest[(0, -1, 0)]
+        check(
+            f"r={r} +hop and -hop overwrite occupancy sets equal",
+            set(occ_plus) == set(occ_minus),
+        )
+        extra = set(occ_plus) - set(one)
+        check(f"r={r} +e2 is not occupancy-extra vs 1-seed", E2 not in extra)
+
+    pr(f"TOTAL: PASS={PASS} FAIL={FAIL}")
+    raise SystemExit(0 if FAIL == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

One-seed curl from origin dest `+e1` **already occupies** the hop-neighbour `+e2`, with dest `+e3 = e1 × e2`. Filling the geometric `y=0` sandwich 8-vertex cubes is a **dest overwrite** at that site, not a new occupied vertex.

Census of all six signed-axis dests at `+e2`, then curl grow, in L2 balls `r=4,6,8`:

- dest `±e2` (the hop): occupies **exactly** the geometric sandwich cubes (`32/88/164`)
- dest `±e1` or `±e3`: **no** 8/8 cube
- `+e2` and `-e2` occupancy sets are equal (sign not selected)
- `+e2` is not occupancy-extra versus one-seed

Runner: `TOTAL: PASS=34 FAIL=0`.

## Why this is a TOE-gap move

PR #7954 framed this as a two-seed plant. The occupancy set of one-seed already contains `+e2`. The extra structure is dest at that neighbour. Among six dests, sandwich 3-cells **select the hop axis**. That dest is still a supplied overwrite — Record/Admissibility do not force it. Sign `±` remains free.

## What this is not

Not a formation law from the four axioms. Not SM. Not `a=ℓ_P`. Not a TOE.

## Files

- `docs/DEST_OVERWRITE_AT_PERP_NN_SANDWICH_SELECTS_HOP_AXIS_BOUNDED_THEOREM_NOTE_2026-09-04.md`
- `scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py`
- `logs/runner-cache/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.txt`
- `docs/audit/data/citation_graph_manifest.json`

## Verify

```bash
python3 scripts/dest_overwrite_at_perp_nn_sandwich_selects_hop_axis_check_2026_09_04.py
# TOTAL: PASS=34 FAIL=0
```