### PR TITLE
docs: deferred-decisions parking registry — bridge + structuralist reading parked

### DIFF
--- a/docs/KEY_SCIENCE.md
+++ b/docs/KEY_SCIENCE.md
@@ -47,6 +47,13 @@ with `archive/PATHMAP.tsv` mapping every moved path. The freeze evidence
 `archive/campaigns/densify-freeze-20260904/`. Consolidated-PR history:
 closed PRs labeled `work-history`, indexed in `archive/LEDGER.md`.
 
+## Deferred decisions
+
+Owner decisions stored away until needed live in
+[`repo/DEFERRED_DECISIONS.md`](repo/DEFERRED_DECISIONS.md) with their
+standing defaults and wake conditions. A parked decision is off the active
+bar: do not re-raise it absent a fired wake condition.
+
 ## Live work
 
 Live campaign records and AI planning surfaces live on the standing

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 11858,
- "node_count": 4755,
+ "edge_count": 11859,
+ "node_count": 4756,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -9931,8 +9931,8 @@
    "out_degree": 5
   },
   "key_science": {
-   "deps_hash": "2b73f7f79249",
-   "out_degree": 9
+   "deps_hash": "10280328eef4",
+   "out_degree": 10
   },
   "key_terminology": {
    "deps_hash": "1c5d14fd0659",
@@ -14937,6 +14937,10 @@
   "repo.controlled_vocabulary": {
    "deps_hash": "14354d83e2fa",
    "out_degree": 2
+  },
+  "repo.deferred_decisions": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
   },
   "repo.four_axiom_narrative_scrub_plan_2026-07-04": {
    "deps_hash": "e3b0c44298fc",

--- a/docs/repo/DEFERRED_DECISIONS.md
+++ b/docs/repo/DEFERRED_DECISIONS.md
@@ -1,0 +1,79 @@
+# Deferred decisions — the parking registry
+
+**Claim type:** meta
+
+This file is where owner decisions are stored away until they are needed.
+An entry here is OFF the active bar: do not re-raise it with the owner, do
+not list it among standing decisions in session reports, handoffs, or
+campaign records, and do not treat it as blocking any lane. Work that
+touches a parked question proceeds under the entry's **standing default**;
+a note that leans on either side of a parked question must carry that side
+as a named supplied premise, exactly as before.
+
+A parked decision returns to the bar only when one of its **wake
+conditions** verifiably fires — then whoever observes it says so, citing
+this file and the condition. Adding, editing, or removing entries is an
+owner action (or owner-directed in the session doing it). Entries link
+their full decision packets; nothing is restated here as authority.
+
+---
+
+## 1. The statistical bridge ("Record Statistics") — PARKED 2026-09-05
+
+**The question:** adopt, or not, the one probabilistic postulate — that
+read-slice record formation odds equal the normalized herm(Q⁻¹) Gram
+weights of the committed action (the formation-odds form).
+
+**Standing default:** NOT adopted. Frequency language stays quarantined;
+statistical lanes proceed conditional-on-Bridge with the conditioning
+named; the weights and μ* remain imposed measured objects.
+
+**Decision packet:** `archive/campaigns/exercise-bridge-adoption-20260826/`
+— `SIGNING_TEXT_FINAL.md` is the panel-closed adoption text; the 2026-08-26
+Cesàro gate measurement is its standing whose-statistics scope witness; the
+door-by-door non-supply table is complete at scope (N1+N2, never N3). The
+superseded 2026-08-22 memo is decision-trail only.
+
+**Wake conditions (any one):**
+1. The committed-action identification lands (the owner's standing
+   action-ID-before-Bridge sequencing rule).
+2. The M₄(ℂ) Qubit-domain proposal (opus packet R133) is decided either
+   way — the carrier under the signing text must be stable before
+   signature.
+3. An exercise reopen condition fires: a covariant forcing proof over the
+   explicit eps-free real-quadratic field, or a theta-covariant committed
+   action passing the construction-bridge gate 0 — then the derivation
+   door reopens and this becomes a theorem program, not an adoption.
+4. A lane produces science it cannot state conditionally — i.e. a result
+   that needs licensed, unconditional probability talk to land.
+
+## 2. The structuralist reading (Ψ9 flip-invariance) — PARKED 2026-09-05
+
+**The question:** whether the Qubit sentence "distinguished by the supplied
+algebraic structure alone" carries flip-invariance of *rule dependence*
+(making every availability set provably achiral and chirality
+non-definable), or whether the Cl(3,0) axis-sign choice is one honest Z₂
+orientation bit of physical data, carried by sign(Ψ9).
+
+**Standing default:** not adopted, either way. The bit stays an open datum;
+no lane assumes either reading silently; the invariant-theory theorems
+(flip group Z₂³, all-even-exponent invariants, Ψ9 flip-odd and unique)
+hold regardless and stay usable.
+
+**Decision packet:**
+`archive/notes/docs/PRESENTATION_GAUGE_AXIS_SIGN_FLIP_INVARIANTS_TWIN_DETECTOR_GAUGE_SECTION_ORIENTATION_BIT_BOUNDED_THEOREM_NOTE_2026-07-04.md`
+(the stated-not-adopted decision-surface section), with the finite
+discriminator — the value-flip census (26/28 attainable, 27 not) — on its
+archived row. Verified 2026-09-05: no live lane consumes this question (the
+August lane's "alphabet exclusion" and "orientation bit" are different
+objects — see the correction blocks on the D-qca/D-ker/D-gauge chains).
+
+**Wake conditions (any one):**
+1. The realized-alphabet chirality / A0 unpaired-orbit program resumes.
+2. A weak-sector or handedness result needs the bit's status to state
+   itself.
+3. The M₄(ℂ) Qubit-domain proposal is decided — the Cl(3,0) flip/invariant
+   analysis must be redone on the new algebra before any ruling.
+4. A licensed-equivalence extension theorem covering antilinear
+   (axis-flip) recodings is derived — then the reading becomes a theorem
+   and no ruling is needed.


### PR DESCRIPTION
The owner's 'store them away and not think about them' mechanism, made concrete: docs/repo/DEFERRED_DECISIONS.md holds parked owner decisions with a standing default and explicit wake conditions each; an entry is off the active bar and must not be re-raised in reports, handoffs, or campaign records unless a wake condition verifiably fires. First two entries per the owner's direction: the statistical bridge (default not adopted; conditional-on-Bridge lanes unaffected) and the structuralist Ψ9 reading (verified: no live consumer). KEY_SCIENCE.md points at the registry. Lint PASS, invariants PASS with graph manifest re-acknowledged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)