### PR TITLE
docs: park the C-add fork — deferred-decisions entry 3

### DIFF
--- a/docs/repo/DEFERRED_DECISIONS.md
+++ b/docs/repo/DEFERRED_DECISIONS.md
@@ -77,3 +77,43 @@ objects — see the correction blocks on the D-qca/D-ker/D-gauge chains).
 4. A licensed-equivalence extension theorem covering antilinear
    (axis-flip) recodings is derived — then the reading becomes a theorem
    and no ruling is needed.
+
+## 3. The C-add record-composition fork (+ POS/LOC admission) — PARKED 2026-09-05
+
+**The question:** which governance home the action-kernel composition
+premise C-add (the kernel-convolution clause) gets — (1) a registered
+narrow record-composition primitive, (2) supply via the banked
+Dynamics-axiom proposal
+(`docs/DYNAMICS_AXIOM_MINIMAL_NONTRIVIALITY_BRANCH_PROPOSAL_2026-06-29.md`,
+provenance-only), or (3) a named conditional premise carried per use —
+and whether to admit POS (nonnegative weights) and LOC (single-step
+locality) alongside it.
+
+**Standing default:** home (3), which is what every downstream result has
+used since July: C-add/POS/LOC stay named unadopted premises; results
+state "under C-add …"; the convolution-semigroup → Metzler → nearest-
+neighbor-heat trichotomy and the wrapped-Gaussian limit remain the
+conditional map. Nothing is adjudicated; no wall is closed or reopened.
+
+**Decision packet:**
+`archive/notes/docs/RECORD_COMPOSITION_BRIDGE_SEMIGROUP_POSITIVITY_SELECTION_BOUNDED_NOTE_2026-07-02.md`
+(the three homes, mapped without adoption) with the action trichotomy in
+`archive/chains/july-kernel-rule-era.md`, the C-add independence witness
+(additivity + one-step sums do not force convolution) in
+`archive/chains/july-frame-weighting-era.md`, and the Cycle-698 contact
+discriminator (pairs(A∪B) − pairs(A) − pairs(B) = cross_bonds(A,B)) on its
+archived row. Epoch note: the 2026-08-13 Record revision removed the
+finite-additivity sentence several July C-add-adjacent legs consumed
+(their rows are flagged), so ANY adoption route must first re-establish
+those legs with a fresh supplier.
+
+**Wake conditions (any one):**
+1. The source/action bridge program (gravity mainline / the
+   metric→dynamics terminal lane) reaches an adoption candidate that
+   needs the convolution clause as registered structure.
+2. The derivation target lands — convolution derived from one-parameter
+   composition + locality + record-compatibility (the Cycle-698 T4(c)
+   framing) — which dissolves the fork with no decision needed.
+3. The banked Dynamics-axiom proposal is revived for adoption (home 2).
+4. A lane produces a result it cannot state conditionally under
+   "if C-add".


### PR DESCRIPTION
Same treatment as the Bridge and the structuralist reading, on the owner's direction: verified no live consumer (96-PR corpus, current lane, opus packet all zero engagement; the two grep hits were vec_add function names), standing default = the named-conditional-premise home that all downstream results already use, decision packet linked (the three governance homes note + trichotomy chains + Cycle-698 discriminator), epoch prerequisite recorded (2026-08-13 Record revision), four wake conditions including the fork-dissolving derivation target. Lint PASS; invariants PASS with manifest re-acknowledged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)