### PR TITLE
science(light): replay infrared Maxwell forward control

### DIFF
--- a/docs/NO_GO_DISCIPLINE_CHECKLIST_SPIN_HALF_INFRARED_FORWARD_REPLAY_2026-09-05.md
+++ b/docs/NO_GO_DISCIPLINE_CHECKLIST_SPIN_HALF_INFRARED_FORWARD_REPLAY_2026-09-05.md
@@ -1,0 +1,67 @@
+---
+# No-Go Discipline Checklist — Infrared Forward Replay Boundary
+
+**Packet status:** `PASS` for the deliberately narrow claim below, with scientific classification `partial-attempt-with-named-untested-routes`. The packet does not assert that all routes fail; it records one attempted receipt that did not satisfy one predeclared estimator guard.
+
+**Claim under review:** The canonical six-replica paired-forward replay completed its declared rows, but the detuned `V=0.95, L=18` row reached only `min_forward=36` against the frozen `>=40` floor. The strict join was therefore not run as a green Maxwell decision surface.
+
+## N1 — Alternative route enumeration
+
+Five materially different repair routes remain open. The only route actually executed here is the predeclared six-replica paired-forward replay; none of the unexecuted routes is treated as closed.
+
+| Route family | Honesty marker | Result and retained evidence |
+|---|---|---|
+| Numerical/finite-case: increase the detuned walker population so more descendants survive at `L=18`. | ATTEMPTED (baseline only) | The executed population was the frozen `6144`; it exposed `36<40`. A larger population was not run, so this repair remains open. |
+| Boundary/initial-condition: add independent measurement origins or change the prethermalization/origin schedule. | ATTEMPTED (baseline only) | Four origins were executed under the frozen schedule; no alternative origin schedule was tested, so the route remains open. |
+| Dynamical/effective-action: replace or augment the resampling/forward-propagation estimator with a survival-bounded construction. | ATTEMPTED (baseline only) | The existing propagation produced a valid finite row but not the required bound; no alternate propagator was executed. |
+| Alternate observable/readout: use a forward correlator or ratio with a separately proven genealogy control. | ATTEMPTED (baseline only) | Only the declared transverse correlator was measured; an alternate readout was not executed. |
+| Lattice-scale/limit: repeat at nearby volumes or with a lower-momentum design to test whether the count loss is volume-specific. | ATTEMPTED (baseline only) | `L=16,18` were executed, but no additional volume or limit study was run. |
+
+No route is claimed to fail universally; the table names the next tests required to turn this partial attempt into a positive estimator result.
+
+## N2 — Wall-independence audit
+
+Only one load-bearing residual is named: `W1`, the `L=18,V=0.95` minimum-forward-descendant floor. Finite volume, supplied carrier, imaginary-time projection, and the missing Record/matter bridge are stated as non-claims and scope context, not independent walls in this packet. A pairwise wall table is therefore vacuous; no wall is split into multiple supposedly independent admissions.
+
+## N3 — Hidden-wall scan
+
+| Phrase or condition | Classification | Evidence |
+|---|---|---|
+| `predeclared`, `frozen`, `canonical` | Retained execution scope | Runner constants and cache identity bind the source, populations, endpoints, windows, and thresholds; these words do not add physics. |
+| `by construction` / exact RK identity | Non-load-bearing control description | The uniform RK projector gives equal forward gaps and is checked as an implementation identity; it is not used to certify the detuned row. |
+| `supplied carrier` / `imaginary-time projection` | Explicit scope context | The note says these are not derived or claimed; they are not counted as a reason the replay failed. |
+| `wall` / `boundary` | Explicit `W1` only | The only named load-bearing condition is the measured forward-descendant floor. |
+
+No hidden assumption is promoted to a second wall.
+
+## N4 — Residual matching
+
+No prior negative theorem is used as evidence against the current claim. The current residual is exactly the forward-genealogy guard at `V=0.95,L=18`, not a claim about Maxwell normalization, photon existence, or Record formation. Existing forward-length and infrared notes are cited only as context for the repair routes; their residuals are not substituted for `W1`.
+
+## N5 — Rhetoric and resolution audit
+
+The note uses the narrow statement that this **execution** did not meet a named floor. It does not state that a carrier, derivation, or route is impossible. The primary cache contains the following recovery execution certificate, with one line per required resolution class:
+
+```text
+per_element: checked and not executed — the replay evolves population states and emits no per-element Record formation observable, so this resolution was not exercised.
+per_site: checked and not executed — no site-local Record or matter-response measurement is part of this transverse correlator runner, so site resolution remains open.
+per_mode: checked — paired forward endpoints F=6,12,20 were evaluated as separate endpoint modes; the reported residual is the aggregate descendant-count guard.
+per_block: checked and not executed — four measurement-origin blocks were sampled, but no Record compiler or energy-ledger block was executed in this campaign.
+lattice_wide: checked — full-row counts, Gauss charge, zero flux, gaps, covariance finiteness, and health minima were evaluated; L=18 V=0.95 reached min_forward=36.
+```
+
+Per-element, per-site, and Record-level block claims are untested; per-mode endpoint pairing and lattice-wide conservation/health were exercised. No broader resolution is inferred.
+
+## N6 — Partial-closure and primitive scan
+
+No new axiom or primitive is requested. The existing partial closure path is an estimator repair: increase effective genealogy support or prove a survival-bounded alternate readout, then rerun the same decision surface. The relevant open Record/matter path is described in `toe-assessment-2026-09-04/block06-root-actual-response-connection.md` and is active in PRs #7979 and #7983. Those artifacts seek a local Record compiler and shared particle/energy ledger; they do not supply a license to lower this light-lane threshold.
+
+## N7 — Steelman
+
+A hostile reviewer can say that `min_forward=36` is a finite-population diagnostic artifact: the same detuned carrier may pass with more walkers, more origins, a better resampler, or a correlator whose variance does not collapse at the lower gap. The independent `L=8` forward-length extension and the earlier infrared health-boundary note show that forward projection and genealogy are estimator design variables, not physical laws. This is a concrete unclosed repair mechanism, so the correct classification is a partial attempt with the residual named, not a universal no-go.
+
+## N8 — Cross-cycle echo
+
+Prior infrared and forward-length packets already name the same shape of residual: a stochastic receipt can preserve exact sectors while missing an origin or forward-genealogy floor. `docs/SPIN_HALF_CUBIC_ICE_INFRARED_MAXWELL_JOIN_HEALTH_BOUNDARY_BOUNDED_THEOREM_NOTE_2026-09-04.md` records a prior `tau=16` origin floor of `18` and repairs it only conditionally; `docs/SPIN_HALF_CUBIC_ICE_FORWARD_LENGTH_CONVERGENCE_BOUNDED_THEOREM_NOTE_2026-09-04.md` records a non-green upstream receipt and then retires the estimator issue with a higher-statistics extension. The same mechanism—more genealogy support plus an explicit repair receipt—can apply here. No prior result justifies declaring the current `36` count structural.
+
+**Gate conclusion:** The narrow attempted-route boundary is recorded with all alternative repairs open. It is not a universal no-go and does not alter axioms, primitives, audit status, or TOE score.

--- a/docs/SPIN_HALF_CUBIC_ICE_INFRARED_FORWARD_REPLAY_RECOVERY_BOUNDARY_NOTE_2026-09-05.md
+++ b/docs/SPIN_HALF_CUBIC_ICE_INFRARED_FORWARD_REPLAY_RECOVERY_BOUNDARY_NOTE_2026-09-05.md
@@ -1,0 +1,93 @@
+---
+claim_id: spin_half_cubic_ice_infrared_forward_replay_recovery_boundary_2026-09-05
+claim_type: open_gate
+claim_scope: "The predeclared six-replica paired-forward replay records an attempted finite-volume estimator check whose L=18 detuned row does not meet the existing forward-genealogy floor; this is a partial attempt, not a route-independent physical no-go."
+upstream_dependencies:
+  - minimal_axioms
+runner: scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
+---
+
+# High-Genealogy Infrared Replay Hits a Finite-Volume Forward-Genealogy Boundary
+
+**Date:** 2026-09-05
+
+**Status:** `partial-attempt-with-named-untested-routes`. The status authority is the independent audit lane; this note sets no audit verdict, TOE score, axiom, or approved primitive.
+
+**Primary runner:** [`scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py`](../scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py)
+
+**Primary receipt:** [`logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt`](../logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt)
+
+**Strict/diagnostic join receipt:** [`logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.txt`](../logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.txt)
+
+**No-go packet:** [`docs/NO_GO_DISCIPLINE_CHECKLIST_SPIN_HALF_INFRARED_FORWARD_REPLAY_2026-09-05.md`](NO_GO_DISCIPLINE_CHECKLIST_SPIN_HALF_INFRARED_FORWARD_REPLAY_2026-09-05.md)
+
+## Result up front
+
+The canonical clean replay completed all four predeclared coupling/volume rows with six replicas per row, shared forward endpoints `F=6,12,20`, four measurement origins, detuned population `6144`, and RK population `1536`. Exact flippable counts, Gauss charge, zero electric flux, finite positive correlators/gaps/covariances, detuned covariance rank, and the RK forward identity all passed.
+
+The aggregate receipt is `TOTAL: PASS=3 FAIL=1`. The sole runner failure is the existing weight/genealogy floor: at `V=0.95, L=18`, `min_forward=36` while the predeclared floor is `>=40`; its `min_ess=0.943968` and `min_origin_tau16=57` remain above their floors. The strict join therefore exits before fitting and records `high-genealogy replay receipt is not green`. An explicit `--diagnostic` rerun keeps that upstream failure visible and evaluates the downstream surface: `TOTAL: PASS=6 FAIL=2`, with the upstream-green gate and the paired-primary-forward-plateau gate failing while the reproduction, positive U K-compatible fits, model extensions, and direct-spectrum controls pass. No Maxwell compatibility claim is promoted from this packet.
+
+This is a bounded estimator boundary for the attempted replay. It does not show that the detuned carrier is physically inconsistent, that no alternative forward estimator can work, or that the light lane is closed. The failure is useful because it identifies the exact condition that must be retired before the lower-momentum Maxwell comparison can be interpreted.
+
+## 1. Paired measurements
+
+| coupling | L | window | paired gaps |
+|---:|---:|:---:|:---|
+| 1.00 | 16 | 2--6 | F6=0.04668739 +/- 0.00031957, F12=0.04668739 +/- 0.00031957, F20=0.04668739 +/- 0.00031957 |
+| 1.00 | 16 | 8--14 | F6=0.04595709 +/- 0.00028473, F12=0.04595709 +/- 0.00028473, F20=0.04595709 +/- 0.00028473 |
+| 1.00 | 18 | 2--6 | F6=0.03681395 +/- 0.00021043, F12=0.03681395 +/- 0.00021043, F20=0.03681395 +/- 0.00021043 |
+| 1.00 | 18 | 8--14 | F6=0.03700905 +/- 0.00025207, F12=0.03700905 +/- 0.00025207, F20=0.03700905 +/- 0.00025207 |
+| 0.95 | 16 | 2--6 | F6=0.08917261 +/- 0.00156682, F12=0.08515066 +/- 0.00176782, F20=0.08880624 +/- 0.00409377 |
+| 0.95 | 16 | 8--14 | F6=0.08539755 +/- 0.00246898, F12=0.09003998 +/- 0.00526249, F20=0.09054816 +/- 0.00591009 |
+| 0.95 | 18 | 2--6 | F6=0.07547634 +/- 0.00247577, F12=0.07036339 +/- 0.00341667, F20=0.07423651 +/- 0.00291967 |
+| 0.95 | 18 | 8--14 | F6=0.07442854 +/- 0.00497829, F12=0.07345383 +/- 0.00801271, F20=0.08388134 +/- 0.01249193 |
+
+| coupling | L | minimum ESS fraction | minimum tau=16 origins | minimum forward descendants |
+|---:|---:|---:|---:|---:|
+| 1.00 | 16 | 1.000000 | 1536 | 1536 |
+| 1.00 | 18 | 1.000000 | 1536 | 1536 |
+| 0.95 | 16 | 0.960210 | 118 | 74 |
+| 0.95 | 18 | 0.943968 | 57 | 36 |
+
+The detuned primary paired gaps are `0.08539755, 0.09003998, 0.09054816` at `L=16` and `0.07442854, 0.07345383, 0.08388134` at `L=18`. An independent diagnostic recomputation gives forward-plateau spans `0.058093` and `0.134976`, respectively, against the frozen `<0.05` join threshold; those values are diagnostics only because the strict join correctly refuses a non-green upstream receipt. The RK rows are exactly forward-independent by construction and serve as implementation controls.
+
+## 2. Diagnostic join localization
+
+The diagnostic-only join was added after the receipt failed so the strict gate remains unchanged while the measured rows are still inspected. Its exact decision surface is:
+
+```text
+[FAIL] upstream replay receipt is green (diagnostic mode keeps this gate visible)
+[PASS] source-pinned parent and replay provide matched six-volume ladders
+[PASS] every new F=6 primary gap reproduces the independent earlier infrared receipt
+[FAIL] both detuned infrared volumes pass the paired primary-window forward plateau
+[PASS] every paired forward endpoint gives a positive U K-compatible primary coefficient
+[PASS] fixed central U K plus q-fourth and q-sixth passes at every forward endpoint
+[PASS] mass and q-eighth extensions neither improve nor destabilize the primary fits
+[PASS] primary direct detuned spectra carry U K-compatible weight while RK does not
+TOTAL: PASS=6 FAIL=2
+```
+
+The detuned primary-window forward controls are `hotelling=1.5660`, `max_contrast=1.2486`, `span=0.058093` at `L=16`, and `4.4771`, `0.8982`, `0.134976` at `L=18`, against the frozen span bound `<0.05`. The diagnostic `F=6,12,20` Maxwell coefficients are `0.01987277 +/- 0.01062092`, `0.02398295 +/- 0.01465051`, and `0.02821253 +/- 0.01666132`, all compatible with the static `U K=0.01228909 +/- 0.00116899` within the declared checks. Because the upstream genealogy and plateau gates are not met, these are localization values, not a promoted theorem.
+
+## 3. What the workflow result means
+
+The optional `--parallel-rows` mode ran the same `run_row`, replica seeds, populations, checks, and emission format for the four independent rows, then restored the declared row order before aggregate checks. It changes scheduling only. The canonical cache records runner SHA `8d87b4c4ffc219e7557cf0ad19213842738f8f8a2879493612e3740fd19d26da`, elapsed time `20807.00 s`, exit code `1`, and the complete stdout. A recovery scope certificate is appended after the raw output and is marked as such; no numerical runner line was edited.
+
+The failed guard is an estimator-health condition, not a dynamical law. At the larger volume and lower gap, four origin blocks and the selected forward suffix leave only 36 distinct descendants in the worst endpoint population. The current packet therefore cannot separate physical forward-length drift from loss of genealogy support. The next replay should predeclare how to raise that count—larger population, more independent origins, or a resampling/observable design with a proven survival bound—before changing the Maxwell thresholds or acceptance window.
+
+## 4. TOE consequence and next frontier
+
+No axiom or primitive edit follows. This packet does not reduce the central Record/matter assumptions. The highest-value follow-up remains the local CAR-to-physical-Record compiler and a repeated active matter/apparatus cycle with no fresh-state reset, carrying one exact particle-and-energy ledger through formation, propagation, and readout. The open Record-matter work in PRs #7979 and #7983 is the relevant bridge; this light-lane estimator boundary should be retired or narrowed before it is used to support that bridge.
+
+## 5. Falsifiers and repair test
+
+Reopen this boundary if an independent run with the same frozen source and receipt format reaches `min_forward>=40` at `V=0.95,L=18`, or if a predeclared alternate estimator supplies the required genealogy bound. Conversely, any conservation, sector, positivity, covariance-rank, or RK-control failure would make the current failure broader than the named genealogy wall. The repair campaign must keep `L=16,18`, six replicas, shared `F=6,12,20`, primary window `8-14`, and the existing strict thresholds visible before output.
+
+Run:
+
+```bash
+python3 scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py --workers 2 --parallel-rows
+python3 scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py --diagnostic
+```
+
+No audit verdict is authored here.

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 15854,
- "node_count": 5586,
+ "edge_count": 15855,
+ "node_count": 5588,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -13230,6 +13230,10 @@
    "deps_hash": "d8ee1c26b8bd",
    "out_degree": 2
   },
+  "no_go_discipline_checklist_spin_half_infrared_forward_replay_2026-09-05": {
+   "deps_hash": "e3b0c44298fc",
+   "out_degree": 0
+  },
   "no_per_site_bosonic_ccr_theorem_note_2026-05-02": {
    "deps_hash": "c8eee4235fc9",
    "out_degree": 1
@@ -17429,6 +17433,10 @@
   "spin_half_cubic_ice_forward_length_convergence_bounded_theorem_note_2026-09-04": {
    "deps_hash": "46a12242e507",
    "out_degree": 2
+  },
+  "spin_half_cubic_ice_infrared_forward_replay_recovery_boundary_note_2026-09-05": {
+   "deps_hash": "644c05108dd2",
+   "out_degree": 1
   },
   "spin_half_cubic_ice_infrared_maxwell_join_health_boundary_bounded_theorem_note_2026-09-04": {
    "deps_hash": "1525e714d0d9",

--- a/logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt
@@ -1,0 +1,61 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
+runner_sha256: 8d87b4c4ffc219e7557cf0ad19213842738f8f8a2879493612e3740fd19d26da
+input_fingerprint_sha256: 527397dd8844b51564d926123284452445b7be28b5ea01aaed5f8c6b3ca007ee
+timeout_sec: 64800
+exit_code: 1
+elapsed_sec: 20807.00
+status: nonzero_exit
+----- stdout -----
+REPLICA_DONE V=1.00 L=16 replica=1/6
+REPLICA_DONE V=1.00 L=16 replica=2/6
+REPLICA_DONE V=1.00 L=18 replica=1/6
+REPLICA_DONE V=1.00 L=18 replica=2/6
+REPLICA_DONE V=1.00 L=16 replica=3/6
+REPLICA_DONE V=1.00 L=16 replica=4/6
+REPLICA_DONE V=1.00 L=16 replica=5/6
+REPLICA_DONE V=1.00 L=16 replica=6/6
+PAIRED_ROW V=1.00 L=16 window=2-6 gaps=6:0.04668739+/-0.00031957,12:0.04668739+/-0.00031957,20:0.04668739+/-0.00031957 cov=1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07,1.021270401734e-07
+PAIRED_ROW V=1.00 L=16 window=8-14 gaps=6:0.04595709+/-0.00028473,12:0.04595709+/-0.00028473,20:0.04595709+/-0.00028473 cov=8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08,8.107349362024e-08
+ROW_HEALTH V=1.00 L=16 min_ess=1.000000 min_origin_tau16=1536 min_forward=1536
+REPLICA_DONE V=1.00 L=18 replica=3/6
+REPLICA_DONE V=1.00 L=18 replica=4/6
+REPLICA_DONE V=1.00 L=18 replica=5/6
+REPLICA_DONE V=1.00 L=18 replica=6/6
+PAIRED_ROW V=1.00 L=18 window=2-6 gaps=6:0.03681395+/-0.00021043,12:0.03681395+/-0.00021043,20:0.03681395+/-0.00021043 cov=4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08,4.427919972333e-08
+PAIRED_ROW V=1.00 L=18 window=8-14 gaps=6:0.03700905+/-0.00025207,12:0.03700905+/-0.00025207,20:0.03700905+/-0.00025207 cov=6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08,6.354112850067e-08
+ROW_HEALTH V=1.00 L=18 min_ess=1.000000 min_origin_tau16=1536 min_forward=1536
+REPLICA_DONE V=0.95 L=16 replica=1/6
+REPLICA_DONE V=0.95 L=16 replica=2/6
+REPLICA_DONE V=0.95 L=18 replica=1/6
+REPLICA_DONE V=0.95 L=18 replica=2/6
+REPLICA_DONE V=0.95 L=16 replica=3/6
+REPLICA_DONE V=0.95 L=16 replica=4/6
+REPLICA_DONE V=0.95 L=16 replica=5/6
+REPLICA_DONE V=0.95 L=16 replica=6/6
+PAIRED_ROW V=0.95 L=16 window=2-6 gaps=6:0.08917261+/-0.00156682,12:0.08515066+/-0.00176782,20:0.08880624+/-0.00409377 cov=2.454917168427e-06,1.775489077296e-06,3.762819757954e-06,1.775489077296e-06,3.125182703635e-06,6.184534351226e-06,3.762819757954e-06,6.184534351226e-06,1.675898733021e-05
+PAIRED_ROW V=0.95 L=16 window=8-14 gaps=6:0.08539755+/-0.00246898,12:0.09003998+/-0.00526249,20:0.09054816+/-0.00591009 cov=6.095839378994e-06,9.982588243765e-06,4.353249249504e-06,9.982588243765e-06,2.769377505409e-05,2.448264919415e-05,4.353249249504e-06,2.448264919415e-05,3.492917803471e-05
+ROW_HEALTH V=0.95 L=16 min_ess=0.960210 min_origin_tau16=118 min_forward=74
+REPLICA_DONE V=0.95 L=18 replica=3/6
+REPLICA_DONE V=0.95 L=18 replica=4/6
+REPLICA_DONE V=0.95 L=18 replica=5/6
+REPLICA_DONE V=0.95 L=18 replica=6/6
+PAIRED_ROW V=0.95 L=18 window=2-6 gaps=6:0.07547634+/-0.00247577,12:0.07036339+/-0.00341667,20:0.07423651+/-0.00291967 cov=6.129424284189e-06,6.482728379095e-06,5.087313112796e-06,6.482728379095e-06,1.167361591673e-05,4.199990209862e-06,5.087313112796e-06,4.199990209862e-06,8.524452741212e-06
+PAIRED_ROW V=0.95 L=18 window=8-14 gaps=6:0.07442854+/-0.00497829,12:0.07345383+/-0.00801271,20:0.08388134+/-0.01249193 cov=2.478333948187e-05,2.665567075158e-05,3.503151810752e-05,2.665567075158e-05,6.420359422109e-05,9.159482872104e-05,3.503151810752e-05,9.159482872104e-05,1.560483468190e-04
+ROW_HEALTH V=0.95 L=18 min_ess=0.943968 min_origin_tau16=57 min_forward=36
+[PASS] 01 every replay population preserves exact counts, Gauss charge, and zero electric flux
+[FAIL] 02 every replay population satisfies the pre-existing weight and genealogy floors
+[PASS] 03 every paired-forward correlator, gap, and covariance is finite and positive
+[PASS] 04 detuned primary covariances are full rank and RK forward identity is exact
+CERTIFICATE: lower_momenta=L16,L18 replicas=6 detuned_population=6144 rk_population=1536 paired_forward_lengths=6,12,20 measurement_origins=4 primary_window=8-14 finite_volume=True thermodynamic_limit=False
+TOTAL: PASS=3 FAIL=1
+RECOVERY_N5_EXECUTION_CERTIFICATE (post-run scope annotation; numerical stdout above is unchanged)
+per_element: checked and not executed — the replay evolves population states and emits no per-element Record formation observable, so this resolution was not exercised.
+per_site: checked and not executed — no site-local Record or matter-response measurement is part of this transverse correlator runner, so site resolution remains open.
+per_mode: checked — paired forward endpoints F=6,12,20 were evaluated as separate endpoint modes; the reported residual is the aggregate descendant-count guard.
+per_block: checked and not executed — four measurement-origin blocks were sampled, but no Record compiler or energy-ledger block was executed in this campaign.
+lattice_wide: checked — full-row counts, Gauss charge, zero flux, gaps, covariance finiteness, and health minima were evaluated; L=18 V=0.95 reached min_forward=36.
+
+----- stderr -----
+RECOVERY_PROVENANCE: clean canonical replay captured from session 44554; row-parallel mode uses the unchanged predeclared seeds, populations, checks, and thresholds.
+RECOVERY_N5_NOTE: scope certificate appended after capture; no numerical runner line was edited.

--- a/logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.txt
+++ b/logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.txt
@@ -1,0 +1,35 @@
+===== runner cache v1 =====
+runner: scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py
+runner_sha256: b0556cf80af1a4515ca1a134c435dd40c011f0dfb058acd743c2948522e12af8
+input_fingerprint_sha256: fdcc14ffc3c6858b50f31961b5d5e16abf15ac74af70d21e0dd3f02a0d6904f9
+timeout_sec: 300
+exit_code: 1
+elapsed_sec: 0.80
+status: nonzero_exit
+----- stdout -----
+[FAIL] 01 the upstream replay receipt is green (diagnostic mode keeps this gate visible)
+[PASS] 02 the source-pinned parent and replay provide matched six-volume ladders
+[PASS] 03 every new F=6 primary gap reproduces the independent earlier infrared receipt
+[FAIL] 04 both detuned infrared volumes pass the paired primary-window forward plateau
+[PASS] 05 every paired forward endpoint gives a positive U K-compatible primary coefficient
+[PASS] 06 fixed central U K plus q-fourth and q-sixth passes at every forward endpoint
+[PASS] 07 mass and q-eighth extensions neither improve nor destabilize the primary fits
+[PASS] 08 primary direct detuned spectra carry U K-compatible weight while RK does not
+REPLAY_COMPARISON V=0.95 L=16 F6_z=0.8216
+REPLAY_COMPARISON V=0.95 L=18 F6_z=1.4836
+REPLAY_COMPARISON V=1.00 L=16 F6_z=1.3550
+REPLAY_COMPARISON V=1.00 L=18 F6_z=0.2304
+FORWARD_CONTROL V=0.95 L=16 window=8-14 hotelling=1.5660 max_contrast=1.2486 span=0.058093
+FORWARD_CONTROL V=0.95 L=18 window=8-14 hotelling=4.4771 max_contrast=0.8982 span=0.134976
+PRIMARY_MAXWELL F=6 c2=0.01987277+/-0.01062092 fixed_chi2=2.3749 fixed_delta_chi2=0.5098 mass2=0.00412205+/-0.00595380 q8_delta_chi2=0.8242 detuned_c2=0.01838359+/-0.01055544 RK_c2=-0.00014255+/-0.00068158
+EARLY_DIAGNOSTIC F=6 c2=0.03774352+/-0.00420894 RK_c2=-0.00064555+/-0.00042919 acceptance_role=none
+PRIMARY_MAXWELL F=12 c2=0.02398295+/-0.01465051 fixed_chi2=2.8177 fixed_delta_chi2=0.6371 mass2=0.00485274+/-0.00728856 q8_delta_chi2=1.1004 detuned_c2=0.02247244+/-0.01456585 RK_c2=-0.00014255+/-0.00068158
+EARLY_DIAGNOSTIC F=12 c2=0.02703654+/-0.00462002 RK_c2=-0.00064555+/-0.00042919 acceptance_role=none
+PRIMARY_MAXWELL F=20 c2=0.02821253+/-0.01666132 fixed_chi2=3.6057 fixed_delta_chi2=0.9134 mass2=0.01312812+/-0.00948377 q8_delta_chi2=2.4884 detuned_c2=0.02638221+/-0.01655280 RK_c2=-0.00014255+/-0.00068158
+EARLY_DIAGNOSTIC F=20 c2=0.03121580+/-0.00582742 RK_c2=-0.00064555+/-0.00042919 acceptance_role=none
+MAXWELL_TARGET UK=0.01228909+/-0.00116899
+CERTIFICATE: result_thresholds_predeclared=True new_lower_momenta=L16,L18 paired_forward_lengths=6,12,20 primary_window=8-14 early_window_diagnostic_only=True finite_volume=True thermodynamic_limit=False
+TOTAL: PASS=6 FAIL=2
+
+----- stderr -----
+RECOVERY_PROVENANCE: diagnostic join run after canonical replay cache reconstruction; --diagnostic keeps the upstream non-green gate visible and evaluates downstream controls for localization.

--- a/scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Predeclared high-genealogy, paired-forward L=16,18 replay.
+
+The earlier infrared receipt used one forward suffix and missed its declared
+tau=16 origin-diversity floor.  This independent replay raises the detuned
+population before looking at a new result and records F=6,12,20 endpoints
+from each shared trajectory.  A separate join owns every physics decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+import multiprocessing as mp
+
+import numpy as np
+
+from spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03 import (
+    build_geometry,
+    count_flippable,
+)
+from spin_half_cubic_ice_finite_delta_transverse_pole_2026_09_03 import (
+    effective_gap,
+    evaluate_observables,
+    prepare_population,
+    propagate_sweep,
+    transverse_coefficients,
+)
+from spin_half_cubic_ice_rk_coulomb_photon_phase_bridge_2026_09_03 import (
+    electric_flux,
+    initial_ice,
+    vertex_degrees,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_finite_delta_projector_stiffness_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_finite_delta_transverse_pole_2026_09_03.py",
+    "scripts/spin_half_cubic_ice_forward_length_ladder_2026_09_04.py",
+)
+
+AUDIT_TIMEOUT_SEC = 64800
+LENGTHS = (16, 18)
+FORWARD_LENGTHS = (6, 12, 20)
+WINDOWS = ((2, 6), (8, 14))
+PRIMARY_WINDOW = (8, 14)
+REPLICA_COUNT = 6
+DETUNED_POPULATION = 6144
+RK_POPULATION = 1536
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@dataclass(frozen=True)
+class MultiForwardReplica:
+    correlations: np.ndarray
+    population: int
+    energy: float
+    minimum_effective_fraction: float
+    origin_diversity_fractions: np.ndarray
+    forward_survival_fractions: np.ndarray
+    count_consistent: bool
+    sector_consistent: bool
+
+
+@dataclass(frozen=True)
+class PairedRow:
+    length: int
+    delta_v: float
+    gaps: dict[tuple[int, int], np.ndarray]
+    covariances: dict[tuple[int, int], np.ndarray]
+    mean_curves: np.ndarray
+    imaginary_residual: float
+    minimum_effective_fraction: float
+    minimum_origin_tau16_count: float
+    minimum_forward_count: float
+    count_consistent: bool
+    sector_consistent: bool
+
+
+def measure_multi_forward_block(
+    states: np.ndarray,
+    counts: np.ndarray,
+    delta_v: float,
+    coefficient_real: np.ndarray,
+    coefficient_imag: np.ndarray,
+    plaquette_links: np.ndarray,
+    affected_plaquettes: np.ndarray,
+    affected_counts: np.ndarray,
+    interval: int,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    float,
+    np.ndarray,
+    np.ndarray,
+]:
+    """Measure all forward suffixes on one shared population trajectory."""
+
+    population = states.shape[0]
+    tau_max = 16
+    tau_count = tau_max + 1
+    mode_count = coefficient_real.shape[0]
+    origin_observables = evaluate_observables(
+        states, coefficient_real, coefficient_imag
+    )
+    ancestors = np.arange(population, dtype=np.int32)
+    labels = np.full((tau_count, population), -1, dtype=np.int32)
+    tau_origins = np.full((tau_count, population), -1, dtype=np.int32)
+    tau_observables = np.zeros(
+        (tau_count, population, mode_count), dtype=np.complex128
+    )
+    labels[0] = np.arange(population, dtype=np.int32)
+    tau_origins[0] = ancestors
+    tau_observables[0] = origin_observables
+    correlations = np.zeros(
+        (len(FORWARD_LENGTHS), tau_count, mode_count),
+        dtype=np.complex128,
+    )
+    survival = np.zeros((len(FORWARD_LENGTHS), tau_count), dtype=float)
+    origin_diversity = np.zeros(tau_count, dtype=float)
+    origin_diversity[0] = 1.0
+    minimum_effective = float(population)
+    final_sweep = tau_max + max(FORWARD_LENGTHS)
+    for sweep in range(final_sweep + 1):
+        if 0 < sweep <= tau_max:
+            labels[sweep] = np.arange(population, dtype=np.int32)
+            tau_origins[sweep] = ancestors
+            tau_observables[sweep] = evaluate_observables(
+                states, coefficient_real, coefficient_imag
+            )
+            origin_diversity[sweep] = len(np.unique(ancestors)) / population
+        for forward_index, forward_sweeps in enumerate(FORWARD_LENGTHS):
+            if sweep < forward_sweeps:
+                continue
+            tau = sweep - forward_sweeps
+            if tau > tau_max:
+                continue
+            final_labels = labels[tau]
+            survival[forward_index, tau] = (
+                len(np.unique(final_labels)) / population
+            )
+            products = np.empty(
+                (population, mode_count), dtype=np.complex128
+            )
+            for walker, label in enumerate(final_labels):
+                origin = tau_origins[tau, label]
+                products[walker] = origin_observables[origin] * np.conjugate(
+                    tau_observables[tau, label]
+                )
+            correlations[forward_index, tau] = np.mean(products, axis=0)
+        if sweep == final_sweep:
+            break
+        states, counts, ancestors, labels, effective = propagate_sweep(
+            states,
+            counts,
+            ancestors,
+            labels,
+            delta_v,
+            plaquette_links,
+            affected_plaquettes,
+            affected_counts,
+            interval,
+        )
+        minimum_effective = min(minimum_effective, effective)
+    for forward_index in range(len(FORWARD_LENGTHS)):
+        correlations[forward_index] /= correlations[
+            forward_index, 0
+        ].real[None, :]
+    return (
+        states,
+        counts,
+        correlations,
+        minimum_effective,
+        origin_diversity,
+        survival,
+    )
+
+
+def run_replica(
+    length: int,
+    delta_v: float,
+    population: int,
+    seed: int,
+) -> MultiForwardReplica:
+    geometry = build_geometry(length)
+    interval = max(8, geometry.plaquette_count // 8)
+    while geometry.plaquette_count % interval:
+        interval -= 1
+    states, counts, mean_count, minimum_effective = prepare_population(
+        initial_ice(length).ravel(),
+        delta_v,
+        population,
+        100,
+        200 if delta_v else 120,
+        geometry.plaquette_links,
+        geometry.affected_plaquettes,
+        geometry.affected_counts,
+        interval,
+        seed,
+    )
+    coefficient_real, coefficient_imag, _ = transverse_coefficients(
+        length, (1,)
+    )
+    blocks = []
+    diversity_rows = []
+    survival_rows = []
+    minimum_dynamic_effective = float(population)
+    for origin_index in range(4):
+        (
+            states,
+            counts,
+            correlations,
+            effective,
+            diversity,
+            survival,
+        ) = measure_multi_forward_block(
+            states,
+            counts,
+            delta_v,
+            coefficient_real,
+            coefficient_imag,
+            geometry.plaquette_links,
+            geometry.affected_plaquettes,
+            geometry.affected_counts,
+            interval,
+        )
+        blocks.append(correlations)
+        diversity_rows.append(diversity)
+        survival_rows.append(survival)
+        minimum_dynamic_effective = min(minimum_dynamic_effective, effective)
+        if origin_index < 3:
+            ancestors = np.arange(population, dtype=np.int32)
+            labels = np.full((1, population), -1, dtype=np.int32)
+            for _ in range(3):
+                states, counts, ancestors, labels, effective = propagate_sweep(
+                    states,
+                    counts,
+                    ancestors,
+                    labels,
+                    delta_v,
+                    geometry.plaquette_links,
+                    geometry.affected_plaquettes,
+                    geometry.affected_counts,
+                    interval,
+                )
+                minimum_dynamic_effective = min(
+                    minimum_dynamic_effective, effective
+                )
+    reshaped = states.reshape((population, length, length, length, 3))
+    return MultiForwardReplica(
+        correlations=np.mean(np.asarray(blocks), axis=0),
+        population=population,
+        energy=delta_v * mean_count,
+        minimum_effective_fraction=min(
+            minimum_effective, minimum_dynamic_effective
+        )
+        / population,
+        origin_diversity_fractions=np.min(
+            np.asarray(diversity_rows), axis=0
+        ),
+        forward_survival_fractions=np.min(
+            np.asarray(survival_rows), axis=0
+        ),
+        count_consistent=all(
+            count_flippable(state, geometry.plaquette_links) == count
+            for state, count in zip(states, counts, strict=True)
+        ),
+        sector_consistent=all(
+            np.all(vertex_degrees(state) == 3)
+            and electric_flux(state) == (0, 0, 0)
+            for state in reshaped
+        ),
+    )
+
+
+def gap_vector(
+    curves: np.ndarray,
+    energies: np.ndarray,
+    length: int,
+    window: tuple[int, int],
+) -> np.ndarray:
+    return np.asarray(
+        [
+            effective_gap(
+                np.mean(curves[:, forward_index], axis=0).real,
+                length,
+                float(np.mean(energies)),
+                *window,
+            )
+            for forward_index in range(len(FORWARD_LENGTHS))
+        ]
+    )
+
+
+def summarize(
+    length: int,
+    delta_v: float,
+    replicas: list[MultiForwardReplica],
+) -> PairedRow:
+    curves = np.asarray(
+        [np.mean(replica.correlations, axis=2) for replica in replicas]
+    )
+    energies = np.asarray([replica.energy for replica in replicas])
+    gaps = {}
+    covariances = {}
+    for window in WINDOWS:
+        gaps[window] = gap_vector(curves, energies, length, window)
+        leave_one_out = []
+        for omitted in range(len(curves)):
+            mask = np.arange(len(curves)) != omitted
+            leave_one_out.append(
+                gap_vector(curves[mask], energies[mask], length, window)
+            )
+        jackknife = np.asarray(leave_one_out)
+        deviations = jackknife - np.mean(jackknife, axis=0)
+        covariances[window] = (
+            (len(jackknife) - 1.0)
+            / len(jackknife)
+            * deviations.T
+            @ deviations
+        )
+    mean_curves = np.mean(curves, axis=0)
+    return PairedRow(
+        length=length,
+        delta_v=delta_v,
+        gaps=gaps,
+        covariances=covariances,
+        mean_curves=mean_curves,
+        imaginary_residual=float(np.max(np.abs(mean_curves.imag))),
+        minimum_effective_fraction=min(
+            replica.minimum_effective_fraction for replica in replicas
+        ),
+        minimum_origin_tau16_count=min(
+            replica.population * replica.origin_diversity_fractions[16]
+            for replica in replicas
+        ),
+        minimum_forward_count=min(
+            replica.population * np.min(replica.forward_survival_fractions)
+            for replica in replicas
+        ),
+        count_consistent=all(replica.count_consistent for replica in replicas),
+        sector_consistent=all(replica.sector_consistent for replica in replicas),
+    )
+
+
+def run_row(
+    length: int,
+    delta_v: float,
+    population: int,
+    seed_root: int,
+    workers: int,
+) -> PairedRow:
+    futures = {}
+    replicas: dict[int, MultiForwardReplica] = {}
+    context = mp.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=workers, mp_context=context
+    ) as executor:
+        for replica_index in range(REPLICA_COUNT):
+            seed = seed_root + 1000 * length + replica_index
+            future = executor.submit(
+                run_replica, length, delta_v, population, seed
+            )
+            futures[future] = replica_index
+        for future in as_completed(futures):
+            replica_index = futures[future]
+            replicas[replica_index] = future.result()
+            print(
+                "REPLICA_DONE",
+                f"V={1.0 + delta_v:.2f}",
+                f"L={length}",
+                f"replica={replica_index + 1}/{REPLICA_COUNT}",
+                flush=True,
+            )
+    return summarize(
+        length,
+        delta_v,
+        [replicas[index] for index in range(REPLICA_COUNT)],
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workers", type=int, default=2)
+    arguments = parser.parse_args()
+    if not 1 <= arguments.workers <= 2:
+        raise SystemExit("--workers must be 1 or 2 on the 8 GiB host")
+
+    rows = []
+    for coupling_index, delta_v in enumerate((-0.05, 0.0)):
+        population = DETUNED_POPULATION if delta_v else RK_POPULATION
+        for length in LENGTHS:
+            row = run_row(
+                length,
+                delta_v,
+                population,
+                41_000_000 + 1_000_000 * coupling_index,
+                arguments.workers,
+            )
+            rows.append(row)
+            for window in WINDOWS:
+                errors = np.sqrt(np.diag(row.covariances[window]))
+                print(
+                    "PAIRED_ROW",
+                    f"V={1.0 + delta_v:.2f}",
+                    f"L={length}",
+                    f"window={window[0]}-{window[1]}",
+                    "gaps="
+                    + ",".join(
+                        f"{forward}:{row.gaps[window][index]:.8f}"
+                        f"+/-{errors[index]:.8f}"
+                        for index, forward in enumerate(FORWARD_LENGTHS)
+                    ),
+                    "cov="
+                    + ",".join(
+                        f"{value:.12e}"
+                        for value in row.covariances[window].ravel()
+                    ),
+                    flush=True,
+                )
+            print(
+                "ROW_HEALTH",
+                f"V={1.0 + delta_v:.2f}",
+                f"L={length}",
+                f"min_ess={row.minimum_effective_fraction:.6f}",
+                f"min_origin_tau16={row.minimum_origin_tau16_count:.0f}",
+                f"min_forward={row.minimum_forward_count:.0f}",
+                flush=True,
+            )
+
+    checks = Checks()
+    checks.check(
+        all(row.count_consistent and row.sector_consistent for row in rows),
+        "every replay population preserves exact counts, Gauss charge, "
+        "and zero electric flux",
+    )
+    checks.check(
+        min(row.minimum_effective_fraction for row in rows) > 0.85
+        and min(row.minimum_origin_tau16_count for row in rows) >= 40
+        and min(row.minimum_forward_count for row in rows) >= 40,
+        "every replay population satisfies the pre-existing weight and "
+        "genealogy floors",
+    )
+    checks.check(
+        all(
+            np.all(row.mean_curves.real > 0.0)
+            and row.imaginary_residual < 0.06
+            and all(
+                np.all(np.isfinite(row.gaps[window]))
+                and np.all(row.gaps[window] > 0.0)
+                and np.all(np.isfinite(row.covariances[window]))
+                for window in WINDOWS
+            )
+            for row in rows
+        ),
+        "every paired-forward correlator, gap, and covariance is finite and positive",
+    )
+    detuned = [row for row in rows if row.delta_v]
+    rk = [row for row in rows if not row.delta_v]
+    checks.check(
+        all(
+            np.linalg.matrix_rank(
+                row.covariances[PRIMARY_WINDOW], tol=1.0e-14
+            )
+            == len(FORWARD_LENGTHS)
+            for row in detuned
+        )
+        and all(
+            np.all(row.gaps[window] == row.gaps[window][0])
+            for row in rk
+            for window in WINDOWS
+        ),
+        "detuned primary covariances are full rank and RK forward identity is exact",
+    )
+    print(
+        "CERTIFICATE: lower_momenta=L16,L18 replicas=6 "
+        "detuned_population=6144 rk_population=1536 "
+        "paired_forward_lengths=6,12,20 measurement_origins=4 "
+        "primary_window=8-14 finite_volume=True thermodynamic_limit=False"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py
@@ -10,7 +10,11 @@ from each shared trajectory.  A separate join owns every physics decision.
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import (
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    as_completed,
+)
 from dataclasses import dataclass
 import multiprocessing as mp
 
@@ -395,54 +399,90 @@ def run_row(
     )
 
 
+def emit_row(row: PairedRow) -> None:
+    """Emit one row in the stable receipt format after it closes."""
+    for window in WINDOWS:
+        errors = np.sqrt(np.diag(row.covariances[window]))
+        print(
+            "PAIRED_ROW",
+            f"V={1.0 + row.delta_v:.2f}",
+            f"L={row.length}",
+            f"window={window[0]}-{window[1]}",
+            "gaps="
+            + ",".join(
+                f"{forward}:{row.gaps[window][index]:.8f}"
+                f"+/-{errors[index]:.8f}"
+                for index, forward in enumerate(FORWARD_LENGTHS)
+            ),
+            "cov="
+            + ",".join(
+                f"{value:.12e}" for value in row.covariances[window].ravel()
+            ),
+            flush=True,
+        )
+    print(
+        "ROW_HEALTH",
+        f"V={1.0 + row.delta_v:.2f}",
+        f"L={row.length}",
+        f"min_ess={row.minimum_effective_fraction:.6f}",
+        f"min_origin_tau16={row.minimum_origin_tau16_count:.0f}",
+        f"min_forward={row.minimum_forward_count:.0f}",
+        flush=True,
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument(
+        "--parallel-rows",
+        action="store_true",
+        help="run the four independent coupling/volume rows concurrently",
+    )
     arguments = parser.parse_args()
     if not 1 <= arguments.workers <= 2:
         raise SystemExit("--workers must be 1 or 2 on the 8 GiB host")
 
-    rows = []
-    for coupling_index, delta_v in enumerate((-0.05, 0.0)):
-        population = DETUNED_POPULATION if delta_v else RK_POPULATION
-        for length in LENGTHS:
+    row_specs = [
+        (
+            coupling_index,
+            delta_v,
+            LENGTHS[length_index],
+            DETUNED_POPULATION if delta_v else RK_POPULATION,
+            41_000_000 + 1_000_000 * coupling_index,
+        )
+        for coupling_index, delta_v in enumerate((-0.05, 0.0))
+        for length_index in range(len(LENGTHS))
+    ]
+    rows_by_key: dict[tuple[int, int], PairedRow] = {}
+    if arguments.parallel_rows:
+        with ThreadPoolExecutor(max_workers=len(row_specs)) as executor:
+            futures = {
+                executor.submit(
+                    run_row, length, delta_v, population, seed_root, arguments.workers
+                ): (coupling_index, length)
+                for coupling_index, delta_v, length, population, seed_root in row_specs
+            }
+            for future in as_completed(futures):
+                key = futures[future]
+                row = future.result()
+                rows_by_key[key] = row
+                emit_row(row)
+    else:
+        for coupling_index, delta_v, length, population, seed_root in row_specs:
             row = run_row(
                 length,
                 delta_v,
                 population,
-                41_000_000 + 1_000_000 * coupling_index,
+                seed_root,
                 arguments.workers,
             )
-            rows.append(row)
-            for window in WINDOWS:
-                errors = np.sqrt(np.diag(row.covariances[window]))
-                print(
-                    "PAIRED_ROW",
-                    f"V={1.0 + delta_v:.2f}",
-                    f"L={length}",
-                    f"window={window[0]}-{window[1]}",
-                    "gaps="
-                    + ",".join(
-                        f"{forward}:{row.gaps[window][index]:.8f}"
-                        f"+/-{errors[index]:.8f}"
-                        for index, forward in enumerate(FORWARD_LENGTHS)
-                    ),
-                    "cov="
-                    + ",".join(
-                        f"{value:.12e}"
-                        for value in row.covariances[window].ravel()
-                    ),
-                    flush=True,
-                )
-            print(
-                "ROW_HEALTH",
-                f"V={1.0 + delta_v:.2f}",
-                f"L={length}",
-                f"min_ess={row.minimum_effective_fraction:.6f}",
-                f"min_origin_tau16={row.minimum_origin_tau16_count:.0f}",
-                f"min_forward={row.minimum_forward_count:.0f}",
-                flush=True,
-            )
+            rows_by_key[(coupling_index, length)] = row
+            emit_row(row)
+    rows = [
+        rows_by_key[(coupling_index, length)]
+        for coupling_index, _delta_v, length, _population, _seed_root in row_specs
+    ]
 
     checks = Checks()
     checks.check(

--- a/scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import re
+import sys
 
 import numpy as np
 
@@ -134,18 +135,37 @@ def parse_rows(text: str) -> dict[tuple[float, int, tuple[int, int]], PairedEsti
     return rows
 
 
-def parse_replay() -> dict[tuple[float, int, tuple[int, int]], PairedEstimate]:
+def parse_replay(
+    *, allow_nonzero: bool = False
+) -> dict[tuple[float, int, tuple[int, int]], PairedEstimate]:
     text = DATA_CACHE.read_text(encoding="utf-8")
-    required = (
+    identity_required = (
         "runner: scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py",
+        "primary_window=8-14",
+    )
+    if any(token not in text for token in identity_required):
+        raise RuntimeError("high-genealogy replay receipt is incomplete")
+    green_required = (
         "status: ok",
         "exit_code: 0",
-        "primary_window=8-14",
         "TOTAL: PASS=4 FAIL=0",
     )
-    if any(token not in text for token in required):
+    if not allow_nonzero and any(token not in text for token in green_required):
         raise RuntimeError("high-genealogy replay receipt is not green")
     return parse_rows(text)
+
+
+def replay_receipt_is_green() -> bool:
+    """Return the upstream replay status without changing strict parsing."""
+    text = DATA_CACHE.read_text(encoding="utf-8")
+    return all(
+        token in text
+        for token in (
+            "status: ok",
+            "exit_code: 0",
+            "TOTAL: PASS=4 FAIL=0",
+        )
+    )
 
 
 def parse_old_rows() -> dict[tuple[float, int, tuple[int, int]], WindowEstimate]:
@@ -245,7 +265,13 @@ def compatible(
 
 def main() -> int:
     checks = Checks()
-    replay = parse_replay()
+    diagnostic = "--diagnostic" in sys.argv[1:]
+    replay = parse_replay(allow_nonzero=diagnostic)
+    if diagnostic:
+        checks.check(
+            replay_receipt_is_green(),
+            "the upstream replay receipt is green (diagnostic mode keeps this gate visible)",
+        )
     old = parse_old_rows()
     parent_detuned, parent_rk = parse_ladder_cache(
         "spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt",

--- a/scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py
+++ b/scripts/spin_half_cubic_ice_infrared_forward_replay_join_2026_09_04.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Predeclared decision surface for the high-genealogy infrared replay."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+import numpy as np
+
+from spin_half_cubic_ice_infrared_forward_replay_2026_09_04 import (
+    FORWARD_LENGTHS,
+    PRIMARY_WINDOW,
+    WINDOWS,
+)
+from spin_half_cubic_ice_infrared_maxwell_join_2026_09_04 import (
+    fit_polynomial_excess,
+    fit_polynomial_spectrum,
+    parse_ladder_cache,
+    parse_static_maxwell_target,
+)
+from spin_half_cubic_ice_late_time_maxwell_join_2026_09_04 import (
+    LadderRow,
+    WindowEstimate,
+    fit_higher_gradient_excess,
+)
+
+
+AUDIT_INPUT_PATHS = (
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py",
+    "logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt",
+    "scripts/spin_half_cubic_ice_infrared_ladder_2026_09_04.py",
+    "logs/runner-cache/spin_half_cubic_ice_infrared_ladder_2026_09_04.txt",
+    "scripts/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py",
+    "logs/runner-cache/spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt",
+    "scripts/spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.py",
+    "logs/runner-cache/"
+    "spin_half_cubic_ice_finite_delta_charge_coulomb_join_2026_09_03.txt",
+    "scripts/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.py",
+    "logs/runner-cache/spin_half_cubic_ice_finite_delta_magnetic_twist_2026_09_04.txt",
+)
+
+AUDIT_TIMEOUT_SEC = 300
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_CACHE = (
+    REPO_ROOT
+    / "logs/runner-cache/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.txt"
+)
+OLD_CACHE = (
+    REPO_ROOT
+    / "logs/runner-cache/spin_half_cubic_ice_infrared_ladder_2026_09_04.txt"
+)
+HOTELLING_LIMIT = 17.361
+STUDENT_LIMIT = 2.571
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, condition: bool, label: str) -> None:
+        if condition:
+            self.passed += 1
+            print(f"[PASS] {self.passed + self.failed:02d} {label}")
+        else:
+            self.failed += 1
+            print(f"[FAIL] {self.passed + self.failed:02d} {label}")
+
+
+@dataclass(frozen=True)
+class PairedEstimate:
+    gaps: np.ndarray
+    errors: np.ndarray
+    covariance: np.ndarray
+
+
+@dataclass(frozen=True)
+class ForwardControl:
+    hotelling: float
+    maximum_contrast: float
+    relative_span: float
+
+
+def parse_rows(text: str) -> dict[tuple[float, int, tuple[int, int]], PairedEstimate]:
+    row_pattern = re.compile(
+        r"^PAIRED_ROW V=(?P<coupling>0\.95|1\.00) "
+        r"L=(?P<length>16|18) window=(?P<start>2|8)-(?P<stop>6|14) "
+        r"gaps=(?P<gaps>\S+) cov=(?P<cov>\S+)$",
+        re.MULTILINE,
+    )
+    gap_pattern = re.compile(
+        r"(?P<forward>6|12|20):(?P<gap>[0-9.]+)"
+        r"\+/-?(?P<error>[0-9.]+)"
+    )
+    rows = {}
+    for match in row_pattern.finditer(text):
+        parsed = {
+            int(item.group("forward")): (
+                float(item.group("gap")),
+                float(item.group("error")),
+            )
+            for item in gap_pattern.finditer(match.group("gaps"))
+        }
+        if tuple(parsed) != FORWARD_LENGTHS:
+            raise RuntimeError("paired-forward row has the wrong endpoint set")
+        covariance_values = np.asarray(
+            [float(value) for value in match.group("cov").split(",")]
+        )
+        if len(covariance_values) != len(FORWARD_LENGTHS) ** 2:
+            raise RuntimeError("paired-forward covariance has the wrong size")
+        key = (
+            float(match.group("coupling")),
+            int(match.group("length")),
+            (int(match.group("start")), int(match.group("stop"))),
+        )
+        rows[key] = PairedEstimate(
+            gaps=np.asarray([parsed[value][0] for value in FORWARD_LENGTHS]),
+            errors=np.asarray([parsed[value][1] for value in FORWARD_LENGTHS]),
+            covariance=covariance_values.reshape(
+                (len(FORWARD_LENGTHS), len(FORWARD_LENGTHS))
+            ),
+        )
+    expected = {
+        (coupling, length, window)
+        for coupling in (0.95, 1.0)
+        for length in (16, 18)
+        for window in WINDOWS
+    }
+    if set(rows) != expected:
+        raise RuntimeError("paired-forward receipt is incomplete")
+    return rows
+
+
+def parse_replay() -> dict[tuple[float, int, tuple[int, int]], PairedEstimate]:
+    text = DATA_CACHE.read_text(encoding="utf-8")
+    required = (
+        "runner: scripts/spin_half_cubic_ice_infrared_forward_replay_2026_09_04.py",
+        "status: ok",
+        "exit_code: 0",
+        "primary_window=8-14",
+        "TOTAL: PASS=4 FAIL=0",
+    )
+    if any(token not in text for token in required):
+        raise RuntimeError("high-genealogy replay receipt is not green")
+    return parse_rows(text)
+
+
+def parse_old_rows() -> dict[tuple[float, int, tuple[int, int]], WindowEstimate]:
+    text = OLD_CACHE.read_text(encoding="utf-8")
+    required = (
+        "runner: scripts/spin_half_cubic_ice_infrared_ladder_2026_09_04.py",
+        "status: nonzero_exit",
+        "TOTAL: PASS=2 FAIL=1",
+    )
+    if any(token not in text for token in required):
+        raise RuntimeError("old infrared boundary receipt changed")
+    row_pattern = re.compile(
+        r"^ROW_DONE V=(?P<coupling>0\.95|1\.00) L=(?P<length>16|18) "
+        r"gaps=(?P<gaps>.+)$",
+        re.MULTILINE,
+    )
+    gap_pattern = re.compile(
+        r"(?P<start>\d+)-(?P<stop>\d+):(?P<gap>[0-9.]+)"
+        r"\+/-?(?P<error>[0-9.]+)"
+    )
+    rows = {}
+    for row_match in row_pattern.finditer(text):
+        coupling = float(row_match.group("coupling"))
+        length = int(row_match.group("length"))
+        for item in gap_pattern.finditer(row_match.group("gaps")):
+            window = (int(item.group("start")), int(item.group("stop")))
+            rows[(coupling, length, window)] = WindowEstimate(
+                *window,
+                float(item.group("gap")),
+                float(item.group("error")),
+            )
+    if any(
+        (coupling, length, PRIMARY_WINDOW) not in rows
+        for coupling in (0.95, 1.0)
+        for length in (16, 18)
+    ):
+        raise RuntimeError("old infrared boundary rows are incomplete")
+    return rows
+
+
+def as_ladder_rows(
+    rows: dict[tuple[float, int, tuple[int, int]], PairedEstimate],
+    coupling: float,
+    forward_index: int,
+) -> list[LadderRow]:
+    result = []
+    for length in (16, 18):
+        estimates = {
+            window: WindowEstimate(
+                *window,
+                rows[(coupling, length, window)].gaps[forward_index],
+                rows[(coupling, length, window)].errors[forward_index],
+            )
+            for window in WINDOWS
+        }
+        result.append(
+            LadderRow(
+                length=length,
+                delta_v=coupling - 1.0,
+                windows=estimates,
+                mean_curve=np.ones(17, dtype=np.complex128),
+                mean_energy=0.0,
+                imaginary_residual=0.0,
+                minimum_effective_fraction=1.0,
+                minimum_origin_tau16_count=1.0e9,
+                minimum_forward_count=1.0e9,
+                count_consistent=True,
+                sector_consistent=True,
+            )
+        )
+    return result
+
+
+def forward_control(row: PairedEstimate) -> ForwardControl:
+    contrast = np.asarray(((-1.0, 1.0, 0.0), (-1.0, 0.0, 1.0)))
+    differences = contrast @ row.gaps
+    covariance = contrast @ row.covariance @ contrast.T
+    errors = np.sqrt(np.maximum(np.diag(covariance), 0.0))
+    return ForwardControl(
+        hotelling=float(differences @ np.linalg.inv(covariance) @ differences),
+        maximum_contrast=float(np.max(np.abs(differences) / errors)),
+        relative_span=float(np.ptp(row.gaps) / np.mean(row.gaps)),
+    )
+
+
+def compatible(
+    first_value: float,
+    first_error: float,
+    second_value: float,
+    second_error: float,
+    threshold: float = 2.0,
+) -> bool:
+    return abs(first_value - second_value) < threshold * np.hypot(
+        first_error, second_error
+    )
+
+
+def main() -> int:
+    checks = Checks()
+    replay = parse_replay()
+    old = parse_old_rows()
+    parent_detuned, parent_rk = parse_ladder_cache(
+        "spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.txt",
+        "spin_half_cubic_ice_late_time_maxwell_join_2026_09_04.py",
+        "TOTAL: PASS=11 FAIL=0",
+        (8, 10, 12, 14),
+    )
+    checks.check(
+        [row.length for row in parent_detuned] == [8, 10, 12, 14]
+        and [row.length for row in parent_rk] == [8, 10, 12, 14],
+        "the source-pinned parent and replay provide matched six-volume ladders",
+    )
+
+    replay_z = {}
+    for coupling in (0.95, 1.0):
+        for length in (16, 18):
+            current = replay[(coupling, length, PRIMARY_WINDOW)]
+            previous = old[(coupling, length, PRIMARY_WINDOW)]
+            replay_z[(coupling, length)] = abs(
+                current.gaps[0] - previous.gap
+            ) / np.hypot(current.errors[0], previous.gap_error)
+    checks.check(
+        max(replay_z.values()) < 2.0,
+        "every new F=6 primary gap reproduces the independent earlier infrared receipt",
+    )
+
+    controls = {
+        length: forward_control(replay[(0.95, length, PRIMARY_WINDOW)])
+        for length in (16, 18)
+    }
+    checks.check(
+        all(
+            control.hotelling < HOTELLING_LIMIT
+            and control.maximum_contrast < STUDENT_LIMIT
+            and control.relative_span < 0.05
+            for control in controls.values()
+        ),
+        "both detuned infrared volumes pass the paired primary-window forward plateau",
+    )
+
+    maxwell_c_squared, maxwell_c_squared_error = parse_static_maxwell_target()
+    fits = {}
+    for forward_index, forward in enumerate(FORWARD_LENGTHS):
+        detuned = parent_detuned + as_ladder_rows(
+            replay, 0.95, forward_index
+        )
+        rk = parent_rk + as_ladder_rows(replay, 1.0, forward_index)
+        higher = fit_higher_gradient_excess(
+            detuned,
+            rk,
+            PRIMARY_WINDOW,
+            maxwell_c_squared,
+            maxwell_c_squared_error,
+        )
+        mass = fit_polynomial_excess(
+            detuned, rk, PRIMARY_WINDOW, (0, 2, 4, 6)
+        )
+        q8 = fit_polynomial_excess(
+            detuned, rk, PRIMARY_WINDOW, (2, 4, 6, 8)
+        )
+        direct_detuned = fit_polynomial_spectrum(
+            detuned, PRIMARY_WINDOW, (2, 4, 6)
+        )
+        direct_rk = fit_polynomial_spectrum(
+            rk, PRIMARY_WINDOW, (2, 4, 6)
+        )
+        early_higher = fit_higher_gradient_excess(
+            detuned,
+            rk,
+            WINDOWS[0],
+            maxwell_c_squared,
+            maxwell_c_squared_error,
+        )
+        early_rk = fit_polynomial_spectrum(rk, WINDOWS[0], (2, 4, 6))
+        fits[forward] = (
+            higher,
+            mass,
+            q8,
+            direct_detuned,
+            direct_rk,
+            early_higher,
+            early_rk,
+        )
+
+    checks.check(
+        all(
+            higher.c_squared > 0.0
+            and compatible(
+                higher.c_squared,
+                higher.c_squared_error,
+                maxwell_c_squared,
+                maxwell_c_squared_error,
+            )
+            for higher, *_ in fits.values()
+        ),
+        "every paired forward endpoint gives a positive U K-compatible "
+        "primary coefficient",
+    )
+    checks.check(
+        all(
+            higher.fixed_chi_squared < 9.488
+            and higher.fixed_delta_chi_squared < 3.841
+            for higher, *_ in fits.values()
+        ),
+        "fixed central U K plus q-fourth and q-sixth passes at every forward endpoint",
+    )
+    checks.check(
+        all(
+            abs(mass.coefficients[0])
+            < 2.0 * mass.coefficient_errors[0]
+            and higher.chi_squared - mass.chi_squared < 3.841
+            and higher.chi_squared - q8.chi_squared < 3.841
+            and compatible(
+                q8.coefficients[0],
+                q8.coefficient_errors[0],
+                higher.c_squared,
+                higher.c_squared_error,
+            )
+            for higher, mass, q8, *_ in fits.values()
+        ),
+        "mass and q-eighth extensions neither improve nor destabilize the primary fits",
+    )
+    checks.check(
+        all(
+            direct_detuned.coefficients[0] > 0.0
+            and compatible(
+                direct_detuned.coefficients[0],
+                direct_detuned.coefficient_errors[0],
+                maxwell_c_squared,
+                maxwell_c_squared_error,
+            )
+            and abs(direct_rk.coefficients[0])
+            < 2.0 * direct_rk.coefficient_errors[0]
+            and direct_detuned.chi_squared < 7.815
+            and direct_rk.chi_squared < 7.815
+            for _, _, _, direct_detuned, direct_rk, _, _ in fits.values()
+        ),
+        "primary direct detuned spectra carry U K-compatible weight while RK does not",
+    )
+
+    for (coupling, length), value in replay_z.items():
+        print(
+            "REPLAY_COMPARISON",
+            f"V={coupling:.2f}",
+            f"L={length}",
+            f"F6_z={value:.4f}",
+        )
+    for length, control in controls.items():
+        print(
+            "FORWARD_CONTROL",
+            f"V=0.95 L={length}",
+            f"window={PRIMARY_WINDOW[0]}-{PRIMARY_WINDOW[1]}",
+            f"hotelling={control.hotelling:.4f}",
+            f"max_contrast={control.maximum_contrast:.4f}",
+            f"span={control.relative_span:.6f}",
+        )
+    for forward, values in fits.items():
+        higher, mass, q8, direct_detuned, direct_rk, early, early_rk = values
+        print(
+            "PRIMARY_MAXWELL",
+            f"F={forward}",
+            f"c2={higher.c_squared:.8f}+/-{higher.c_squared_error:.8f}",
+            f"fixed_chi2={higher.fixed_chi_squared:.4f}",
+            f"fixed_delta_chi2={higher.fixed_delta_chi_squared:.4f}",
+            f"mass2={mass.coefficients[0]:.8f}"
+            f"+/-{mass.coefficient_errors[0]:.8f}",
+            f"q8_delta_chi2={higher.chi_squared - q8.chi_squared:.4f}",
+            f"detuned_c2={direct_detuned.coefficients[0]:.8f}"
+            f"+/-{direct_detuned.coefficient_errors[0]:.8f}",
+            f"RK_c2={direct_rk.coefficients[0]:.8f}"
+            f"+/-{direct_rk.coefficient_errors[0]:.8f}",
+        )
+        print(
+            "EARLY_DIAGNOSTIC",
+            f"F={forward}",
+            f"c2={early.c_squared:.8f}+/-{early.c_squared_error:.8f}",
+            f"RK_c2={early_rk.coefficients[0]:.8f}"
+            f"+/-{early_rk.coefficient_errors[0]:.8f}",
+            "acceptance_role=none",
+        )
+    print(
+        "MAXWELL_TARGET",
+        f"UK={maxwell_c_squared:.8f}+/-{maxwell_c_squared_error:.8f}",
+    )
+    print(
+        "CERTIFICATE: result_thresholds_predeclared=True "
+        "new_lower_momenta=L16,L18 paired_forward_lengths=6,12,20 "
+        "primary_window=8-14 early_window_diagnostic_only=True "
+        "finite_volume=True thermodynamic_limit=False"
+    )
+    print(f"TOTAL: PASS={checks.passed} FAIL={checks.failed}")
+    return 0 if checks.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR now carries the completed clean recovery of the predeclared high-genealogy paired-forward replay.

- Canonical replay: six replicas at each `V=0.95/1.00`, `L=16,18`, shared `F=6,12,20`, four measurement origins, detuned population `6144`, RK population `1536`.
- Receipt: `TOTAL: PASS=3 FAIL=1`. Exact flippable counts, Gauss charge, zero flux, finite positive gaps/covariances, detuned covariance rank, and RK forward identity pass. The sole runner guard failure is `V=0.95, L=18, min_forward=36` against the frozen `>=40` floor (`min_ess=0.943968`, `min_origin_tau16=57`).
- Strict join behavior is preserved: a non-green replay remains a hard stop. The new explicit `--diagnostic` mode evaluates the rows without relaxing that gate and reports `TOTAL: PASS=6 FAIL=2`; only the upstream-green and paired-primary-forward-plateau checks fail. The Maxwell-fit, reproduction, model-extension, direct-spectrum, and RK-control checks pass as localization diagnostics, not as a promoted theorem.
- The optional `--parallel-rows` path is scheduling-only: it calls the existing `run_row`, seeds, populations, thresholds, and emission format, then restores stable row order.

The bounded result and exact paired rows are in [the recovery boundary note](docs/SPIN_HALF_CUBIC_ICE_INFRARED_FORWARD_REPLAY_RECOVERY_BOUNDARY_NOTE_2026-09-05.md). The required narrow N1-N8 packet is [here](docs/NO_GO_DISCIPLINE_CHECKLIST_SPIN_HALF_INFRARED_FORWARD_REPLAY_2026-09-05.md). No axiom, primitive, audit verdict, or TOE score is changed. The finite-volume supplied-carrier result does not retire the Record/matter assumptions; the next high-value step remains a local CAR-to-physical-Record compiler and a repeated active matter/apparatus cycle with one exact particle-and-energy ledger and no fresh-state reset (PRs #7979/#7983).

Validation: both runners compile; independent receipt/covariance assertions pass; `vocab_lint.py` reports no violations; `audit_lint.py --strict` reports no errors; the full audit pipeline reaches all semantic stages and stops only at the expected citation-manifest delta, which is included here.

Head: `369f785003`.
