### PR TITLE
workflow: include complete open PR science in frontier selection

### DIFF
--- a/docs/ai_methodology/skills/physics-loop/SKILL.md
+++ b/docs/ai_methodology/skills/physics-loop/SKILL.md
@@ -678,6 +678,32 @@ For publication-facing or quantitative work, also inspect
 2. **Ground, then sweep for prior art.** Build the current lane map from repo
    authority surfaces rather than memory.
 
+   **Include the open PR science, not only main.** Main owns adopted premises
+   and status; open PRs can already contain the newest results, counterexamples,
+   or stronger versions of a proposed target. At campaign intake, read the open
+   proposals' bodies, changed primary science notes, evidence and substantive
+   review findings. Keep a per-PR receipt binding its captured identity and what was actually
+   read; a title inventory is not scientific coverage. Reuse matching receipts
+   and refresh new or changed proposals before choosing later blocks. Treat
+   proposed results as prior art to inspect, never as audited authority.
+
+   `scripts/open_pr_science_coverage.py capture --repo OWNER/REPO --output current.json`
+   checks the total open count, records head/base commits, recovers paginated
+   changed-file lists (the `gh pr list` file field can stop at 100), and rejects
+   observed capture drift. After reading a proposal in the saved snapshot, use
+   `receipt --reviewed current.json --number N --read-coverage 'Describe the surfaces read and any limits'`
+   to emit its JSONL receipt. Preserve that snapshot with the receipt. Its
+   offline `check --current current.json --reviewed reviewed.json --receipts reads.jsonl`
+   compares a saved reviewed inventory with JSONL receipts containing `number`,
+   `head`, `inventory_identity`, and a nonempty `read_coverage` description.
+   The identity binds the proposal text and metadata as well as the commits;
+   replacing the reviewed snapshot cannot refresh an old receipt. Exit 0 means matching
+   declared coverage, 1 means missing/stale receipts, and 2 means invalid inputs.
+   The description is self-reported; the tool checks only its presence, cannot
+   verify that a person or model read or understood a note, and assigns no
+   scientific grade. `updatedAt` is a conservative metadata-change signal, not
+   a stored review-discussion transcript; inspect the discussion when refreshing.
+
    **Then search the repo for the result you are about to produce, before you
    produce it.** This is a hard prerequisite, not a courtesy. The failure mode
    was observed on 2026-07-25: a cycle derived that a finite-dimensional

--- a/scripts/open_pr_science_coverage.py
+++ b/scripts/open_pr_science_coverage.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Capture complete open-PR inventories and compare declared reading coverage.
+
+Coverage means a matching, self-reported reading receipt, not scientific
+correctness, proof review, audit status, or permission to land a PR. Capture
+uses the authenticated gh CLI read-only; check works entirely offline.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+FIELDS = "number,title,body,headRefOid,baseRefName,baseRefOid,updatedAt,isDraft,files,changedFiles,url"
+INDEX_FIELDS = "number,headRefOid,baseRefOid,updatedAt,changedFiles"
+TOTAL_QUERY = """query($owner:String!,$name:String!){repository(owner:$owner,name:$name){
+pullRequests(states:OPEN){totalCount}}}"""
+
+
+class CoverageError(ValueError):
+    """Invalid or incomplete evidence for planning coverage."""
+
+
+def gh_json(*args: str):
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if result.returncode:
+        raise CoverageError(f"gh read failed: {result.stderr.strip()}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise CoverageError("gh returned invalid JSON") from exc
+
+
+def inventory_rows(inventory: dict, *, allow_capped_files: bool = False) -> dict[int, dict]:
+    if not isinstance(inventory, dict) or inventory.get("schema_version") != 1:
+        raise CoverageError("inventory needs schema_version: 1")
+    if not isinstance(inventory.get("repository"), str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", inventory["repository"]
+    ):
+        raise CoverageError("inventory needs repository")
+    prs = inventory.get("pull_requests")
+    count = inventory.get("total_count")
+    if not isinstance(prs, list) or type(count) is not int or count != len(prs):
+        raise CoverageError("open-PR total_count does not match the supplied list")
+    rows = {}
+    for pr in prs:
+        if not isinstance(pr, dict):
+            raise CoverageError("each PR must be an object")
+        number = pr.get("number")
+        if type(number) is not int or number < 1 or number in rows:
+            raise CoverageError(f"invalid or duplicate PR number: {number!r}")
+        for field in ("headRefOid", "baseRefOid"):
+            if not isinstance(pr.get(field), str) or not re.fullmatch(r"[0-9a-f]{40}", pr[field]):
+                raise CoverageError(f"PR #{number}: missing full {field} commit")
+        for field in ("title", "body", "baseRefName", "updatedAt", "url"):
+            if not isinstance(pr.get(field), str):
+                raise CoverageError(f"PR #{number}: missing {field}")
+        if type(pr.get("isDraft")) is not bool:
+            raise CoverageError(f"PR #{number}: missing isDraft")
+        files, expected = pr.get("files"), pr.get("changedFiles")
+        if (not isinstance(files, list) or type(expected) is not int or expected < 0
+                or len(files) > expected or (not allow_capped_files and len(files) != expected)):
+            raise CoverageError(f"PR #{number}: incomplete changed-file list (expected {expected})")
+        paths = set()
+        for file in files:
+            if not isinstance(file, dict) or not isinstance(file.get("path"), str):
+                raise CoverageError(f"PR #{number}: malformed file entry")
+            path = file["path"]
+            if not path or path in paths:
+                raise CoverageError(f"PR #{number}: empty or duplicate file path")
+            paths.add(path)
+            for field in ("additions", "deletions"):
+                if type(file.get(field)) is not int or file[field] < 0:
+                    raise CoverageError(f"PR #{number}: invalid {field} for {path}")
+        rows[number] = pr
+    return rows
+
+
+def identity(pr: dict) -> str:
+    """Bind head/base, proposal text, file set and discussion-change signal."""
+    payload = {field: pr[field] for field in FIELDS.split(",") if field != "files"}
+    payload["files"] = sorted(pr["files"], key=lambda item: item["path"])
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def index_signature(prs: list[dict]) -> list[tuple]:
+    if not isinstance(prs, list):
+        raise CoverageError("malformed final PR index")
+    try:
+        return sorted(tuple(pr[field] for field in INDEX_FIELDS.split(",")) for pr in prs)
+    except (KeyError, TypeError) as exc:
+        raise CoverageError("malformed final PR index") from exc
+
+
+def capture(repository: str) -> dict:
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise CoverageError("repository must be owner/name")
+    owner, name = repository.split("/")
+    total_result = gh_json("api", "graphql", "-f", f"query={TOTAL_QUERY}",
+                           "-F", f"owner={owner}", "-F", f"name={name}")
+    try:
+        total = total_result["data"]["repository"]["pullRequests"]["totalCount"]
+    except (KeyError, TypeError) as exc:
+        raise CoverageError("could not read the repository's open-PR total") from exc
+    if type(total) is not int or total < 0:
+        raise CoverageError("invalid open-PR total")
+    limit = str(max(1, total + 1))
+    prs = gh_json("pr", "list", "--repo", repository, "--state", "open", "--limit", limit,
+                  "--json", FIELDS)
+    if not isinstance(prs, list) or len(prs) != total:
+        raise CoverageError("open PR set changed during capture; retry with a fresh snapshot")
+    inventory = {"schema_version": 1, "repository": repository, "total_count": total,
+                 "pull_requests": prs}
+    inventory_rows(inventory, allow_capped_files=True)
+    for pr in prs:
+        if len(pr["files"]) != pr["changedFiles"]:
+            pages = gh_json("api", f"repos/{repository}/pulls/{pr['number']}/files?per_page=100",
+                            "--paginate", "--slurp")
+            try:
+                if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+                    raise CoverageError(f"PR #{pr['number']}: malformed paginated files")
+                pr["files"] = [{"path": f["filename"], "additions": f["additions"],
+                                "deletions": f["deletions"]} for page in pages for f in page]
+            except (KeyError, TypeError) as exc:
+                raise CoverageError(f"PR #{pr['number']}: malformed paginated files") from exc
+    inventory["pull_requests"] = sorted(prs, key=lambda item: item["number"], reverse=True)
+    inventory_rows(inventory)  # Also detects server-side file-list caps.
+    final = gh_json("pr", "list", "--repo", repository, "--state", "open", "--limit", limit,
+                    "--json", INDEX_FIELDS)
+    if index_signature(final) != index_signature(prs):
+        raise CoverageError("PR heads, bases, metadata or file counts changed during capture; retry")
+    return inventory
+
+
+def read_receipts(paths: list[Path]) -> dict[int, dict]:
+    receipts = {}
+    for path in paths:
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise CoverageError(f"{path}:{line_number}: invalid JSON receipt") from exc
+            if not isinstance(row, dict):
+                raise CoverageError(f"{path}:{line_number}: receipt must be an object")
+            number = row.get("number")
+            if type(number) is not int or number < 1 or number in receipts:
+                raise CoverageError(f"invalid or duplicate reading receipt for PR {number!r}")
+            if not isinstance(row.get("read_coverage"), str) or not row["read_coverage"].strip():
+                raise CoverageError(f"PR #{number}: receipt must describe what was actually read")
+            if not isinstance(row.get("head"), str) or not re.fullmatch(r"[0-9a-f]{40}", row["head"]):
+                raise CoverageError(f"PR #{number}: receipt needs its full read head commit")
+            if not isinstance(row.get("inventory_identity"), str) or not re.fullmatch(
+                r"[0-9a-f]{64}", row["inventory_identity"]
+            ):
+                raise CoverageError(f"PR #{number}: receipt needs the identity of its read inventory row")
+            receipts[number] = row
+    return receipts
+
+
+def compare(current: dict, reviewed: dict, receipts: dict[int, dict]) -> dict:
+    now, before = inventory_rows(current), inventory_rows(reviewed)
+    if current["repository"] != reviewed["repository"]:
+        raise CoverageError("current and reviewed inventories name different repositories")
+    for number, receipt in receipts.items():
+        if (number not in before or receipt["head"] != before[number]["headRefOid"]
+                or receipt.get("inventory_identity") != identity(before[number])):
+            raise CoverageError(f"PR #{number}: receipt does not bind to the reviewed inventory")
+    matched, missing, stale = [], [], []
+    for number in sorted(now, reverse=True):
+        if number not in receipts:
+            missing.append(number)
+        elif identity(now[number]) != identity(before[number]):
+            stale.append(number)
+        else:
+            matched.append(number)
+    return {"schema_version": 1, "repository": current["repository"],
+            "meaning": "matching self-reported reading coverage; not scientific validity or audit status",
+            "open_count": len(now), "matched_review_receipts": matched,
+            "missing_review_receipts": missing, "stale_review_receipts": stale,
+            "no_longer_open": sorted(set(receipts) - set(now), reverse=True),
+            "complete": not missing and not stale}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    snapshot = commands.add_parser("capture", help="read GitHub and refuse incomplete/drifting inventories")
+    snapshot.add_argument("--repo", required=True)
+    snapshot.add_argument("--output", type=Path, required=True)
+    bind = commands.add_parser("receipt", help="record a reader's coverage statement against a saved inventory row")
+    bind.add_argument("--reviewed", type=Path, required=True)
+    bind.add_argument("--number", type=int, required=True)
+    bind.add_argument("--read-coverage", required=True)
+    check = commands.add_parser("check", help="compare current inventory with a reviewed snapshot and JSONL receipts")
+    check.add_argument("--current", type=Path, required=True)
+    check.add_argument("--reviewed", type=Path, required=True)
+    check.add_argument("--receipts", type=Path, nargs="+", required=True)
+    check.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        if args.command == "capture":
+            result = capture(args.repo)
+            args.output.write_text(json.dumps(result, indent=2) + "\n")
+            print(f"Captured {result['total_count']} open PRs with complete changed-file lists.")
+            return 0
+        if args.command == "receipt":
+            rows = inventory_rows(json.loads(args.reviewed.read_text()))
+            if args.number not in rows or not args.read_coverage.strip():
+                raise CoverageError("receipt needs a PR in the reviewed inventory and a nonempty coverage statement")
+            pr = rows[args.number]
+            print(json.dumps({"number": args.number, "head": pr["headRefOid"],
+                              "inventory_identity": identity(pr), "read_coverage": args.read_coverage}))
+            return 0
+        result = compare(json.loads(args.current.read_text()), json.loads(args.reviewed.read_text()),
+                         read_receipts(args.receipts))
+        encoded = json.dumps(result, indent=2) + "\n"
+        if args.output:
+            args.output.write_text(encoded)
+        print(encoded, end="")
+        return 0 if result["complete"] else 1
+    except (CoverageError, OSError, json.JSONDecodeError) as exc:
+        print(f"open-pr-science-coverage: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_open_pr_science_coverage.py
+++ b/tests/test_open_pr_science_coverage.py
@@ -1,0 +1,153 @@
+"""Regressions for silent PR omissions and stale reading coverage."""
+from copy import deepcopy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import open_pr_science_coverage as coverage
+
+
+def pr(number=7, file_count=1):
+    return {"number": number, "headRefOid": "a" * 40, "title": "Supplied model",
+            "body": "Claim and explicit assumptions", "baseRefName": "main", "baseRefOid": "c" * 40,
+            "updatedAt": "2026-09-04T00:00:00Z", "isDraft": False,
+            "url": f"https://github.com/owner/repo/pull/{number}", "changedFiles": file_count,
+            "files": [{"path": f"docs/note-{i}.md", "additions": 3, "deletions": 0}
+                      for i in range(file_count)]}
+
+
+def inventory(*prs):
+    return {"schema_version": 1, "repository": "owner/repo",
+            "total_count": len(prs), "pull_requests": list(prs)}
+
+
+def receipt(p):
+    return {"number": p["number"], "head": p["headRefOid"],
+            "inventory_identity": coverage.identity(p),
+            "read_coverage": "Read body and complete primary note; code not audited."}
+
+
+class CoverageTests(unittest.TestCase):
+    def test_rejects_truncated_open_inventory(self):
+        incomplete = inventory(pr())
+        incomplete["total_count"] = 2
+        with self.assertRaisesRegex(coverage.CoverageError, "total_count"):
+            coverage.inventory_rows(incomplete)
+
+    def test_rejects_gh_hundred_file_cap(self):
+        p = pr(file_count=114)
+        p["files"] = p["files"][:100]
+        with self.assertRaisesRegex(coverage.CoverageError, "incomplete changed-file"):
+            coverage.inventory_rows(inventory(p))
+
+    def test_capture_recovers_all_paginated_files(self):
+        full = pr(file_count=114)
+        capped = deepcopy(full)
+        capped["files"] = capped["files"][:100]
+        files = [{"filename": f["path"], "additions": f["additions"],
+                  "deletions": f["deletions"]} for f in full["files"]]
+        total = {"data": {"repository": {"pullRequests": {"totalCount": 1}}}}
+        with patch.object(coverage, "gh_json", side_effect=[total, [capped],
+                                                          [files[:100], files[100:]], [full]]) as gh:
+            result = coverage.capture("owner/repo")
+        self.assertEqual(result["pull_requests"][0]["files"], full["files"])
+        self.assertIn("--paginate", gh.call_args_list[2].args)
+
+    def test_capture_rejects_changes_during_pagination(self):
+        p = pr()
+        changed = deepcopy(p)
+        changed["headRefOid"] = "b" * 40
+        total = {"data": {"repository": {"pullRequests": {"totalCount": 1}}}}
+        with patch.object(coverage, "gh_json", side_effect=[total, [p], [changed]]):
+            with self.assertRaisesRegex(coverage.CoverageError, "changed during capture"):
+                coverage.capture("owner/repo")
+
+    def test_receipts_are_not_reused_after_semantic_or_metadata_change(self):
+        p = pr()
+        for field, replacement in (("headRefOid", "b" * 40), ("body", "Changed assumption"),
+                                   ("title", "Broader theorem"), ("baseRefName", "other-base"),
+                                   ("baseRefOid", "d" * 40),
+                                   ("updatedAt", "2026-09-04T01:00:00Z"), ("isDraft", True)):
+            with self.subTest(field=field):
+                changed = deepcopy(p)
+                changed[field] = replacement
+                report = coverage.compare(inventory(changed), inventory(p), {7: receipt(p)})
+                self.assertFalse(report["complete"])
+                self.assertEqual(report["stale_review_receipts"], [7])
+
+    def test_file_list_change_and_reordering_are_distinct(self):
+        p = pr(file_count=2)
+        reordered = deepcopy(p)
+        reordered["files"].reverse()
+        self.assertTrue(coverage.compare(inventory(reordered), inventory(p), {7: receipt(p)})["complete"])
+        changed = deepcopy(p)
+        changed["files"][0]["path"] = "docs/different.md"
+        self.assertFalse(coverage.compare(inventory(changed), inventory(p), {7: receipt(p)})["complete"])
+
+    def test_old_receipt_cannot_bind_to_a_replaced_snapshot_at_same_head(self):
+        old = pr()
+        changed = deepcopy(old)
+        changed["body"] = "New assumptions at the same commit"
+        with self.assertRaisesRegex(coverage.CoverageError, "does not bind"):
+            coverage.compare(inventory(changed), inventory(changed), {7: receipt(old)})
+
+    def test_capture_rejects_malformed_rows_before_pagination(self):
+        total = {"data": {"repository": {"pullRequests": {"totalCount": 1}}}}
+        malformed = [None, {}, {**pr(), "number": None}, {**pr(), "files": None},
+                     {**pr(), "changedFiles": "114"}, {**pr(), "files": [None]}]
+        for row in malformed:
+            with self.subTest(row=row):
+                with patch.object(coverage, "gh_json", side_effect=[total, [row]]):
+                    with self.assertRaises(coverage.CoverageError):
+                        coverage.capture("owner/repo")
+
+    def test_capture_rejects_malformed_paginated_pages(self):
+        total = {"data": {"repository": {"pullRequests": {"totalCount": 1}}}}
+        for pages in (None, {}, [{}], [[None]], [[{"filename": "missing-counts"}]]):
+            with self.subTest(pages=pages):
+                capped = pr(file_count=114)
+                capped["files"] = capped["files"][:100]
+                with patch.object(coverage, "gh_json", side_effect=[total, [capped], pages]):
+                    with self.assertRaises(coverage.CoverageError):
+                        coverage.capture("owner/repo")
+
+    def test_new_and_closed_prs_do_not_hide_missing_coverage(self):
+        old, new = pr(7), pr(8)
+        report = coverage.compare(inventory(new), inventory(old), {7: receipt(old)})
+        self.assertEqual(report["missing_review_receipts"], [8])
+        self.assertEqual(report["no_longer_open"], [7])
+        self.assertFalse(report["complete"])
+
+    def test_wrong_head_or_repository_cannot_certify_coverage(self):
+        p = pr()
+        wrong = receipt(p)
+        wrong["head"] = "b" * 40
+        with self.assertRaises(coverage.CoverageError):
+            coverage.compare(inventory(p), inventory(p), {7: wrong})
+        other = inventory(p)
+        other["repository"] = "another/repo"
+        with self.assertRaises(coverage.CoverageError):
+            coverage.compare(other, inventory(p), {7: receipt(p)})
+
+    def test_duplicate_receipts_cannot_mask_different_reads(self):
+        with tempfile.TemporaryDirectory() as directory:
+            p = Path(directory) / "reads.jsonl"
+            line = json.dumps(receipt(pr())) + "\n"
+            p.write_text(line + line)
+            with self.assertRaisesRegex(coverage.CoverageError, "duplicate"):
+                coverage.read_receipts([p])
+
+    def test_matching_receipt_is_explicitly_not_a_scientific_grade(self):
+        p = pr()
+        report = coverage.compare(inventory(p), inventory(p), {7: receipt(p)})
+        self.assertTrue(report["complete"])
+        self.assertEqual(report["matched_review_receipts"], [7])
+        self.assertIn("not scientific validity", report["meaning"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Frontier selection can repeat science already present in open PRs, and `gh pr list --json files` silently stopped at 100 files during this campaign even though PR #6009 changed 114. The physics-loop intake now includes open proposal bodies, primary notes, evidence and substantive reviews, with refreshes before later science blocks.

The read-only capture tool checks the total PR count, recovers complete file lists by pagination, and rejects observed head/base/metadata drift. Offline checks bind each reading receipt to the exact saved proposal identity, so replacing a snapshot at the same head cannot refresh an old receipt. A receipt is a self-reported reading scope; it establishes neither actual reading nor scientific validity and changes no audit status.

Validation:
- 13 offline regression tests pass, including the 100/114-file case, malformed inputs, capture drift and stale receipts.
- Live capture returned all 223 open PRs, including all 114 files in #6009.
- Full repository pipeline, strict audit lint, vocabulary lint, Python compilation and whitespace checks pass. Generated audit outputs were restored; no audit or citation-manifest changes are included.
- Independent review identified four issues, all addressed and re-reviewed with no remaining defect found in those areas.

Discussion text is inspected by the reader; `updatedAt` is only a conservative refresh signal, not a transcript digest. This is a workflow change, with no scientific grade or axiom change.
