### PR TITLE
feat(chirality): the continuum alphabet keeps the winding phase; the echo law gives no field and the fibred odds a fair-coin sign

### DIFF
--- a/docs/THE_CONTINUUM_RECORD_ALPHABET_KEEPS_THE_WINDING_PHASE_AS_RECORD_CONTENT_THE_ECHO_LAW_DOES_NOT_SUPPORT_IT_AS_A_FIELD_AND_THE_FIBRED_ODDS_REGISTER_ITS_SIGN_AS_A_FAIR_COIN_BOUNDED_THEOREM_NOTE_2026-09-04.md
+++ b/docs/THE_CONTINUUM_RECORD_ALPHABET_KEEPS_THE_WINDING_PHASE_AS_RECORD_CONTENT_THE_ECHO_LAW_DOES_NOT_SUPPORT_IT_AS_A_FIELD_AND_THE_FIBRED_ODDS_REGISTER_ITS_SIGN_AS_A_FAIR_COIN_BOUNDED_THEOREM_NOTE_2026-09-04.md
@@ -1,0 +1,287 @@
+---
+claim_id: continuum_alphabet_keeps_winding_phase_echo_law_no_field_sign_fair_coin_2026_09_04
+claim_type: bounded_theorem
+claim_scope: "Exact rational one-site algebra under a Z^3 nearest-neighbour law on the continuum record alphabet, plus one-particle numerics on declared finite geometries. SUPPLIED, none of it read out of any axiom: the continuum effect alphabet {cP(n)} u {cI} and the record-echo law L_CONT of PR #7926 under reading R1 (a cI record carries no Bloch direction); the variant law L_HYB defined here; the fibred odds L_FIB of PR #7926 with t = 2/3 and its lattice-dipole class map, and a record-value class map with a supplied tilt; the coupling of the mass to the record direction, its scale M_0, the operator M2 and the endpoint mean on the hop; H1's D4 with M = 0.8, r_s = 1 and hard ends; the core positions, the pinned seeds, the declared flip patterns, and every size, cut and window. (T1) A record cP(n) on a declared great circle has phase readout (cos phi, sin phi) = (n.e_1, n.e_2), exact at 7 rational circle points, independent of the scale c, absent for a cI record, and shifted by pi/2 under the C_4 about the circle normal; L_CONT is covariant on 37056 exact checks with 0 mismatches; the H2 mass read from that register gives node spectrum +-M_0 fourfold for every uniform phase at max deviation 8.9e-16, and the Dirac mass is the cell average of the record-read mass at tr(eps D)/8 = 0.250000. (T2) Complete over all 8^6 = 262144 neighbourhood conditions, a rank-one effect is in L_CONT's support for 1152 of 1152 conditions with one direction-recorded neighbour and 960 of those with three positively spanning ones, and for none with 0, 2, 4, 5 or 6; every rank-one direction in every support is a neighbour's direction or its antipode, 262144 of 262144, so a fully recorded bulk site is an I record. The Gibbs census gives 64 of 40353607 configurations supported at every site on the 3x3 periodic plane with direction degrees {1: 108, 3: 216} and at most 6 of 9 directional, and 19 of 5764801 on the 2x2x2 open cube with degrees {1: 72}, dimers only. From no seed all 8! = 40320 orders and picks form only I records; from one seed 57264 leaves offer only {m_1, -m_1} and from three seeds 2880 leaves offer nothing beyond the seeds and antipodes. (T3) On a 16^3 periodic-supercell Bloch scan the dimer superlattices at densities 1/6, 1/3 and 1/8 are gapless at both M_0 and both phases, max 5.8e-16 over 12 scans, against a uniform control gapped at 0.7000 and 1.5000; on the 48x48 open plane the L_CONT-supported winding has 7 states below |E| = 0.1, smallest 0.0008, against a uniform gap 1.5027; the same dilute field in H1's record-time operator is gapped at 0.267204 (N = 24) and 0.246455 (N = 32) against M/3 = 0.2667 and carries the index, interior +0.951637036 and edge -0.828326136 at N = 32 under the cut 0.12. (T4) The variant L_HYB supports the XY-relaxed vortex as its own fixed point at residual 9.9e-15, 1.0e-14 and 1.1e-14 over 960, 1792 and 4224 unpinned sites; the string carries 2 co-moving modes at E = +0.09983 with <V_z> = +0.995, v = 0.998; the light-cut bulk net handedness is +1.9983 at R = 14 and 18 on 48x48 and +1.9864 at R = 11 on 32x32, whole-plane sums -5.6e-16, -8.8e-16 and -9.1e-16, with p = 0 core/ring splittings 3.125e-03, 3.991e-04 and 7.748e-06; on a periodic torus the exactly built string/anti-string field carries a 2 pi winding along the cycle between the cores, relaxes at 9.8e-15 and 9.9e-15 with y-cycle windings {0, 1} and exactly two vortex plaquettes, and carries +1.9767/-1.9767 (48x24) and +1.9836/-1.9836 (64x32) within r < 11 with a whole-torus sum 1.6e-15; in H1's geometry the relaxed vortex gives interior +0.999991511 at N = 32 with the partner on the edge at -0.997255565; a site-centred core has vanishing neighbour sum (6.5e-22) and is registered I by both laws. (T5) The lattice-dipole class map sends a fully recorded condition to lambda = 0, the only Bloch vector fixed by all 24 proper cubic rotations is 0 at exact rank 3, so that fibre carries rho = I/2 and the bulk binary menu has odds 1/2, 1/2 exactly; a dimer whose phase circle is normal to its axis likewise gives 1/2, 1/2, one tilted onto the x-z circle 23/30 and 7/30, and the ternary odds in the invariant fibre are 3/8, 5/16, 5/16; one class tick re-registers the vortex unflipped with odds 2^-N^2 = 10^-173.4, 10^-308.3 and 10^-693.6, or (5/6)^N^2 = 10^-45.6, 10^-81.1 and 10^-182.4 under a record-value map of tilt 2/3; a declared flip pattern of density 1/2 leaves 0 core modes on the 24x24 vortex and 18 light states filling H1's gap with interior -0.059, while densities 1/9 and about 1/6 keep 2 core modes and interiors +0.998770616 and +0.997107900; the mean-field flip density under a tilted record-value map settles at 0.3724 with mean registered mass +0.0000 at t = 0 and keeps +0.6217 at t = 2/3. L_HYB, the relaxed fields and the torus pair field are model constructions, not landed laws or landed fields. Interactions, many-body statements, dynamics for the phase, the fine lattice, gauge coupling, junction configurations in the matter law, the record-time density-1/2 index, and sizes other than those named are out of scope. No axiom is changed, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py
+---
+
+# The continuum record alphabet keeps the winding phase as record content, the record-echo law does not support it as a field, and the fibred Born odds register its sign as a fair coin: a vortex read from records carries `2n` per string and `n` per record-time vortex, partner included
+
+**Date:** 2026-09-04
+**Type:** bounded_theorem (`T1`-`T3`, `T5`) + model_construction (`L_HYB`, the relaxed fields, the torus pair field of `T4`)
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py`](../scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py)
+**Runner cache:**
+[`logs/runner-cache/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.txt`](../logs/runner-cache/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.txt)
+**Parents:** none load-bearing. Every object used below is declared in this note and rebuilt from scratch by the runner; the notes named in "Interfaces" are plain-text pointers carrying no grade and no dependency weight.
+
+A handed mode bound to a mass vortex needs a phase that turns, and the open branch that found the `2n` string said plainly that a site register in `U(1)` is a charged scalar's phase by another name and that the framework has nowhere to keep one. The continuum
+record alphabet is a place to keep one: a record locks a Bloch direction, and a direction on a declared great circle *is* a phase. This note asks three separate questions of that alphabet and gets three different answers. The alphabet **keeps** the phase, as
+readable record content. The landed record-echo law **does not support** it as a field: its supports echo neighbours' directions and register `I` in any dense bulk, so a winding survives only as a dilute dimer echo of supplied seeds, which the staggered matter
+law leaves gapless. And the landed fibred odds that pay the abundance clause on the same alphabet **register the phase's sign as a fair coin** in the bulk, and a coin-signed field carries no string mode. A minimal variant law does support the smooth vortex, and
+in it the pairing found by the two vortex branches is untouched by where the phase is kept.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "T1's phase readout and covariance, T2's whole support census and Gibbs census and formation walks, and T5's odds and exact powers are exact rational or complete-enumeration statements on finite declared families. T3's gaplessness and gaps and T4's mode counts, region sums and splittings are one-particle floating-point statements on the named finite geometries at the stated tolerance. L_HYB, the XY-relaxed fields and the torus pair field are model constructions declared here, not landed laws or landed fields; T4 is a theorem about those constructions and not about the framework's law. No statement here is a proof about the infinite lattice, and none is read out of any axiom."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-size result, and route to the lane that owns the fibred odds the one item this note prices but does not pay: which member of {P(m), P(-m)} forms, given that a rotation-invariant fibre pins the state to I/2 and a tilt on a record-value class map is supplied rather than fixed."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Setting
+
+The framework axioms are quoted, not amended. **Qubit / Site Possibility**, verbatim:
+
+> Each site has a domain of local possibilities. The full one-site possibility domain has algebraic presentation `M_2(C)`. [...] No possibility is privileged. Possibilities are distinguished by the supplied algebraic structure alone.
+
+**Admissibility / Local Constraint**, verbatim:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations. For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor conditions.
+
+with its reading notes, verbatim: *"(2) Read with Record, the distribution concerns which possibility a forming record locks, conditional on formation at that site; it does not supply the formation site, probability, or rate. (3) The distribution is a probability
+measure on the local possibility domain; 'available'/'admissible' denotes its support -- on finite menus, exactly the possibilities of nonzero probability. On a continuous domain, a supported exact point may have zero singleton measure; Record locks a supported
+realization."*
+
+**Record / Fixed Reality**, verbatim:
+
+> Records form. When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent. Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read.
+
+Nothing below is read out of these. The **supplied surface** is quoted from the open branches that declare it.
+
+The continuum alphabet and the record-echo law `L_CONT` are quoted from the continuum-alphabet branch (PR #7926), verbatim: *"On the multiset `R(n)` of recorded Bloch directions, one record echoes as the binary resolution of its own direction, three coplanar
+positively spanning records as their ternary resolution, two records as a coin; anything else gives `{I}`"*, with its table
+
+| records | support `S(n)` |
+|---|---|
+| `{m}` | `{P(m), P(-m)}` |
+| `{m_1, m_2, m_3}` coplanar, positively spanning | `{c_k P(m_k)}`, `c` the unique solution of `sum c_k m_k = 0`, `sum c_k = 2` |
+| `{m_1, m_2}` with `a = (1 + m_1 dot m_2)/2` in `(0,1)` | `{a I, (1-a) I}` |
+
+and its fibred odds, verbatim: *"`L_FIB` sets `rho_l = (I + (2/3) l dot sigma)/2` for `l` a unit lattice direction and `I/2` otherwise"*, over *"the lattice-dipole fibration `lambda(n)` [...] the sum of the recorded slot directions"*. That branch's covariance
+obstruction, which `T5` recomputes and applies to the bulk, is its own: *"a fibre class map with rotation-invariant classes forces `rho = I/2`, so an invariant scalar label cannot carry a state."*
+
+The mass is the one the `2n`-string branch (PR #7949) declares, `m_1 + i m_2` with `m_1` on sites times `eps_v` and `m_2 = M2^{(cell)} = X1Y2X3` on the body diagonals, together with the Kawamoto-Smit signs, the `2x2x2` cell algebra `Gamma = (Y1, Z1Y2, Z1Z2Y3)`,
+`Xi = (X1, Z1X2, Z1Z2X3)`, `eps = Z1Z2Z3` and its `M_0 = 0.7`. The record-time operator is the one the record-time-vortex branch (PR #7935) declares,
+`D4 = K_1 alpha_1 + K_2 alpha_2 + [M (r.e_1) + r_s L] alpha_3 + M (r.e_2) alpha_4` with `M = 0.8`, `r_s = 1`, hard ends and light cut `0.30`. Both are supplied, and neither is read out of an axiom.
+
+## Definitions
+
+```text
+alphabet      a record is ("P", c, n) = c P(n), 0 < c <= 1, n in S^2, or ("I", c) = cI
+reading R1    a cI record carries no Bloch direction and does not enter R(n)   SUPPLIED
+L_CONT        the record-echo law quoted in "Setting", counting R(n) as a list SUPPLIED
+L_HYB         L_CONT on 1, 2, 3 recorded directions; on any other condition the
+              binary resolution {P(vhat), P(-vhat)} of the neighbour mean
+              v = sum_d m_d, with v = 0 giving {I}          THIS NOTE'S CONSTRUCTION
+L_FIB         rho_l = (I + t lhat.sigma)/2 on a unit lattice dipole l, I/2
+              otherwise; t = 2/3                                              SUPPLIED
+phase phi_v   (cos phi_v, sin phi_v) = (n_v.e_1, n_v.e_2) on a declared great
+              circle with orthonormal Bloch axes (e_1, e_2) = the (x,y) axes
+r_v           c_v n_v, the record's Bloch vector; r_v = 0 for cI or no record
+H             sum_<vv'> eta_vv' + M_0 sum_v eps_v (r_v.e_1) n_v
+                + M_0 sum_cells sum_{body diag} (1/2)[(r_v.e_2)+(r_vbar.e_2)] M2
+D4            H1's record-time operator, as quoted in "Setting"               SUPPLIED
+support res.  max_v |n_v x v_v| / |v_v| over unpinned sites, v_v the in-plane
+              neighbour sum plus 2 n_v (the two z-neighbours of a z-uniform string)
+light cut     |E| < 0.3 (transverse planes), |E| < 0.30 or 0.12 (record time)
+```
+
+Sizes: open transverse planes `24, 32, 48`; tori `48x24` and `64x32`; record-time squares `24, 32`, and `25` for the site-centred core; supercell scans on `2x2x2`, `6x2x2`, `2x2x6` and `4x2x2` with a `16^3` Bloch grid; the dense `24x24` plane for the flip
+patterns; `M_0 = 0.7` except `M_0 = 1.5` on the dilute `48x48` plane; in-gap window `|E| < 0.686`, `R_c = 5`. Every transverse and record-time eigenproblem is solved by sparse shift-invert about `E = 0` — **there is no random number and no seed anywhere in the
+runner**, every field, pattern and formation order being declared arithmetic and the "quasi-random" flip patterns the deterministic `frac(x*golden + y*sqrt2)`. The largest dense matrix built anywhere is `1152 x 1152`.
+
+## Theorem 1 -- the alphabet keeps the winding phase as record content
+
+On the declared great circle the readout `(cos phi_v, sin phi_v) = (n_v.e_1, n_v.e_2)` is exact at the seven rational circle points `n(t) = ((1-t^2)/(1+t^2), 2t/(1+t^2), 0)`, `t = 0, +-1/2, +-1, +-2`. It depends on the record's direction alone and not on its
+scale — the same value at `c = 1` and `c = 1/2` — a `cI` record has none, and the `C_4` about the circle normal sends `(3/5, 4/5)` to `(-4/5, 3/5)`, that is `phi -> phi + pi/2`. By Record's own clause a readout value is determined by record content alone, and
+`phi_v` is such a value once the circle and the origin are supplied: the axes `(e_1, e_2)` and the origin of `phi` are supplied readout context, the value is record content. The register is `U(1)`-valued per site on a great circle, `S^2`-valued in general.
+
+`L_CONT` rebuilt here reproduces PR #7926's branches exactly — `{m}` binary, `{m_1, m_2, m_3}` ternary with weights `(3/4, 5/8, 5/8)` summing to `2` at weighted sum `0`, `{m_1, m_2}` the coin `(1/5, 4/5)`, and `{I}` for two equal records, six equal records, the
+empty condition and an all-`I` condition — and is covariant, `S(g.n) = g.S(n)` on **37056 exact checks with 0 mismatches**.
+
+The mass couples to the register covariantly: for a uniform record direction of phase `phi = 0, 0.7, 2.0` the node spectrum is `+-M_0 = +-0.7` fourfold each at max deviation `8.9e-16`. And the Dirac mass is the **cell average** of the record-read mass: a
+site-diagonal `eps_b m_b` on a cell has `eps`-component `tr(eps D)/8 = 0.250000`, the plain cell average of `m_b`, so a recorded pattern of density `d` carries Dirac mass `d M_0` up to its superlattice components. That last identity is what decides `T3`.
+
+## Theorem 2 -- the record-echo law supports no dense direction field
+
+Complete over all `8^6 = 262144` neighbourhood conditions — each of six slots blank, an `I` record, or `P(d)` for six declared directions — a rank-one effect lies in `L_CONT`'s support **for 1152 of the 1152 conditions with one direction-recorded neighbour and
+for 960 of those with three (exactly the positively spanning triples), and for none of the conditions with 0, 2, 4, 5 or 6**.
+
+> **Echo lemma.** Every rank-one direction in every support is a neighbour's recorded direction or its antipode: **262144 of 262144**.
+
+A fully recorded bulk site therefore has `kP = 6` — 46656 conditions — and is an `I` record. So in a configuration supported at its own neighbourhood everywhere, a direction record has exactly 1 or 3 direction-recorded neighbours, and no dense winding field,
+smooth or clock-like, is in the support: its directions would have to be echoes, and its bulk would have to be `I`.
+
+The Gibbs census confirms the shape. On the `3x3` periodic plane over the seven-letter alphabet, **64 of `7^9` = 40353607** configurations are in the support at every site, the direction sites have degrees `{1: 108, 3: 216}` in the direction subgraph, and at
+most **6 of 9** sites carry a direction. On the `2x2x2` open cube, **19 of `7^8` = 5764801**, degrees `{1: 72}`, at most 4 of 8 — dimers only, no junction. Sequential formation says the same from the other side: from **no seed**, all `8! = 40320` orders and
+every pick form only `I` records, with **zero** directions ever offered; from **one seed** the 57264 (order, pick) leaves offer only `{m_1, -m_1}`, and from **three** positively spanning seeds the 2880 leaves offer nothing beyond the seeds and their antipodes.
+The law never creates a direction; it echoes seeds.
+
+## Theorem 3 -- the field the law does support is gapless in the staggered law and gapped in the record-time one
+
+The densest supported winding is a dimer superlattice. On a `16^3` periodic-supercell Bloch scan of the staggered 3D matter law, **every** dimer superlattice tested — densities `1/6`, `1/3` and `1/8`, both `M_0 = 0.7` and `1.5`, phases `0` and `pi/2` — is
+**gapless**, `max |E|_min = 5.8e-16` over the 12 scans, against a uniform control gapped at exactly `0.7000` and `1.5000`. The minimum sits at the node, where the landed cell Bloch matrix vanishes and every unrecorded site is an exact zero mode; the dimer's
+site-diagonal mass is three node-splitting strings for one Dirac mass. On the `48x48` open plane the `L_CONT`-supported winding — 768 recorded sites at density `1/6`, **0** support violations — has **7 states below `|E| = 0.1`**, the smallest `0.0008`, against
+a uniform field of the same `M_0` gapped at `1.5027`. No in-gap string mode is defined on the field the landed law supports.
+
+The record-time operator treats the same field differently, because it takes a site-diagonal record mass as a genuine Dirac mass. The uniform-phase dilute field at density `1/3` is **gapped** at `0.267204` (`N = 24`) and `0.246455` (`N = 32`) against
+`M/3 = 0.2667`, and the winding on it **carries the index**: at `N = 32` under the cut `0.12` there are 2 light states at `max|E| = 2.364e-03` (next `0.22978`), interior `+0.951637036`, edge ring `-0.828326136`.
+
+## Theorem 4 -- a variant law supports the smooth vortex, and the pairing is untouched
+
+`L_HYB` is defined in "Definitions" and is **a construction of this note, landed nowhere**. It is covariant by construction, nearest-neighbour, and its abundance family is `L_CONT`'s. A configuration is in its support at every site exactly when each `n_v` is
+parallel to its neighbour sum with positive projection — the fixed points of the XY relaxation.
+
+The XY-relaxed vortex is such a fixed point: support residual `9.9e-15`, `1.0e-14` and `1.1e-14` over the 960, 1792 and 4224 unpinned sites of the `24`, `32` and `48` open planes, `min n_v.vhat_v = +1.000000`, and the registered phase winding `+1` on the square
+loops of half-side 2, 4 and 6. On it the string carries **2 co-moving modes** at `E = +0.09983` each with `<V_z> = +0.995`, that is `v = 0.998`, and the light cut keeps four states. The **bulk net handedness** inside a disc is `+1.9983` at `R = 14` and at
+`R = 18` on the `48x48` plane and `+1.9864` at `R = 11` on `32x32` — the plateau is `2n = 2` and it extends with the plane — while the whole-plane sum is `-5.6e-16`, `-8.8e-16` and `-9.1e-16`. The `-2n` sits on the boundary ring, and the core pair decouples
+from it exponentially: the `p = 0` splitting falls `3.125e-03`, `3.991e-04`, `7.748e-06` at `N = 24, 32, 48`.
+
+With no boundary the partner has nowhere to hide but the anti-string. On a periodic torus a string and an anti-string **force** a `2 pi` winding of the record phase along the cycle between them: the exactly constructed pair field — Poisson solve for the stream
+function, discrete curl, a uniform twist making the cycle circulations integers, integration on a spanning tree — relaxes to a fixed point at residual `9.8e-15` and `9.9e-15`, keeps `y`-cycle windings `{0, 1}` and exactly two vortex plaquettes, and its four
+light states carry `+1.9767 / -1.9767` (`48x24`) and `+1.9836 / -1.9836` (`64x32`) within `r < 11` of the two cores, whole-torus sum `1.6e-15`.
+
+In H1's record-time geometry the same relaxed field is an `L_HYB` fixed point (residual `9.5e-15`) and its vortex gives interior chirality `+0.999991511` at `N = 32` with the compensating partner on the edge ring at `-0.997255565`, over 2 light states at
+`max|E| = 5.9e-10` (next `0.31023`). And the core is the law's, not a supplied profile: a **site-centred** core has its four in-plane neighbours at `0, 90, 180, 270` degrees, its neighbour sum vanishes (`6.5e-22` on the relaxed `25x25` field, the one site with
+`|v| = 0`), and **both** laws register `I` there, so the complex mass is zero at the core by the law.
+
+## Theorem 5 -- the fibred odds register the phase's sign as a fair coin
+
+The lattice-dipole class map sends a fully recorded condition to `lambda = (0, 0, 0)`. The only Bloch vector fixed by all 24 proper cubic rotations is `0` — exact rank `3` of the stacked `R - 1` — so that fibre is rotation-invariant and carries
+`rho = I/2` exactly, and the two members of the bulk binary menu `{P(vhat), P(-vhat)}` have odds **`1/2` and `1/2`**. The same holds on a dimer whose phase circle is normal to its axis (`lambda = e_z`, `t = 2/3` as landed): `1/2, 1/2` exactly. A direction tilted
+onto the `x`-`z` circle instead gives `23/30` and `7/30`, and the ternary odds in the invariant fibre are `3/8, 5/16, 5/16`, that is `c_k/2`.
+
+The consequences are arithmetic. One class tick of the superlattice parity class re-registers the whole vortex **with no sign flip** with odds `2^-N^2` = `10^-173.4`, `10^-308.3`, `10^-693.6` at `N = 24, 32, 48`; under a record-value class map of tilt `t = 2/3`
+the same path costs `(5/6)^N^2` = `10^-45.6`, `10^-81.1`, `10^-182.4`. And a coin-signed field carries no string mode: a declared flip pattern of density `1/2` (mean sign `+0.000`) leaves **0** core modes on the `24x24` relaxed vortex, where no flips
+(`+1.000`) keep 2 at `E = +0.09988`, density `1/9` (`+0.778`) keeps 2 and density about `1/6` (`+0.663`) keeps 2. In the record-time geometry the same coin **fills the gap**: density `1/2` gives **18 light states** under the cut `0.30` (`max|E| = 0.289`
+against next `0.318`) and an interior sum of `-0.059`, where no flips give 2 states and `+0.999951757`, density `1/9` gives 2 and `+0.998770616`, and density about `1/6` gives 2 and `+0.997107900`.
+
+A class map that reads record **values** can carry a supplied tilt `t`. Under the mean-field iteration over class ticks the flip density settles at `0.3724` with `I`-density `0.2553` at `t = 0`, so the mean registered complex mass is `+0.0000` — the registered
+field is a director with a coin for its sign — while `t = 2/3` keeps `+0.6217` of the mass and `t = 9/10` keeps `+0.8979`. The tilt `t` is supplied and is fixed by nothing quoted here.
+
+## Corollary -- one supplied object, both registers, and the unpaid item
+
+Within the setting declared above, on the geometries named:
+
+1. **The alphabet supplies the winding phase as a register**, readable by the Record axiom's own clause, **but not, through the landed law, as a field.** `T1` gives the readout; `T2` gives the complete census under which no dense direction field is supported and
+   any winding is a dilute echo of supplied seeds; `T3` gives that echo gapless in the staggered matter law.
+2. **A minimal variant law supports the smooth vortex as its own fixed point**, and in it the pairing found by the two vortex branches **is untouched by where the phase is kept**: `2n` per string with `-2n` on the boundary ring, `+2n` and `-2n` on a torus pair
+   with nothing else, `n` per record-time vortex with the partner on the edge, and a whole-volume sum at machine zero in every geometry. **The compensating partner is never absent from the bulk in any geometry.**
+3. **The fibred odds that pay the abundance clause on the same alphabet register the phase's sign as a fair coin in the bulk**, and a coin-signed field has no string mode. So one supplied object — a Bloch direction per record — pays both registers and charges
+   both alike: the binary menu that gives abundance always holds the antipode, so the very menus that buy the one make the registered phase a director with a coin for its sign wherever the fibre is rotation-invariant, which is the bulk. **The unpaid item is the
+   odds of the antipode**: which member of `{P(m), P(-m)}` forms. Paying it costs a class map that reads record values with a supplied tilt, and this note does not fix that tilt.
+
+**Seven disagreements with the expectation, stated plainly.** (i) The expectation was that a continuum alphabet supplies the phase and a vortex is then a matter of running the string construction. It is **the law, not the alphabet, that blocks the winding**:
+the alphabet supplies the register, and `L_CONT` never forms a direction that is not a neighbour's or its antipode. (ii) The partner is not absent from the bulk in any geometry. (iii) The fibred odds — the very thing the abundance clause buys — make the
+registered sign a fair coin in the bulk, and the vortex modes do not survive that; this is the new price and it is exact. (iv) The dilute supported field is gapless in the staggered 3D law but gapped and index-carrying in the record-time operator: the two
+matter constructions treat a site-diagonal record mass differently. (v) **The torus pair must be constructed with its `2 pi` twist**; a relaxation started from a seam-mismatched field instead nucleates a second pair, which is a valid fixed point of lower XY
+energy but has four vortex plaquettes, so any torus run must build the field exactly rather than relax into it. (vi) The region-resolved handedness is clean only with a light cut; without it the `l = 1` bound states hybridised with the ring add `O(0.5)` to the
+disc sums. (vii) The naive winding of the registered phases is destroyed by a single flipped site, while the matter law's modes survive a dilute flip gas and are lost at density `1/2`: "is the winding stable" has two answers depending on which object is asked.
+
+**Reading, not theorem (this register).** The alphabet does have somewhere to keep a turning phase: a record is a direction, and a direction on a circle is an angle. Read one off each record and the mass the fermion feels turns with it, and a line where the
+angle turns once carries two modes running the same way, with two running the other way somewhere else — on the edge, or on a partner line — exactly as before. What goes wrong is not the keeping but the making. The landed rule for what a site may record only
+ever repeats a neighbour's direction or its opposite, and where a site is surrounded by records it must record nothing directional at all, so a full sheet of turning arrows is not something that rule allows; what it allows is a sparse scatter of pairs, and the
+fermion sees no gap in that. And the rule for *which* of the two opposite directions a site actually takes, on the odds the same alphabet buys elsewhere, is a coin. A field of arrows whose signs are coins is not a turning field; it is a field of undirected
+lines, and the mode is gone. So the same one object pays for both things wanted from it, and charges for both in the same currency — and the bill nobody has paid is which way the arrow points.
+
+## Interfaces named for other lanes, not taken up here
+
+- **The continuum alphabet and the fibred Born theorem** (open branch, PR #7926), `A_CONTINUUM_RECORD_ALPHABET_LIFTS_THE_ABUNDANCE_NO_GO_A_FIBRED_BORN_THEOREM_AND_A_FACTOR_OF_TWO_OBSTRUCTION_BOUNDED_THEOREM_NOTE_2026-09-04.md`, whose `L_CONT`, `L_FIB` with
+  `t = 2/3` and lattice-dipole class map are quoted verbatim in "Setting". Whether any equivariant class map with non-trivial stabiliser can carry a tilt without a supplied parameter belongs to that lane.
+- **The fibred menu-independence clause** (open branch, PR #7931), `A_FIBRED_MENU_INDEPENDENCE_CLAUSE_NON_VACUOUS_ON_THE_CONTINUUM_LAW_DISCRIMINATING_ON_THE_CUBE_BOUNDED_THEOREM_NOTE_2026-09-04.md`.
+- **The Born form from balanced ternaries** (open branch, PR #7950), `THE_BORN_FORM_FROM_BALANCED_TERNARY_MENUS_WITHOUT_THE_FRAME_IMPORT_EXACT_FOR_HOMOGENEOUS_GRADINGS_AND_A_COUNTING_ROGUE_ON_THE_REALISED_FAMILY_BOUNDED_THEOREM_NOTE_2026-09-03.md`.
+- **The one-frame tick result** (open branch, PR #7969),
+  `THE_MATTER_LAWS_OWN_TICKS_REALISE_MENUS_IN_ONE_FRAME_ONLY_THE_GLOBAL_CLAUSE_IS_REFUTED_BY_THE_SUPPORTS_THE_FIBRED_CLAUSE_IS_AN_IDENTITY_AND_ABUNDANCE_IS_UNPAID_BOUNDED_NOTE_2026-09-04.md`.
+- **The record-time vortex** (open branch, PR #7935), `A_VORTEX_IN_A_TWO_DIMENSIONAL_RECORD_TIME_CARRIES_A_SINGLE_WEYL_MODE_IN_THE_INTERIOR_AND_A_REAL_MASS_CARRIES_NONE_BOUNDED_THEOREM_NOTE_2026-09-04.md`, whose `D4` is quoted in "Setting" and whose interior
+  number `T4` reproduces on a relaxed field.
+- **The `2n` string** (open branch, PR #7949), `THE_TASTE_SINGLET_SECOND_MASS_IS_A_BODY_DIAGONAL_IMAGINARY_HOP_AND_ITS_VORTEX_STRINGS_CARRY_2N_CO_MOVING_MODES_BOUNDED_THEOREM_NOTE_2026-09-03.md`, whose mass and cell algebra are quoted in "Setting" and whose
+  open question — whether any record-native register can carry the winding phase — is the one `T1` answers for the register and `T2` answers differently for the field.
+- **The tick line** (open branches, PR #7947 and PR #7968), `NO_SITE_WISE_FORMATION_RULE_PRESERVES_THE_SEA_UNDER_TICK_EVOLUTION_THE_EIGENVECTOR_CONDITION_IS_PER_STEP_AND_SET_WISE_BOUNDED_THEOREM_NOTE_2026-09-03.md` and
+  `THE_FORMATION_UNIT_THAT_PRESERVES_THE_SEA_IS_A_WHOLE_CLASS_OF_THE_SUPERLATTICE_ROLE_PATTERN_THE_EIGEN_SET_CRITERION_IS_ONE_PARTICLE_AND_ITS_MINIMAL_SETS_ARE_THE_PARITY_CLASSES_BOUNDED_NOTE_2026-09-04.md`, whose parity-class formation unit is the tick `T5`
+  prices.
+- [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md): the three axioms quoted in "Setting". No grade of it is cited and no hypothesis is adopted.
+
+## Executable claim block
+
+```text
+setting: continuum effect alphabet {cP(n)} u {cI}; L_CONT (PR #7926, list count of recorded directions) under reading R1; L_HYB as defined here (model_construction); L_FIB with t = 2/3 and the lattice-dipole class map (PR #7926); a record-value class map with a supplied tilt, named only as an alternative. Matter laws: the coarse-lattice construction of PR #7949 (KS signs, 2x2x2 cell, M2 = X1Y2X3, M_0 = 0.7, endpoint mean on the body-diagonal hop) and D4 of PR #7935 (M = 0.8, r_s = 1, hard ends, cut 0.30). One particle, free field, no gauge coupling, no interactions, no fine lattice. Qubit, Admissibility and Record quoted from MINIMAL_AXIOMS_2026-06-29.md.
+T1 register [exact + 1e-12]: (cos phi, sin phi) = (n.e_1, n.e_2) exact at 7 rational circle points, scale-independent, absent for cI, C_4 shift pi/2; L_CONT branches reproduced with ternary weights (3/4,5/8,5/8) and covariance 37056 checks / 0 mismatches; node spectrum +-M_0 fourfold for phi = 0, 0.7, 2.0 at max dev 8.9e-16; tr(eps D)/8 = 0.250000 = the cell average
+T2 census [exact]: all 8^6 = 262144 conditions -> rank-one supported for 1152/1152 at kP = 1 and 960 at kP = 3, never at kP = 0,2,4,5,6; echo lemma 262144/262144; kP = 6 (46656 conditions) is an I record; Gibbs 64 of 40353607 on the 3x3 periodic plane, degrees {1:108, 3:216}, at most 6 of 9; 19 of 5764801 on the 2x2x2 cube, degrees {1:72}, at most 4 of 8; no seed -> all 8! = 40320 give only I, 0 directions offered; one seed -> 57264 leaves, only {m_1,-m_1}; three seeds -> 2880 leaves, seeds and antipodes only
+T3 dilute [numerical, model_construction fields]: 16^3 supercell scan -> dimer superlattices at densities 1/6, 1/3, 1/8, both M_0, phases 0 and pi/2 all gapless, max 5.8e-16 over 12 scans; uniform control 0.7000 / 1.5000; 48x48 plane, 768 sites, 0 violations -> 7 states below 0.1, smallest 0.0008, uniform gap 1.5027; record-time density 1/3 gapped 0.267204 (N=24) / 0.246455 (N=32) vs M/3 = 0.2667; index at N = 32, cut 0.12 -> 2 light states, max|E| 2.364e-03, next 0.22978, interior +0.951637036, edge -0.828326136
+T4 L_HYB [model_construction, numerical]: fixed-point residual 9.9e-15 / 1.0e-14 / 1.1e-14 over 960 / 1792 / 4224 unpinned sites at N = 24 / 32 / 48, min n.vhat +1.000000, winding +1 on loops 2, 4, 6; 2 core modes E = +0.09983, <V_z> = +0.995, v = 0.998, light cut keeps 4; h = +1.9983 at R = 14 and 18 (48x48), +1.9864 at R = 11 (32x32), whole plane -5.6e-16 / -8.8e-16 / -9.1e-16; p = 0 splitting 3.125e-03 / 3.991e-04 / 7.748e-06; torus pair built exactly, relaxed at 9.8e-15 / 9.9e-15, y-cycle windings {0,1}, exactly 2 vortex plaquettes, +1.9767/-1.9767 (48x24) and +1.9836/-1.9836 (64x32) at r < 11, torus sum 1.6e-15; record-time relaxed vortex residual 9.5e-15, interior +0.999991511 at N = 32, edge -0.997255565, 2 light states max|E| 5.9e-10, next 0.31023; site-centred core |v| = 6.5e-22, {I} under both laws
+T5 fair coin [exact + numerical]: lambda = (0,0,0), invariant-vector rank 3, rho = I/2, bulk odds 1/2, 1/2; dimer normal to its axis 1/2, 1/2; x-z tilt 23/30, 7/30; ternary 3/8, 5/16, 5/16 = c_k/2; class tick unflipped at 2^-N^2 = 10^-173.4 / 10^-308.3 / 10^-693.6, tilt 2/3 -> 10^-45.6 / 10^-81.1 / 10^-182.4; flips density 1/2 -> 0 core modes (24x24) and 18 record-time light states with interior -0.059; none -> 2 and +0.999951757; 1/9 -> 2 and +0.998770616; ~1/6 -> 2 and +0.997107900; tilted class map fixed point 0.3724 with mean mass +0.0000 at t = 0, +0.6217 at t = 2/3, +0.8979 at t = 9/10
+F solver certificate [1e-9]: sparse shift-invert vs dense LAPACK on a 12x12 record-time square (dim 576) agree to 7.2e-15 over the 20 eigenvalues nearest zero; largest dense matrix 1152 x 1152; no random number and no seed anywhere
+supplied: the alphabet, L_CONT and reading R1; L_HYB; L_FIB with t = 2/3 and its class map, and the record-value map's tilt; the mass coupling, which Bloch axes, M_0 and the endpoint mean; M2 outside nearest-neighbour adjacency; the core positions and pinned seeds; the torus pair field's construction; the two-dimensional record order and D4; the flip patterns; every size, cut and window
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=29 FAIL=0
+```
+
+## Proof boundary
+
+**Alphabet and rules.** The continuum effect domain `{cP(n)} u {cI}` of PR #7926; `L_CONT` verbatim, counting recorded directions as a list, under reading **R1** (a `cI` record carries no direction — PR #7926's runner never feeds an `I` record as a condition, so
+the landed rule is silent on this and R1 is stated, not landed); `L_HYB` as defined in "Definitions"; the fibred odds `L_FIB` with `t = 2/3` and the lattice-dipole class map; the record-value class map only as a named alternative.
+
+**Matter laws.** The coarse-lattice one-particle construction of PR #7949 (KS signs, `2x2x2` cell, `M2 = X1Y2X3`, `M_0 = 0.7`, `m_2` on the body-diagonal hops as the endpoint mean) and `D4` of PR #7935 (`M = 0.8`, `r_s = 1`, hard ends, cut `0.30`). Free field,
+one particle, no gauge coupling, no interactions, no fine lattice.
+
+**Sizes.** Open planes `24, 32, 48`; tori `48x24` and `64x32`; record-time squares `24, 32` and `25` for the site-centred core; supercell scans on `2x2x2`, `6x2x2`, `2x2x6` and `4x2x2` with a `16^3` grid; the dense `24x24` plane for the flip patterns.
+
+**Fields.** The XY fixed points with the boundary ring and the four core corners pinned — **their residual is not zero, and they are the supplied seeds**; the exact torus pair field with the `2 pi` twist; the `x`-dimer and `z`-dimer patterns; the declared flip
+patterns. The analytic `e^{i n theta}` initial field where the relaxation starts from it.
+
+**Declared reductions this runner makes.** (1) `D4` is assembled sparse and solved by shift-invert about `E = 0` rather than by dense LAPACK; the two agree to `7.2e-15` over the 20 eigenvalues nearest zero on a `12x12` square, and the eigenvalues reproduce the
+source campaign's dense values digit for digit. The one visible cost is the whole-plane light-state sum at `N = 32`, which reads `1.1e-11` here against `3.0e-15` from a dense diagonalisation: that is the eigenvector convergence of a near-degenerate pair at
+`5.9e-10`, not a different number. (2) The transverse-plane eigenproblems use sparse shift-invert, as the source does. (3) The largest dense matrix built anywhere is `1152 x 1152`. (4) The `n = +2` and `n = -1` single-vortex planes, the `p = 0` and `p = -0.1`
+tables, the heat-kernel cut-free index density, the `2^12` loop-winding histogram and the site-wise growth walk are computed in the source campaign and **not** recomputed here; no number from them is claimed.
+
+**Not claimed.** That `L_CONT` or `L_HYB` is the framework's law — neither is landed, and `L_HYB` is this note's own construction. Any derivation of the mass coupling, `M2`, the tilt, the class map, the core position or the two-dimensional record order. Anything
+at the many-body level. The record-time density-`1/2` index, which is undefined here because the gap is filled and the two cuts disagree. Junction configurations in the matter law. Any general statement about the odds of a winding under sequential formation
+beyond the declared orders. **Nothing here is read out of the axioms**: the alphabet, both laws, the odds, the mass coupling, the fields, the sizes and the cuts are declared objects, and no coefficient is derived.
+
+## Review record
+
+**Honest-auditor read.** An auditor should come away with three exact results, one exact price, and one numerical census, in that order. First, the **register is real**: the phase readout is exact rational, depends on record content alone, and the supplied mass
+couples to it covariantly with an exact node gap — the object the string branch said the framework had nowhere to keep is a possibility of the qubit domain that Record locks. Second, the **landed law does not carry it as a field**: a census complete over all
+`262144` neighbourhood conditions gives the echo lemma at `262144/262144` and `I` for every fully recorded bulk, the Gibbs censuses give `64/40353607` and `19/5764801` with direction degrees in `{1, 3}`, and formation from no seed is sterile over all `40320`
+orders. Third, the **odds price is exact**: a rotation-invariant fibre carries `rho = I/2` by an exact rank-3 computation, so the bulk sign is `1/2, 1/2` and a class tick costs `2^-N^2`. Then the census: on a variant law that does support the smooth field, `2n`
+per string, `n` per record-time vortex, and the compensating partner present in every geometry at machine-zero total.
+
+The auditor should also come away with five caveats. `L_HYB`, the relaxed fields and the torus pair field are **model constructions**, not landed objects, and every `T4` number is a statement about them. The string results are **numerical on finite geometries**,
+and the ring compensation is read from a splitting that is small (`7.748e-06` at `N = 48`), not zero. The region-resolved handedness needs the **declared light cut**; without it the `l = 1` states hybridised with the ring pollute the disc sums. The torus pair
+field must be **built**, not relaxed into, or a second pair nucleates. And a long list of items is **supplied** — both laws, reading R1, the odds and their tilt, the mass coupling with `M_0` and `M2`, the core positions, the pinned seeds, the flip patterns and
+every size — so this note bounds what the declared constructions give, and not what the axioms give.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the pointers in "Interfaces" carry no grade and no weight. The ledger is fully unaudited since 2026-08-07, and no status word
+in this note describes any current audit standing. Hard landing conditions are a fresh runner and cache pair closing at `PASS=29 FAIL=0`, runtime under the declared `AUDIT_TIMEOUT_SEC = 300`, and passing pipeline and strict-lint gates; independent audit remains
+a separate lane.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py
+```
+
+Expected terminal summary:
+
+```text
+TOTAL: PASS=29 FAIL=0
+```

--- a/logs/runner-cache/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.txt
+++ b/logs/runner-cache/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.txt
@@ -1,0 +1,42 @@
+===== runner cache v1 =====
+runner: scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py
+runner_sha256: c1e275b33cbd72882b3433d4566e8bd5631049778720eb12b9c4843fdac6b154
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 20.46
+status: ok
+----- stdout -----
+PASS A1 [exact] L_CONT rebuilt (PR #7926): {m}->binary; {m1,m2,m3}->ternary, weights (3/4,5/8,5/8), sum 2, weighted sum 0; {m1,m2}->coin (1/5,4/5); {m,m}, 6 equal, empty, I-only -> {I}
+PASS A2 [exact] L_CONT covariance S(g.n) = g.S(n) on 37056 checks (24 rotations x every slot pattern with 1-3 records from 4 directions): 0 mismatches
+PASS A3 [exact] the register: (cos phi, sin phi) = (n.e_1, n.e_2) on the declared circle, exact at 7 rational points, same at c = 1 and c = 1/2, none for cI; the C_4 sends (3/5,4/5) to (-4/5,3/5), phi -> phi + pi/2
+PASS A4 [1e-12] the H2 mass couples covariantly: for a uniform phase phi = 0, 0.7, 2.0 the node spectrum is +-M_0 = +-0.7 fourfold, max dev 8.9e-16
+PASS A5 [1e-14] the Dirac mass is the cell average of the record-read mass: tr(eps D)/8 = 0.250000 = the cell average 0.250000, so density d gives Dirac mass d M_0
+PASS B1 [exact] complete census over all 8^6 = 262144 conditions (slots blank, I or P(d), 6 directions): a rank-one effect is supported for 1152/1152 of kP = 1 and 960 of kP = 3 (the positively spanning triples), never for kP = 0, 2, 4, 5, 6
+PASS B2 [exact] ECHO LEMMA: every rank-one direction in a support is a neighbour's or its antipode, 262144 of 262144; a fully recorded bulk site (kP = 6, 46656) is an I record
+PASS B3 [exact] Gibbs census, 3x3 periodic plane, 7 letters: 64 of 7^9 = 40353607 supported everywhere, direction degrees {1: 108, 3: 216}, at most 6 of 9 directional
+PASS B4 [exact] 2x2x2 open cube: 19 of 7^8 = 5764801, degrees {1: 72}, at most 4 of 8 -- dimers only
+PASS B5 [exact] from NO seed, every order and pick on the 2x2x2 cube: all 8! = 40320 form only I records, 0 directions ever offered
+PASS B6 [exact] from seeds it only echoes them: one seed -> 57264 leaves offering only {m_1, -m_1}; three seeds -> 2880 leaves, nothing beyond the seeds and antipodes
+PASS C1 [1e-9] supercell Bloch scan (16^3) of the 3D matter law: the uniform control is gapped at 0.7000 and 1.5000, every dimer superlattice (densities 1/6, 1/3, 1/8, both M_0, phases 0 and pi/2) is GAPLESS, max 5.8e-16 over 12
+PASS C2 [numerical] the dilute winding, 48x48 plane (M_0 = 1.5, 768 sites at density 1/6, 0 violations): 7 states below |E| = 0.1, smallest 0.0008, uniform gap 1.5027
+PASS C3 [numerical] the same field in H1's operator (M = 0.8, r_s = 1, hard ends, density 1/3, 0 violations) is GAPPED at 0.267204 (N = 24), 0.246455 (N = 32); M/3 = 0.2667
+PASS C4 [numerical] and carries the index: N = 32, cut 0.12 -> 2 light states, max|E| 2.364e-03 (next 0.22978), interior +0.951637036, edge -0.828326136
+PASS D1 [1e-13] L_HYB (this note's variant, not landed) supports the smooth vortex as its own fixed point: residual 9.9e-15/1.0e-14/1.1e-14 over 960/1792/4224 unpinned sites (N = 24/32/48), min n.vhat +1.000000, winding +1 on loops 2, 4, 6
+PASS D2 [numerical] the string carries 2n co-moving modes: 2 core modes at E = +0.09983 +0.09983, <V_z> = +0.995 +0.995, v = 0.998; the cut keeps 4 states
+PASS D3 [numerical] bulk net handedness (cut 0.3): h = +1.9983 at R = 14, +1.9983 at R = 18 on 48x48, +1.9864 at R = 11 on 32x32; whole plane 7.2e-16, -2.4e-15, 2.1e-15 -- the -2n is on the ring
+PASS D4 [numerical] the core pair decouples exponentially: p = 0 splitting 3.125e-03, 3.991e-04, 7.748e-06 at N = 24, 32, 48
+PASS D5 [numerical] torus: the pair forces a 2 pi winding along the cycle between them -- relaxed at 9.8e-15/9.9e-15, y-cycle windings [0.0, 1.0], exactly 2/2 vortex plaquettes, 4 light states carrying +1.9767/-1.9767 (48x24), +1.9836/-1.9836 (64x32) at r < 11, torus 2.7e-15
+PASS D6 [numerical] H1's geometry: the relaxed field is an L_HYB fixed point (residual 9.5e-15) giving interior +0.999991511 at N = 32, edge ring -0.997255565, net 1.1e-11 over 2 light states (max|E| 5.9e-10, next 0.31023)
+PASS D7 [exact] a site-centred core is registered I by BOTH laws (neighbours at 0, 90, 180, 270 deg, |v_core| = 6.5e-22, relaxed 25x25): the mass zero there is the law's
+PASS E1 [exact] the dipole class map sends a fully recorded condition to lambda = (0, 0, 0); the only Bloch vector fixed by all 24 rotations is 0 (rank 3), so rho = I/2 and the bulk menu has odds 1/2, 1/2 -- a fair coin
+PASS E2 [exact] a dimer with its phase circle normal to the axis (lambda = e_z, t = 2/3) gives 1/2, 1/2; tilted onto the x-z circle 23/30, 7/30; ternary odds in the invariant fibre 3/8, 5/16, 5/16 = c_k/2
+PASS E3 [exact] one class tick re-registers the vortex unflipped with odds 2^-N^2 = 10^-173.4, 10^-308.3, 10^-693.6 (N = 24, 32, 48); with tilt 2/3, (5/6)^N^2 = 10^-45.6, 10^-81.1, 10^-182.4
+PASS E4a [numerical] a coin-signed field has no string mode: density 1/2 (mean sign +0.000) leaves 0 core modes on the 24x24 vortex; none (+1.000) keeps 2 at E = +0.09988 +0.09988, 1/9 (+0.778) keeps 2, ~1/6 (+0.663) keeps 2
+PASS E4b [numerical] the coin fills H1's gap: density 1/2 -> 18 light states (max|E| 0.289, next 0.318), interior -0.059; none -> 2, +0.999951757; 1/9 -> 2, +0.998770616; ~1/6 -> 2, +0.997107900
+PASS E5 [1e-3] a record-value class map with a supplied tilt t: at t = 0 the flip density is 0.3724, I-density 0.2553, mean mass +0.0000 (a director with a coin); t = 2/3 keeps +0.6217, t = 9/10 +0.8979
+PASS F1 [1e-9] solver certificate: sparse shift-invert agrees with dense LAPACK on a 12x12 record-time square to 9.5e-15 over the 20 nearest zero; largest dense 1152; no seed
+SUMMARY: a register; no field under the landed law; a field under a variant; a fair-coin sign.  [19.4 s]
+TOTAL: PASS=29 FAIL=0
+
+----- stderr -----
+

--- a/scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py
+++ b/scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py
@@ -1,0 +1,1346 @@
+#!/usr/bin/env python3
+"""The continuum record alphabet keeps the winding phase as record content, the
+record-echo law does not support it as a field, and the fibred Born odds
+register its sign as a fair coin.
+
+Self-contained class-A runner.  Every object is declared here; nothing is
+derived from any axiom.  There is no random number and no seed anywhere: every
+field, pattern and formation order is declared arithmetic, and the
+"quasi-random" flip patterns are the deterministic frac(x*golden + y*sqrt2).
+
+SOURCE BLOCKS COPIED.  Each helper below reproduces a named block of the H3
+scratch campaign (scratchpad/H3/), and is copied so this runner stands alone:
+
+  dot/add/neg/cross/solve_exact/ternary_weights/dirs_of/L_CONT/mean_dir/
+  L_HYB/in_support/phase_of/_rots/matvec/rot_rec/SLOTS/circle_dir
+        <- h3_common.py, blocks "exact vector helpers" and the exact record
+           rules (L_CONT is PR #7926's law verbatim in its branch structure,
+           re-implemented there from continuum_abundance_check.py:252-272;
+           L_HYB is the H3 probe's variant, not landed anywhere)
+  P3/G/XI/EPS/M2S/CHI/Plane/build_H/ingap_modes
+        <- h3_common.py, block "cell algebra (H2 conventions)"
+  relax_xy_fast/support_residual/winding_number/loop_sites
+        <- h3_common.py, block "XY relaxation (L_HYB fixed points)"
+  cell_density/analytic_field/torus_pair_field/relaxed_field/
+  dilute_dimer_field/check_dimer_support/supercell_gap
+        <- h3_b_vortex3d.py, blocks B0-B5
+  A1..A4/B4/chain_ops/square_ops/D4/grid/chi_density4/interior_mask/
+  analytic_dirs/relax2d/support_check2d/rt_profile
+        <- h3_c_recordtime.py, block "H1's operator, verbatim" and C1-C6
+  build_table/census/degree_stats  <- h3_a_register.py, block A5
+  form_all                         <- h3_a_register.py, block A4
+  rho_of_label/born/lam            <- h3_a_register.py, block A6
+  flip_step                        <- h3_d_formation.py, block D2
+
+DECLARED REDUCTIONS relative to the source campaign.  (1) H1's record-time
+operator D4 is assembled sparse and solved by shift-invert about E = 0 instead
+of dense LAPACK; group F1 certifies the two solvers agree on a small square.
+(2) The transverse-plane eigenproblems use sparse shift-invert exactly as the
+source does.  (3) The largest dense matrix built anywhere is 1152 x 1152 (the
+24 x 24 transverse plane of group E); every other dense object is at most
+24 x 24.  Sizes are stated in every check label.
+
+GROUPS
+  A  T1  the register: the phase readout is record content; the H2 mass couples
+         to it covariantly; the node gap is M_0 for every uniform phase; the
+         Dirac mass is the cell average of the record-read mass.
+  B  T2  the complete support census of L_CONT over all 8^6 neighbourhood
+         conditions; the echo lemma; the Gibbs census; formation from no seed
+         and from seeds.
+  C  T3  the dilute (dimer-superlattice) winding is gapless in the staggered 3D
+         matter law and gapped, index-carrying, in H1's record-time operator.
+  D  T4  the variant law L_HYB supports the smooth vortex as its own fixed
+         point; 2n co-moving modes; the bulk net handedness; the torus pair;
+         H1's geometry; the core.
+  E  T5  the fibred Born odds register the phase's sign as a fair coin; flip
+         patterns; the tilted class map.
+  F      solver certificate.
+
+Output: one PASS/FAIL line per check and a final `TOTAL: PASS=N FAIL=M`.
+"""
+from __future__ import annotations
+
+import math
+import sys
+import time
+from fractions import Fraction as F
+from itertools import combinations, permutations, product
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+AUDIT_TIMEOUT_SEC = 300
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    """Record and print one check."""
+    global PASS, FAIL
+    ok = bool(cond)
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print(("PASS " if ok else "FAIL ") + label)
+
+
+# ===================================================================== h3_common.py
+# --- exact vector helpers ------------------------------------------------------
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+def add(a, b):
+    return tuple(x + y for x, y in zip(a, b))
+
+
+def neg(a):
+    return tuple(-x for x in a)
+
+
+def smul(s, a):
+    return tuple(s * x for x in a)
+
+
+def cross(a, b):
+    return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
+
+def solve_exact(A, b):
+    """Exact Gaussian elimination on the augmented matrix; None if not unique."""
+    m, n = len(A), len(A[0])
+    M = [list(row) + [bb] for row, bb in zip(A, b)]
+    piv_cols = []
+    r = 0
+    for c in range(n):
+        p = None
+        for i in range(r, m):
+            if M[i][c] != 0:
+                p = i
+                break
+        if p is None:
+            continue
+        M[r], M[p] = M[p], M[r]
+        pv = M[r][c]
+        M[r] = [x / pv for x in M[r]]
+        for i in range(m):
+            if i != r and M[i][c] != 0:
+                f = M[i][c]
+                M[i] = [x - f * y for x, y in zip(M[i], M[r])]
+        piv_cols.append(c)
+        r += 1
+        if r == m:
+            break
+    for i in range(r, m):
+        if M[i][n] != 0:
+            return None
+    if len(piv_cols) < n:
+        return None
+    x = [F(0)] * n
+    for i, c in enumerate(piv_cols):
+        x[c] = M[i][n]
+    return x
+
+
+def ternary_weights(n1, n2, n3):
+    A = [[n1[0], n2[0], n3[0]], [n1[1], n2[1], n3[1]], [n1[2], n2[2], n3[2]], [F(1), F(1), F(1)]]
+    c = solve_exact(A, [F(0), F(0), F(0), F(2)])
+    if c is None or any(x <= 0 for x in c):
+        return None
+    return c
+
+
+def dirs_of(cond):
+    """Multiset of recorded Bloch directions (reading R1: a cI record has none)."""
+    return [rec[2] for rec in cond if rec[0] == "P"]
+
+
+def L_CONT(cond):
+    """PR #7926's record-echo law, verbatim in its branch structure (list count)."""
+    ms = dirs_of(cond)
+    if len(ms) == 1:
+        m = ms[0]
+        return (("P", F(1), m), ("P", F(1), neg(m)))
+    if len(ms) == 3:
+        c = ternary_weights(*ms)
+        if c is not None:
+            return tuple(("P", c[k], ms[k]) for k in range(3))
+        return (("I", F(1)),)
+    if len(ms) == 2:
+        a = (1 + dot(ms[0], ms[1])) / 2
+        if 0 < a < 1:
+            return (("I", a), ("I", 1 - a))
+        return (("I", F(1)),)
+    return (("I", F(1)),)
+
+
+def mean_dir(ms):
+    v = (F(0), F(0), F(0))
+    for m in ms:
+        v = add(v, m)
+    return v, dot(v, v)
+
+
+def L_HYB(cond):
+    """The H3 probe's variant: L_CONT on 1-3 recorded directions, otherwise the
+    binary resolution {P(vhat), P(-vhat)} of the neighbour mean v (v = 0 -> {I}).
+    Returned symbolically as ("PDIR", v).  Not landed anywhere."""
+    ms = dirs_of(cond)
+    if 1 <= len(ms) <= 3:
+        return L_CONT(cond)
+    v, v2 = mean_dir(ms)
+    if v2 == 0:
+        return (("I", F(1)),)
+    return (("PDIR", v),)
+
+
+def in_support(rec, S):
+    for it in S:
+        if it[0] == "PDIR":
+            if rec[0] != "P" or rec[1] != 1:
+                continue
+            if cross(rec[2], it[1]) == (0, 0, 0):
+                return True
+            continue
+        if it[0] == rec[0] and it[1] == rec[1] and (it[0] == "I" or it[2] == rec[2]):
+            return True
+    return False
+
+
+def phase_of(rec, e1=(F(1), F(0), F(0)), e2=(F(0), F(1), F(0))):
+    """The phase readout (cos phi, sin phi) = (n.e1, n.e2) on the declared circle."""
+    if rec[0] != "P":
+        return None
+    n = rec[2]
+    return (dot(n, e1), dot(n, e2))
+
+
+def _rots():
+    out = []
+    for perm in [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]:
+        for signs in product([1, -1], repeat=3):
+            R = [[F(0)] * 3 for _ in range(3)]
+            for i in range(3):
+                R[i][perm[i]] = F(signs[i])
+            det = (R[0][0] * (R[1][1] * R[2][2] - R[1][2] * R[2][1])
+                   - R[0][1] * (R[1][0] * R[2][2] - R[1][2] * R[2][0])
+                   + R[0][2] * (R[1][0] * R[2][1] - R[1][1] * R[2][0]))
+            if det == 1:
+                out.append(R)
+    return out
+
+
+ROTS = _rots()
+
+
+def matvec(R, v):
+    return tuple(sum(R[i][j] * v[j] for j in range(3)) for i in range(3))
+
+
+def rot_rec(R, rec):
+    if rec[0] == "P":
+        return ("P", rec[1], matvec(R, rec[2]))
+    if rec[0] == "PDIR":
+        return ("PDIR", matvec(R, rec[1]))
+    return rec
+
+
+SLOTS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+
+
+def circle_dir(t):
+    """Exact rational unit vector on the x-y great circle; t = tan(phi/2)."""
+    d = 1 + t * t
+    return ((1 - t * t) / d, 2 * t / d, F(0))
+
+
+# --- cell algebra (H2 conventions) --------------------------------------------
+I2 = np.eye(2)
+Xp = np.array([[0, 1], [1, 0]], complex)
+Yp = np.array([[0, -1j], [1j, 0]])
+Zp = np.diag([1.0, -1.0]).astype(complex)
+PAULI = {"I": I2, "X": Xp, "Y": Yp, "Z": Zp}
+
+
+def P3(s):
+    return np.kron(np.kron(PAULI[s[0]], PAULI[s[1]]), PAULI[s[2]])
+
+
+G = [P3("YII"), P3("ZYI"), P3("ZZY")]
+XI = [P3("XII"), P3("ZXI"), P3("ZZX")]
+EPS = P3("ZZZ")
+M2S = P3("XYX")
+CHI = 1j * G[0] @ G[1] @ G[2]
+
+
+class Plane:
+    """Transverse (x, y) plane of coarse sites with the z cell bit b."""
+
+    def __init__(self, Nx, Ny, periodic=False):
+        assert Nx % 2 == 0 and Ny % 2 == 0
+        self.Nx, self.Ny, self.periodic = Nx, Ny, periodic
+        self.D = 2 * Nx * Ny
+        xs, ys, bs = np.meshgrid(np.arange(Nx), np.arange(Ny), np.arange(2), indexing="ij")
+        self.x = xs.ravel()
+        self.y = ys.ravel()
+        self.b = bs.ravel()
+        self.cells = [(X, Y) for X in range(Nx // 2) for Y in range(Ny // 2)]
+
+    def idx(self, x, y, b):
+        return (x * self.Ny + y) * 2 + b
+
+    def cell_sites(self, X, Y):
+        return [self.idx(2 * X + b1, 2 * Y + b2, b3)
+                for b1 in range(2) for b2 in range(2) for b3 in range(2)]
+
+    def hop_matrices(self):
+        Nx, Ny, idx = self.Nx, self.Ny, self.idx
+        rows, cols, vals = [], [], []
+        zr, zc, zv = [], [], []
+        for x in range(Nx):
+            for y in range(Ny):
+                for b in range(2):
+                    i = idx(x, y, b)
+                    if x + 1 < Nx or self.periodic:
+                        j = idx((x + 1) % Nx, y, b)
+                        rows += [j, i]
+                        cols += [i, j]
+                        vals += [1.0, 1.0]
+                    if y + 1 < Ny or self.periodic:
+                        amp = (-1.0) ** x
+                        j = idx(x, (y + 1) % Ny, b)
+                        rows += [j, i]
+                        cols += [i, j]
+                        vals += [amp, amp]
+                eta3 = (-1.0) ** (x + y)
+                i0, i1 = idx(x, y, 0), idx(x, y, 1)
+                rows += [i1, i0]
+                cols += [i0, i1]
+                vals += [eta3, eta3]
+                zr += [i0]
+                zc += [i1]
+                zv += [eta3]
+        H0 = sp.csr_matrix((vals, (rows, cols)), shape=(self.D, self.D), dtype=complex)
+        Zi = sp.csr_matrix((zv, (zr, zc)), shape=(self.D, self.D), dtype=complex)
+        return H0, Zi
+
+    def cell_operator(self, O8):
+        rows, cols, vals = [], [], []
+        nz = np.argwhere(np.abs(O8) > 0)
+        for (X, Y) in self.cells:
+            s = self.cell_sites(X, Y)
+            for i, j in nz:
+                rows.append(s[i])
+                cols.append(s[j])
+                vals.append(O8[i, j])
+        return sp.csr_matrix((vals, (rows, cols)), shape=(self.D, self.D), dtype=complex)
+
+    def m2_hop_operator(self, m2_site):
+        """The body-diagonal hop M2 with each hop's amplitude the MEAN of the two
+        endpoint records' m_2 (each hop reads its two records)."""
+        rows, cols, vals = [], [], []
+        nz = np.argwhere(np.abs(M2S) > 0)
+        for (X, Y) in self.cells:
+            s = self.cell_sites(X, Y)
+            for i, j in nz:
+                rows.append(s[i])
+                cols.append(s[j])
+                vals.append(0.5 * (m2_site[s[i]] + m2_site[s[j]]) * M2S[i, j])
+        return sp.csr_matrix((vals, (rows, cols)), shape=(self.D, self.D), dtype=complex)
+
+    def neighbours_inplane(self, i):
+        x, y, b = self.x[i], self.y[i], self.b[i]
+        out = []
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            xx, yy = x + dx, y + dy
+            if self.periodic:
+                xx %= self.Nx
+                yy %= self.Ny
+            elif not (0 <= xx < self.Nx and 0 <= yy < self.Ny):
+                continue
+            out.append(self.idx(xx, yy, b))
+        return out
+
+
+def build_H(pl, rvec, M0, H0, Zi, e1=(1, 0, 0), e2=(0, 1, 0)):
+    """The dressed one-particle Hamiltonian read from the record Bloch vectors."""
+    e1 = np.asarray(e1, float)
+    e2 = np.asarray(e2, float)
+    m1 = M0 * (rvec @ e1)
+    m2 = M0 * (rvec @ e2)
+    eps = (-1.0) ** (pl.x + pl.y + pl.b)
+    Hstat = (H0 + sp.diags(eps * m1) + pl.m2_hop_operator(m2)).tocsr()
+
+    def H(q):
+        return (Hstat + Zi * np.exp(-1j * q) + Zi.conj().T * np.exp(1j * q)).tocsr()
+
+    def V(q):
+        return (-1j * Zi * np.exp(-1j * q) + 1j * Zi.conj().T * np.exp(1j * q)).tocsr()
+
+    return H, V
+
+
+def ingap_modes(Hq, k, window):
+    E, U = spla.eigsh(Hq, k=k, sigma=0.0, which="LM", tol=1e-12)
+    o = np.argsort(E)
+    E, U = E[o], U[:, o]
+    sel = np.abs(E) < window
+    return E[sel], U[:, sel]
+
+
+# --- XY relaxation (L_HYB fixed points) ---------------------------------------
+def relax_xy_fast(pl, n0, pinned, zterm=2.0, tol=1e-14, maxit=200000):
+    n = n0.copy()
+    nbl = np.array([pl.neighbours_inplane(i) + [i] * (4 - len(pl.neighbours_inplane(i)))
+                    for i in range(pl.D)])
+    cnt = np.array([len(pl.neighbours_inplane(i)) for i in range(pl.D)])
+    pad = 4 - cnt
+    free = ~pinned
+    for it in range(maxit):
+        s = n[nbl].sum(1) - pad[:, None] * n + zterm * n
+        norm = np.linalg.norm(s, axis=1)
+        new = n.copy()
+        m = free & (norm > 0)
+        new[m] = s[m] / norm[m, None]
+        delta = np.max(np.abs(new - n))
+        n = new
+        if delta < tol:
+            return n, it + 1
+    return n, maxit
+
+
+def support_residual(pl, n, zterm=2.0):
+    nbl = [pl.neighbours_inplane(i) for i in range(pl.D)]
+    res = np.zeros(pl.D)
+    dotp = np.zeros(pl.D)
+    for i in range(pl.D):
+        v = n[nbl[i]].sum(0) + zterm * n[i]
+        vn = np.linalg.norm(v)
+        if vn > 0:
+            res[i] = np.linalg.norm(np.cross(n[i], v)) / vn
+            dotp[i] = n[i] @ v / vn
+    return res, dotp
+
+
+def winding_number(phis):
+    d = np.diff(np.append(phis, phis[0]))
+    d = (d + np.pi) % (2 * np.pi) - np.pi
+    return float(np.sum(d) / (2 * np.pi))
+
+
+def loop_sites(pl, xc, yc, R, b=0):
+    pts = []
+    x0, x1 = int(round(xc - R)), int(round(xc + R))
+    y0, y1 = int(round(yc - R)), int(round(yc + R))
+    for x in range(x0, x1 + 1):
+        pts.append((x, y0))
+    for y in range(y0 + 1, y1 + 1):
+        pts.append((x1, y))
+    for x in range(x1 - 1, x0 - 1, -1):
+        pts.append((x, y1))
+    for y in range(y1 - 1, y0, -1):
+        pts.append((x0, y))
+    out = []
+    for (x, y) in pts:
+        if pl.periodic:
+            x %= pl.Nx
+            y %= pl.Ny
+        elif not (0 <= x < pl.Nx and 0 <= y < pl.Ny):
+            return None
+        out.append(pl.idx(x, y, b))
+    return out
+
+
+# ===================================================================== h3_b_vortex3d.py
+M0 = 0.7
+WGAP = 0.98 * M0
+
+
+def cell_density(pl, psi, O8):
+    out = np.zeros(len(pl.cells))
+    for ci, (X, Y) in enumerate(pl.cells):
+        s = pl.cell_sites(X, Y)
+        v = psi[s]
+        out[ci] = np.real(v.conj() @ O8 @ v)
+    return out
+
+
+def analytic_field(pl, cores):
+    r = np.zeros((pl.D, 3))
+    for i in range(pl.D):
+        ph = 0.0
+        for (xc, yc, n) in cores:
+            ph += n * np.arctan2(pl.y[i] - yc, pl.x[i] - xc)
+        r[i] = [np.cos(ph), np.sin(ph), 0.0]
+    return r
+
+
+def torus_pair_field(pl, cores):
+    """Single-valued phase with vorticity 2 pi n at the core plaquettes and integer
+    cycle windings: Poisson solve for the stream function, discrete curl, a uniform
+    twist making the cycle circulations integers, integration on a spanning tree."""
+    Nx, Ny = pl.Nx, pl.Ny
+    q = np.zeros((Nx, Ny))
+    for (xc, yc, n) in cores:
+        q[int(round(xc - 0.5)), int(round(yc - 0.5))] += 2 * np.pi * n
+    kx = 2 * np.pi * np.fft.fftfreq(Nx)
+    ky = 2 * np.pi * np.fft.fftfreq(Ny)
+    lap = 2 * np.cos(kx)[:, None] + 2 * np.cos(ky)[None, :] - 4
+    qk = np.fft.fft2(q)
+    psik = np.zeros_like(qk)
+    m = np.abs(lap) > 1e-12
+    psik[m] = qk[m] / lap[m]
+    psi = np.real(np.fft.ifft2(psik))
+    ux = psi - np.roll(psi, 1, axis=1)
+    uy = np.roll(psi, 1, axis=0) - psi
+    c0 = (int(round(cores[0][0] - 0.5)), int(round(cores[0][1] - 0.5)))
+    if (ux + np.roll(uy, -1, axis=0) - np.roll(ux, -1, axis=1) - uy)[c0] * cores[0][2] < 0:
+        ux, uy = -ux, -uy
+    cx = ux.sum(0)
+    cy = uy.sum(1)
+    tx = (np.round(cx.mean() / (2 * np.pi)) * 2 * np.pi - cx.mean()) / Nx
+    ty = -cy[0] / Ny
+    ux = ux + tx
+    uy = uy + ty
+    phi = np.zeros((Nx, Ny))
+    for x in range(1, Nx):
+        phi[x, 0] = phi[x - 1, 0] + ux[x - 1, 0]
+    for y in range(1, Ny):
+        phi[:, y] = phi[:, y - 1] + uy[:, y - 1]
+    circ = ux + np.roll(uy, -1, axis=0) - np.roll(ux, -1, axis=1) - uy
+    r = np.zeros((pl.D, 3))
+    for i in range(pl.D):
+        r[i] = [np.cos(phi[pl.x[i], pl.y[i]]), np.sin(phi[pl.x[i], pl.y[i]]), 0.0]
+    return r, circ, uy.sum(1)
+
+
+def relaxed_field(pl, cores):
+    """The L_HYB fixed point: XY relaxation from the analytic field (open plane) or
+    from the exact torus pair field (torus), with the boundary ring and the four
+    plaquette corners about each core pinned (the core position is supplied)."""
+    if pl.periodic:
+        n0, circ, cy = torus_pair_field(pl, cores)
+        pinned = np.zeros(pl.D, bool)
+    else:
+        n0 = analytic_field(pl, cores)
+        circ = cy = None
+        pinned = np.minimum.reduce([pl.x, pl.y, pl.Nx - 1 - pl.x, pl.Ny - 1 - pl.y]) < 0.5
+    for (xc, yc, _) in cores:
+        pinned |= (np.abs(pl.x - xc) < 0.75) & (np.abs(pl.y - yc) < 0.75)
+    n, _ = relax_xy_fast(pl, n0, pinned)
+    res, dotp = support_residual(pl, n)
+    free = ~pinned
+    return n, float(res[free].max()), float(dotp[free].min()), int(free.sum()), circ, cy
+
+
+def dilute_dimer_field(pl, cores, period=3):
+    """The L_CONT-supported field: same-direction x-dimers, everything else
+    unrecorded (r = 0)."""
+    r = np.zeros((pl.D, 3))
+    rec = np.zeros(pl.D, bool)
+    for i in range(pl.D):
+        x, y, b = pl.x[i], pl.y[i], pl.b[i]
+        if b != 0 or y % 2 != 0 or x % period not in (0, 1):
+            continue
+        if x % period == 1 and x - 1 < 0:
+            continue
+        if x % period == 0 and x + 1 >= pl.Nx:
+            continue
+        xm = (x - (x % period)) + 0.5
+        ph = sum(n * np.arctan2(y - yc, xm - xc) for (xc, yc, n) in cores)
+        r[i] = [np.cos(ph), np.sin(ph), 0.0]
+        rec[i] = True
+    return r, rec
+
+
+def check_dimer_support(pl, r, rec):
+    """Exact L_CONT support check: every recorded site sees exactly its partner."""
+    bad = 0
+    nrec = 0
+    for i in range(pl.D):
+        if not rec[i]:
+            continue
+        nrec += 1
+        recs = [j for j in pl.neighbours_inplane(i) if rec[j]]
+        if len(recs) != 1 or not np.allclose(r[recs[0]], r[i]):
+            bad += 1
+    return nrec, bad
+
+
+def supercell_gap(M0_, recfn, box, phi=0.0, nq=16):
+    """Periodic-supercell Bloch scan of the staggered 3D matter law on a record
+    pattern; returns the minimum |E| over the declared q grid."""
+    Lx, Ly, Lz = box
+    sites = [(x, y, z) for x in range(Lx) for y in range(Ly) for z in range(Lz)]
+    idx = {s_: i for i, s_ in enumerate(sites)}
+    Dm = len(sites)
+    gmin = 1e9
+    qs = np.linspace(-np.pi, np.pi, nq, endpoint=False)
+    for qx in qs:
+        for qy in qs:
+            for qz in qs:
+                Hm = np.zeros((Dm, Dm), complex)
+                for (x, y, z) in sites:
+                    i = idx[(x, y, z)]
+                    eta = [1.0, (-1) ** x, (-1) ** (x + y)]
+                    for a, dv in enumerate([(1, 0, 0), (0, 1, 0), (0, 0, 1)]):
+                        nx_, ny_, nz_ = x + dv[0], y + dv[1], z + dv[2]
+                        ph = 1.0
+                        if nx_ == Lx:
+                            nx_ = 0
+                            ph = np.exp(-1j * qx)
+                        if ny_ == Ly:
+                            ny_ = 0
+                            ph = np.exp(-1j * qy)
+                        if nz_ == Lz:
+                            nz_ = 0
+                            ph = np.exp(-1j * qz)
+                        j = idx[(nx_, ny_, nz_)]
+                        Hm[j, i] += eta[a] * ph
+                        Hm[i, j] += eta[a] * np.conj(ph)
+                    if recfn(x, y, z):
+                        Hm[i, i] += M0_ * np.cos(phi) * (-1) ** (x + y + z)
+                for X in range(Lx // 2):
+                    for Y in range(Ly // 2):
+                        for Z in range(Lz // 2):
+                            for b1 in range(2):
+                                for b2 in range(2):
+                                    for b3 in range(2):
+                                        bb = (1 - b1, 1 - b2, 1 - b3)
+                                        si = (2 * X + b1, 2 * Y + b2, 2 * Z + b3)
+                                        sj = (2 * X + bb[0], 2 * Y + bb[1], 2 * Z + bb[2])
+                                        i, j = idx[si], idx[sj]
+                                        m2i = M0_ * np.sin(phi) if recfn(*si) else 0.0
+                                        m2j = M0_ * np.sin(phi) if recfn(*sj) else 0.0
+                                        ii = b1 * 4 + b2 * 2 + b3
+                                        jj = bb[0] * 4 + bb[1] * 2 + bb[2]
+                                        Hm[i, j] += 0.5 * (m2i + m2j) * M2S[ii, jj]
+                gmin = min(gmin, float(np.min(np.abs(np.linalg.eigvalsh(Hm)))))
+    return gmin
+
+
+# ===================================================================== h3_c_recordtime.py
+S1 = np.array([[0, 1], [1, 0]], dtype=complex)
+S2 = np.array([[0, -1j], [1j, 0]])
+S3 = np.diag([1, -1]).astype(complex)
+A1 = np.kron(S1, S1)
+A2 = np.kron(S1, S2)
+A3 = np.kron(S1, S3)
+A4 = np.kron(S2, np.eye(2, dtype=complex))
+B4 = A1 @ A2 @ A3 @ A4
+M_DEF = 0.8
+R_S = 1.0
+
+
+def chain_ops(n):
+    """H1's hard-ended chain: K = -i/2 (shift - shift^dag), LAP the Wilson term."""
+    k = sp.lil_matrix((n, n), dtype=complex)
+    lap = sp.lil_matrix((n, n), dtype=complex)
+    for s in range(n - 1):
+        k[s, s + 1] += -0.5j
+        k[s + 1, s] += 0.5j
+        lap[s, s] += 0.5
+        lap[s + 1, s + 1] += 0.5
+        lap[s, s + 1] += -0.5
+        lap[s + 1, s] += -0.5
+    lap[0, 0] += 0.5
+    lap[n - 1, n - 1] += 0.5
+    return k.tocsr(), lap.tocsr()
+
+
+def square_ops(n1, n2):
+    k1, l1 = chain_ops(n1)
+    k2, l2 = chain_ops(n2)
+    E1 = sp.identity(n1, format="csr", dtype=complex)
+    E2 = sp.identity(n2, format="csr", dtype=complex)
+    return sp.kron(k1, E2), sp.kron(E1, k2), sp.kron(l1, E2) + sp.kron(E1, l2)
+
+
+def D4(n1, n2, m1, m2):
+    """H1's operator: K_1 a_1 + K_2 a_2 + [diag(m1) + r_s LAP] a_3 + diag(m2) a_4."""
+    K1, K2, LAP = square_ops(n1, n2)
+    mass1 = sp.diags(np.asarray(m1, dtype=float).ravel()) + R_S * LAP
+    mass2 = sp.diags(np.asarray(m2, dtype=float).ravel())
+    return (sp.kron(K1, A1) + sp.kron(K2, A2) + sp.kron(mass1, A3) + sp.kron(mass2, A4)).tocsc()
+
+
+def grid(n1, n2):
+    u = np.arange(n1)[:, None] - (n1 - 1) / 2.0
+    v = np.arange(n2)[None, :] - (n2 - 1) / 2.0
+    return np.broadcast_to(u, (n1, n2)).copy(), np.broadcast_to(v, (n1, n2)).copy()
+
+
+def chi_density4(evec, idx, n1, n2):
+    v = evec[:, idx].reshape(n1 * n2, 4, -1)
+    return np.einsum("scm,cd,sdm->s", v.conj(), B4, v).real.reshape(n1, n2)
+
+
+def interior_mask(n1, n2, pad):
+    m = np.zeros((n1, n2), bool)
+    m[pad:n1 - pad, pad:n2 - pad] = True
+    return m
+
+
+def analytic_dirs(N, cores):
+    u, v = grid(N, N)
+    ph = np.zeros((N, N))
+    for (uc, vc, n) in cores:
+        ph += n * np.arctan2(v - vc, u - uc)
+    return np.stack([np.cos(ph), np.sin(ph)], -1)
+
+
+def relax2d(N, n0, pinned, tol=1e-14, maxit=400000):
+    n = n0.copy()
+    for it in range(maxit):
+        s = np.zeros_like(n)
+        s[1:, :] += n[:-1, :]
+        s[:-1, :] += n[1:, :]
+        s[:, 1:] += n[:, :-1]
+        s[:, :-1] += n[:, 1:]
+        norm = np.linalg.norm(s, axis=-1)
+        new = n.copy()
+        m = (~pinned) & (norm > 1e-13)
+        new[m] = s[m] / norm[m][:, None]
+        delta = np.max(np.abs(new - n))
+        n = new
+        if delta < tol:
+            break
+    s = np.zeros_like(n)
+    s[1:, :] += n[:-1, :]
+    s[:-1, :] += n[1:, :]
+    s[:, 1:] += n[:, :-1]
+    s[:, :-1] += n[:, 1:]
+    return n, np.linalg.norm(s, axis=-1), s
+
+
+def support_check2d(n, s, pinned):
+    norm = np.linalg.norm(s, axis=-1)
+    res = np.zeros(norm.shape)
+    m = norm > 1e-13
+    res[m] = np.abs(n[m][:, 0] * s[m][:, 1] - n[m][:, 1] * s[m][:, 0]) / norm[m]
+    return float(res[(~pinned) & m].max()), np.argwhere(~m)
+
+
+def rt_profile(N, r, cut=0.30, pad=4, k=24):
+    """H1's light-cut chirality census, sparse shift-invert about E = 0."""
+    D = D4(N, N, M_DEF * r[..., 0], M_DEF * r[..., 1])
+    ev, evec = spla.eigsh(D, k=k, sigma=0.0, which="LM", tol=1e-12)
+    o = np.argsort(np.abs(ev))
+    ev, evec = ev[o], evec[:, o]
+    idx = np.where(np.abs(ev) < cut)[0]
+    rest = np.abs(ev[np.abs(ev) >= cut])
+    nxt = float(rest.min()) if rest.size else float("inf")
+    chi = chi_density4(evec, idx, N, N)
+    inter = interior_mask(N, N, pad)
+    return (len(idx), float(np.max(np.abs(ev[idx]))) if len(idx) else 0.0, nxt,
+            float(chi[inter].sum()), float(chi[~interior_mask(N, N, 2)].sum()), float(chi.sum()))
+
+
+# ===================================================================== h3_a_register.py A4/A5/A6
+CUBE = list(product(range(2), repeat=3))
+CUBE_NB = {v: [u for u in CUBE if sum(abs(a - b) for a, b in zip(u, v)) == 1] for v in CUBE}
+
+
+def form_all(seeds, sites):
+    """Sequential formation: walk all orders of `sites` and all picks."""
+    dirs_seen = set()
+    finals = []
+    for order in permutations(sites):
+        stack = [(0, dict(seeds))]
+        while stack:
+            i, cfg = stack.pop()
+            if i == len(order):
+                finals.append(cfg)
+                continue
+            v = order[i]
+            S = L_CONT([cfg[u] for u in CUBE_NB[v] if u in cfg])
+            for it in S:
+                if it[0] == "P":
+                    dirs_seen.add(it[2])
+                c2 = dict(cfg)
+                c2[v] = it
+                stack.append((i + 1, c2))
+    return dirs_seen, finals
+
+
+def build_table(LET, nnb):
+    tab = np.zeros((7, 8 ** 7), dtype=bool)
+    seen = set()
+    for tup in product(range(7), repeat=nnb):
+        key = sum(8 ** l for l in tup)
+        if key in seen:
+            continue
+        seen.add(key)
+        S = L_CONT([LET[l] for l in tup])
+        for i, l in enumerate(LET):
+            tab[i, key] = in_support(l, S)
+    return tab
+
+
+def census(nsites, nbr_lists, tab, chunk=1 << 21):
+    total = 7 ** nsites
+    pw = np.array([8 ** l for l in range(7)], dtype=np.int64)
+    nsup = 0
+    found = []
+    for start in range(0, total, chunk):
+        idx = np.arange(start, min(total, start + chunk), dtype=np.int64)
+        digs = []
+        r = idx.copy()
+        for _ in range(nsites):
+            digs.append(r % 7)
+            r //= 7
+        digs = np.array(digs)
+        ok = np.ones(idx.shape[0], dtype=bool)
+        for s in range(nsites):
+            key = np.zeros(idx.shape[0], dtype=np.int64)
+            for u in nbr_lists[s]:
+                key += pw[digs[u]]
+            ok &= tab[digs[s], key]
+        nsup += int(ok.sum())
+        found.extend(idx[ok].tolist())
+    return nsup, found
+
+
+def degree_stats(found, nsites, nbr_lists):
+    degs = {}
+    maxdir = 0
+    for i in found:
+        d = []
+        for _ in range(nsites):
+            d.append(i % 7)
+            i //= 7
+        isdir = [l < 6 for l in d]
+        maxdir = max(maxdir, sum(isdir))
+        for s in range(nsites):
+            if isdir[s]:
+                k = sum(1 for u in nbr_lists[s] if isdir[u])
+                degs[k] = degs.get(k, 0) + 1
+    return degs, maxdir
+
+
+TILT = F(2, 3)
+
+
+def rho_of_label(l):
+    """L_FIB (PR #7926): rho_l = (I + t lhat.sigma)/2 for l a unit lattice direction,
+    I/2 otherwise; t = 2/3."""
+    if l in [tuple(s) for s in SLOTS]:
+        return tuple(TILT * F(x) for x in l)
+    return (F(0), F(0), F(0))
+
+
+def born(r, it):
+    if it[0] == "I":
+        return it[1]
+    return it[1] * (1 + dot(r, it[2])) / 2
+
+
+def lam(slots):
+    v = (0, 0, 0)
+    for d in slots:
+        v = tuple(a + b for a, b in zip(v, d))
+    return v
+
+
+def flip_step(rho, t):
+    """h3_d_formation.py D2: one class tick of the tilted record-value class map."""
+    Pk = [F(math.comb(6, k)) * rho ** k * (1 - rho) ** (6 - k) for k in range(7)]
+    pplus = (1 + t) / 2
+    return (sum(Pk[k] for k in (4, 5, 6)) * pplus
+            + sum(Pk[k] for k in (0, 1, 2)) * (1 - pplus)), Pk[3]
+
+
+# ===================================================================== A -- T1 the register
+m1 = circle_dir(F(0))
+m2 = circle_dir(F(2))
+m3 = circle_dir(F(-2))
+ez = (F(0), F(0), F(1))
+Pr = lambda c, n: ("P", F(c), n)
+
+cT = ternary_weights(m1, m2, m3)
+branches = [
+    (L_CONT([Pr(1, m1)]) == (Pr(1, m1), Pr(1, neg(m1)))),
+    (L_CONT([Pr(1, m1), Pr(1, m2), Pr(1, m3)])
+     == (("P", cT[0], m1), ("P", cT[1], m2), ("P", cT[2], m3))),
+    (L_CONT([Pr(1, m1), Pr(1, m2)]) == (("I", F(1, 5)), ("I", F(4, 5)))),
+    (L_CONT([Pr(1, m1), Pr(1, m1)]) == (("I", F(1)),)),
+    (L_CONT([Pr(1, m1)] * 6) == (("I", F(1)),)),
+    (L_CONT([]) == (("I", F(1)),)),
+    (L_CONT([("I", F(1))] * 6) == (("I", F(1)),)),
+]
+check("A1 [exact] L_CONT rebuilt (PR #7926): {m}->binary; {m1,m2,m3}->ternary, weights (%s,%s,%s), "
+      "sum 2, weighted sum 0; {m1,m2}->coin (1/5,4/5); {m,m}, 6 equal, empty, I-only -> {I}" % (cT[0], cT[1], cT[2]),
+      all(branches) and sum(cT) == 2
+      and add(add(smul(cT[0], m1), smul(cT[1], m2)), smul(cT[2], m3)) == (0, 0, 0))
+
+D4dirs = [m1, m2, m3, ez]
+nchk = 0
+mism = 0
+for kk in (1, 2, 3):
+    for slots in combinations(range(6), kk):
+        for ds in product(D4dirs, repeat=kk):
+            cond = {SLOTS[s]: Pr(1, d) for s, d in zip(slots, ds)}
+            S = L_CONT(list(cond.values()))
+            for R in ROTS:
+                condR = {tuple(int(x) for x in matvec(R, tuple(F(a) for a in sl))): rot_rec(R, rc)
+                         for sl, rc in cond.items()}
+                nchk += 1
+                if set(L_CONT(list(condR.values()))) != set(rot_rec(R, it) for it in S):
+                    mism += 1
+check("A2 [exact] L_CONT covariance S(g.n) = g.S(n) on %d checks (24 rotations x every slot pattern "
+      "with 1-3 records from 4 directions): %d mismatches" % (nchk, mism),
+      mism == 0 and nchk == 37056)
+
+readouts = []
+for t in (F(0), F(1, 2), F(1), F(2), F(-1), F(-1, 2), F(-2)):
+    n = circle_dir(t)
+    cs = phase_of(Pr(1, n))
+    readouts.append(cs == (n[0], n[1]) and cs[0] ** 2 + cs[1] ** 2 == 1)
+Rz = [R for R in ROTS if matvec(R, (F(1), F(0), F(0))) == (F(0), F(1), F(0))
+      and matvec(R, ez) == ez][0]
+cs0 = phase_of(Pr(1, circle_dir(F(1, 2))))
+cs1 = phase_of(rot_rec(Rz, Pr(1, circle_dir(F(1, 2)))))
+check("A3 [exact] the register: (cos phi, sin phi) = (n.e_1, n.e_2) on the declared circle, exact "
+      "at 7 rational points, same at c = 1 and c = 1/2, none for cI; the C_4 sends (3/5,4/5) to "
+      "(-4/5,3/5), phi -> phi + pi/2",
+      all(readouts)
+      and all(phase_of(Pr(F(1, 2), circle_dir(t))) == phase_of(Pr(1, circle_dir(t)))
+              for t in (F(0), F(2), F(-2)))
+      and phase_of(("I", F(1))) is None and cs1 == (-cs0[1], cs0[0]))
+
+
+def landed_bloch(q):
+    return sum((1 + np.cos(q[a])) * XI[a] + np.sin(q[a]) * G[a] for a in range(3))
+
+
+Hn = landed_bloch((np.pi, np.pi, np.pi))
+gaps = []
+for phi in (0.0, 0.7, 2.0):
+    ev = np.linalg.eigvalsh(Hn + M0 * np.cos(phi) * EPS + M0 * np.sin(phi) * M2S)
+    gaps.append(float(np.max(np.abs(np.abs(ev) - M0))))
+check("A4 [1e-12] the H2 mass couples covariantly: for a uniform phase phi = 0, 0.7, 2.0 the node "
+      "spectrum is +-M_0 = +-%.1f fourfold, max dev %.1e" % (M0, max(gaps)),
+      max(gaps) < 1e-12)
+
+mb = np.array([0.3, -0.1, 0.5, 0.2, 0.0, 0.9, -0.4, 0.6])
+epsb = np.array([(-1.0) ** (b1 + b2 + b3) for b1 in range(2) for b2 in range(2) for b3 in range(2)])
+coef = float(np.real(np.trace(EPS @ np.diag(epsb * mb))) / 8)
+check("A5 [1e-14] the Dirac mass is the cell average of the record-read mass: tr(eps D)/8 = %.6f = "
+      "the cell average %.6f, so density d gives Dirac mass d M_0" % (coef, mb.mean()),
+      abs(coef - mb.mean()) < 1e-14)
+
+# ===================================================================== B -- T2 the census
+D6 = [m1, m2, m3, neg(m1), ez, neg(ez)]
+STATES = [None, ("I", F(1))] + [Pr(1, d) for d in D6]
+stats = {}
+nonecho = 0
+for states in product(range(8), repeat=6):
+    cond = [STATES[s] for s in states if STATES[s] is not None]
+    ms = dirs_of(cond)
+    S = L_CONT(cond)
+    hasP = any(it[0] == "P" for it in S)
+    echo = all(it[2] in ms or neg(it[2]) in ms for it in S if it[0] == "P")
+    nonecho += (not echo)
+    st = stats.setdefault(len(ms), [0, 0, 0])
+    st[0] += 1
+    st[1] += hasP
+    st[2] += (len(S) == 3)
+tot_cond = sum(v[0] for v in stats.values())
+check("B1 [exact] complete census over all 8^6 = %d conditions (slots blank, I or P(d), 6 "
+      "directions): a rank-one effect is supported for %s of kP = 1 and %d of kP = 3 (the "
+      "positively spanning triples), never for kP = 0, 2, 4, 5, 6"
+      % (tot_cond, "%d/%d" % (stats[1][1], stats[1][0]), stats[3][1]),
+      tot_cond == 262144 and stats[1][1] == stats[1][0] == 1152 and stats[3][1] == 960
+      and stats[3][2] == 960 and all(stats[k][1] == 0 for k in (0, 2, 4, 5, 6)))
+check("B2 [exact] ECHO LEMMA: every rank-one direction in a support is a neighbour's or its "
+      "antipode, %d of %d; a fully recorded bulk site (kP = 6, %d) is an I record"
+      % (tot_cond - nonecho, tot_cond, stats[6][0]),
+      nonecho == 0 and stats[6][1] == 0 and stats[6][0] == 46656)
+
+LET = [Pr(1, m1), Pr(1, m2), Pr(1, m3), Pr(cT[0], m1), Pr(cT[1], m2), Pr(cT[2], m3), ("I", F(1))]
+sites9 = [(x, y) for x in range(3) for y in range(3)]
+nb9 = [[sites9.index(((x + dx) % 3, (y + dy) % 3)) for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))]
+       for (x, y) in sites9]
+n9, f9 = census(9, nb9, build_table(LET, 4))
+degs9, maxdir9 = degree_stats(f9, 9, nb9)
+check("B3 [exact] Gibbs census, 3x3 periodic plane, 7 letters: %d of 7^9 = %d supported everywhere, "
+      "direction degrees %s, at most %d of 9 directional"
+      % (n9, 7 ** 9, {k: degs9[k] for k in sorted(degs9)}, maxdir9),
+      n9 == 64 and degs9 == {1: 108, 3: 216} and maxdir9 == 6)
+
+nb8 = [[CUBE.index(u) for u in CUBE_NB[v]] for v in CUBE]
+n8, f8 = census(8, nb8, build_table(LET, 3))
+degs8, maxdir8 = degree_stats(f8, 8, nb8)
+check("B4 [exact] 2x2x2 open cube: %d of 7^8 = %d, degrees %s, at most %d of 8 -- dimers only"
+      % (n8, 7 ** 8, {k: degs8[k] for k in sorted(degs8)}, maxdir8),
+      n8 == 19 and degs8 == {1: 72} and maxdir8 == 4)
+
+d0, fin0 = form_all({}, CUBE)
+check("B5 [exact] from NO seed, every order and pick on the 2x2x2 cube: all 8! = %d form only I "
+      "records, %d directions ever offered" % (len(fin0), len(d0)),
+      len(fin0) == 40320 and len(d0) == 0
+      and all(all(rc[0] == "I" for rc in cfg.values()) for cfg in fin0))
+
+d1, fin1 = form_all({(0, 0, 0): Pr(1, m1)}, [v for v in CUBE if v != (0, 0, 0)])
+seed3 = {(0, 0, 0): Pr(1, m1), (1, 1, 0): Pr(1, m2), (1, 0, 1): Pr(1, m3)}
+d3, fin3 = form_all(seed3, [v for v in CUBE if v not in seed3])
+check("B6 [exact] from seeds it only echoes them: one seed -> %d leaves offering only {m_1, -m_1}; "
+      "three seeds -> %d leaves, nothing beyond the seeds and antipodes" % (len(fin1), len(fin3)),
+      len(fin1) == 57264 and d1 <= {m1, neg(m1)} and len(fin3) == 2880
+      and d3 <= {m1, m2, m3, neg(m1), neg(m2), neg(m3)})
+
+# ===================================================================== C -- T3 the dilute field
+PATTERNS = [
+    ("uniform control", lambda x, y, z: True, (2, 2, 2)),
+    ("x-dimers 1/6", lambda x, y, z: z == 0 and y == 0 and (x % 3) in (0, 1), (6, 2, 2)),
+    ("z-dimers 1/3", lambda x, y, z: (x + y) % 2 == 0 and (z % 3) in (0, 1), (2, 2, 6)),
+    ("x-dimers 1/8", lambda x, y, z: z == 0 and y == 0 and (x % 4) in (0, 1), (4, 2, 2)),
+]
+sc = {}
+for (nm, fn, box) in PATTERNS:
+    for M0_ in (0.7, 1.5):
+        for phi in (0.0, np.pi / 2):
+            sc[(nm, M0_, phi)] = supercell_gap(M0_, fn, box, phi)
+dilute_gaps = [v for (nm, M0_, phi), v in sc.items() if nm != "uniform control"]
+check("C1 [1e-9] supercell Bloch scan (16^3) of the 3D matter law: the uniform control is "
+      "gapped at %.4f and %.4f, every dimer superlattice (densities 1/6, 1/3, 1/8, both M_0, "
+      "phases 0 and pi/2) is GAPLESS, max %.1e over %d"
+      % (sc[("uniform control", 0.7, 0.0)], sc[("uniform control", 1.5, 0.0)],
+         max(dilute_gaps), len(dilute_gaps)),
+      abs(sc[("uniform control", 0.7, 0.0)] - 0.7) < 1e-9
+      and abs(sc[("uniform control", 1.5, 0.0)] - 1.5) < 1e-9
+      and max(dilute_gaps) < 1e-9)
+
+Nd = 48
+pld = Plane(Nd, Nd)
+H0d, Zid = pld.hop_matrices()
+cd = ((Nd - 1) / 2, (Nd - 1) / 2)
+rd, recd = dilute_dimer_field(pld, [(cd[0], cd[1], 1)])
+nrecd, badd = check_dimer_support(pld, rd, recd)
+Hd, _ = build_H(pld, rd, 1.5, H0d, Zid)
+Ed = np.sort(np.abs(spla.eigsh(Hd(np.pi), k=60, sigma=0.0, which="LM", tol=1e-10)[0]))
+ru = np.zeros((pld.D, 3))
+ru[:, 0] = 1.0
+Hu, _ = build_H(pld, ru, 1.5, H0d, Zid)
+Eu = float(np.min(np.abs(spla.eigsh(Hu(np.pi), k=6, sigma=0.0, which="LM", tol=1e-10)[0])))
+n01 = int(np.sum(Ed < 0.1))
+check("C2 [numerical] the dilute winding, 48x48 plane (M_0 = 1.5, %d sites at density 1/6, %d "
+      "violations): %d states below |E| = 0.1, smallest %.4f, uniform gap %.4f"
+      % (nrecd, badd, n01, Ed[0], Eu),
+      badd == 0 and nrecd == 768 and n01 == 7 and Ed[0] < 0.01 and abs(Eu - 1.5027) < 5e-3)
+
+rt_gaps = {}
+for Nc in (24, 32):
+    rr = np.zeros((Nc, Nc, 2))
+    recc = np.zeros((Nc, Nc), bool)
+    uu, vv = grid(Nc, Nc)
+    for s1 in range(Nc):
+        for s2 in range(Nc):
+            if s2 % 2 != 0 or s1 % 3 not in (0, 1):
+                continue
+            if s1 % 3 == 0 and s1 + 1 >= Nc:
+                continue
+            base = s1 - (s1 % 3)
+            ph = np.arctan2(vv[base, s2], 0.5 * (uu[base, s2] + uu[base + 1, s2]))
+            rr[s1, s2] = [np.cos(ph), np.sin(ph)]
+            recc[s1, s2] = True
+    bad = 0
+    for s1 in range(Nc):
+        for s2 in range(Nc):
+            if not recc[s1, s2]:
+                continue
+            nb = [(s1 + d1, s2 + d2) for d1, d2 in ((1, 0), (-1, 0), (0, 1), (0, -1))
+                  if 0 <= s1 + d1 < Nc and 0 <= s2 + d2 < Nc]
+            rn = [p for p in nb if recc[p]]
+            if len(rn) != 1 or not np.allclose(rr[rn[0]], rr[s1, s2]):
+                bad += 1
+    ruc = np.zeros((Nc, Nc, 2))
+    ruc[recc] = [1.0, 0.0]
+    gu = float(np.min(np.abs(spla.eigsh(D4(Nc, Nc, M_DEF * ruc[..., 0], M_DEF * ruc[..., 1]),
+                                        k=4, sigma=0.0, which="LM", tol=1e-12)[0])))
+    rt_gaps[Nc] = (bad, gu, rt_profile(Nc, rr, cut=0.12, pad=4, k=24))
+check("C3 [numerical] the same field in H1's operator (M = 0.8, r_s = 1, hard ends, density 1/3, %d "
+      "violations) is GAPPED at %.6f (N = 24), %.6f (N = 32); M/3 = %.4f"
+      % (rt_gaps[24][0] + rt_gaps[32][0], rt_gaps[24][1], rt_gaps[32][1], M_DEF / 3),
+      rt_gaps[24][0] == 0 and rt_gaps[32][0] == 0
+      and abs(rt_gaps[24][1] - 0.267204) < 1e-5 and abs(rt_gaps[32][1] - 0.246455) < 1e-5)
+c4 = rt_gaps[32][2]
+check("C4 [numerical] and carries the index: N = 32, cut 0.12 -> %d light states, max|E| %.3e (next "
+      "%.5f), interior %+.9f, edge %+.9f" % (c4[0], c4[1], c4[2], c4[3], c4[4]),
+      c4[0] == 2 and abs(c4[3] - 0.951637) < 1e-4 and c4[4] < -0.8)
+
+# ===================================================================== D -- T4 the variant law
+Rl = [3, 5, 7, 9, 11, 14, 18, 22]
+plane_res = {}
+hR = {}
+split = {}
+core_E = {}
+for N in (24, 32, 48):
+    pl = Plane(N, N)
+    H0, Zi = pl.hop_matrices()
+    c = ((N - 1) / 2, (N - 1) / 2)
+    cores = [(c[0], c[1], 1)]
+    n, res, dp, nfree, _, _ = relaxed_field(pl, cores)
+    wind = [winding_number(np.arctan2(n[L, 1], n[L, 0]))
+            for R in (2, 4, 6) for L in [loop_sites(pl, c[0], c[1], R)] if L is not None]
+    plane_res[N] = (res, dp, nfree, wind)
+    H, V = build_H(pl, n, M0, H0, Zi)
+    kk = {24: 40, 32: 60, 48: 110}[N]
+    E, U = ingap_modes(H(np.pi + 0.1), kk, WGAP)
+    Vq = V(np.pi + 0.1)
+    cellpos = np.array([(2 * X + 0.5, 2 * Y + 0.5) for (X, Y) in pl.cells])
+    cellr = np.hypot(cellpos[:, 0] - c[0], cellpos[:, 1] - c[1])
+    dens = np.zeros(len(pl.cells))
+    nL = 0
+    for j in range(len(E)):
+        if abs(E[j]) < 0.3:
+            dens += cell_density(pl, U[:, j], -G[2])
+            nL += 1
+    hR[N] = ({R: float(dens[cellr < R].sum()) for R in Rl if R < N / 2}, float(dens.sum()), nL)
+    core = np.hypot(pl.x - c[0], pl.y - c[1]) < 5
+    sel = [j for j in range(len(E)) if (np.abs(U[:, j]) ** 2)[core].sum() > 0.6]
+    core_E[N] = (sorted(float(E[j]) for j in sel),
+                 [float(np.real(U[:, j].conj() @ (Vq @ U[:, j]))) for j in sel])
+    E0, _ = ingap_modes(H(np.pi), 12, WGAP)
+    split[N] = float(np.min(np.abs(E0)))
+check("D1 [1e-13] L_HYB (this note's variant, not landed) supports the smooth vortex as its own "
+      "fixed point: residual %.1e/%.1e/%.1e over %d/%d/%d unpinned sites (N = 24/32/48), "
+      "min n.vhat %+.6f, winding +1 on loops 2, 4, 6"
+      % (plane_res[24][0], plane_res[32][0], plane_res[48][0],
+         plane_res[24][2], plane_res[32][2], plane_res[48][2], plane_res[48][1]),
+      all(plane_res[N][0] < 1e-13 and abs(plane_res[N][1] - 1) < 1e-9
+          and all(abs(w - 1) < 1e-6 for w in plane_res[N][3]) for N in (24, 32, 48)))
+v48 = core_E[48][0][0] / 0.1
+check("D2 [numerical] the string carries 2n co-moving modes: %d core modes at E = %s, <V_z> = %s, "
+      "v = %.3f; the cut keeps 4 states"
+      % (len(core_E[48][0]), " ".join("%+.5f" % e for e in core_E[48][0]),
+         " ".join("%+.3f" % v for v in core_E[48][1]), v48),
+      len(core_E[48][0]) == 2 and all(abs(e - 0.09983) < 5e-5 for e in core_E[48][0])
+      and all(v > 0.99 for v in core_E[48][1]) and hR[48][2] == 4 and hR[32][2] == 4)
+check("D3 [numerical] bulk net handedness (cut 0.3): h = %+.4f at R = 14, %+.4f at R = 18 on 48x48, "
+      "%+.4f at R = 11 on 32x32; whole plane %.1e, %.1e, %.1e -- the -2n is on the ring"
+      % (hR[48][0][14], hR[48][0][18], hR[32][0][11], hR[24][1], hR[32][1], hR[48][1]),
+      abs(hR[48][0][14] - 1.9983) < 2e-3 and abs(hR[48][0][18] - 1.9983) < 2e-3
+      and abs(hR[32][0][11] - 1.9864) < 2e-3
+      and max(abs(hR[N][1]) for N in (24, 32, 48)) < 1e-13)
+check("D4 [numerical] the core pair decouples exponentially: p = 0 splitting %.3e, %.3e, %.3e at "
+      "N = 24, 32, 48" % (split[24], split[32], split[48]),
+      abs(split[24] - 3.125e-3) < 1e-4 and abs(split[32] - 3.991e-4) < 1e-5
+      and abs(split[48] - 7.748e-6) < 1e-6 and split[24] > split[32] > split[48])
+
+torus = {}
+for (Nx, Ny) in ((48, 24), (64, 32)):
+    plt_ = Plane(Nx, Ny, periodic=True)
+    H0t, Zit = plt_.hop_matrices()
+    cores = [(Nx / 4 - 0.5, Ny / 2 - 0.5, 1), (3 * Nx / 4 - 0.5, Ny / 2 - 0.5, -1)]
+    n, res, dp, nfree, circ, cy = relaxed_field(plt_, cores)
+    ycyc = sorted(set(np.round(cy / (2 * np.pi), 6).tolist()))
+    nvort = 0
+    for X in range(plt_.Nx):
+        for Y in range(plt_.Ny):
+            L = [plt_.idx(X, Y, 0), plt_.idx((X + 1) % plt_.Nx, Y, 0),
+                 plt_.idx((X + 1) % plt_.Nx, (Y + 1) % plt_.Ny, 0),
+                 plt_.idx(X, (Y + 1) % plt_.Ny, 0)]
+            if abs(winding_number(np.arctan2(n[L, 1], n[L, 0]))) > 0.5:
+                nvort += 1
+    H, V = build_H(plt_, n, M0, H0t, Zit)
+    E, U = ingap_modes(H(np.pi + 0.15), 16, WGAP)
+    cellpos = np.array([(2 * X + 0.5, 2 * Y + 0.5) for (X, Y) in plt_.cells])
+    dens = np.zeros(len(plt_.cells))
+    nL = 0
+    for j in range(len(E)):
+        if abs(E[j]) < 0.3:
+            dens += cell_density(plt_, U[:, j], -G[2])
+            nL += 1
+    hs = []
+    for (xc, yc, _) in cores:
+        d = np.hypot(cellpos[:, 0] - xc, cellpos[:, 1] - yc)
+        hs.append(float(dens[d < 11].sum()))
+    torus[(Nx, Ny)] = (res, ycyc, nvort, nL, hs, float(dens.sum()))
+check("D5 [numerical] torus: the pair forces a 2 pi winding along the cycle between them -- relaxed "
+      "at %.1e/%.1e, y-cycle windings %s, exactly %d/%d vortex plaquettes, 4 light states "
+      "carrying %+.4f/%+.4f (48x24), %+.4f/%+.4f (64x32) at r < 11, torus %.1e"
+      % (torus[(48, 24)][0], torus[(64, 32)][0], torus[(48, 24)][1], torus[(48, 24)][2],
+         torus[(64, 32)][2], torus[(48, 24)][4][0], torus[(48, 24)][4][1],
+         torus[(64, 32)][4][0], torus[(64, 32)][4][1], torus[(64, 32)][5]),
+      all(torus[t][0] < 1e-13 and torus[t][1] == [0.0, 1.0] and torus[t][2] == 2
+          and torus[t][3] == 4 and torus[t][4][0] > 1.97 and torus[t][4][1] < -1.97
+          and abs(torus[t][5]) < 1e-13 for t in torus))
+
+Nr = 32
+n0r = analytic_dirs(Nr, [(0.0, 0.0, 1)])
+pin = np.zeros((Nr, Nr), bool)
+pin[0, :] = pin[-1, :] = pin[:, 0] = pin[:, -1] = True
+uu, vv = grid(Nr, Nr)
+pin |= (np.abs(uu) < 0.75) & (np.abs(vv) < 0.75)
+nrel, vnr, srel = relax2d(Nr, n0r, pin)
+res2d, zero2d = support_check2d(nrel, srel, pin)
+rt32 = rt_profile(Nr, nrel, cut=0.30, pad=4, k=20)
+check("D6 [numerical] H1's geometry: the relaxed field is an L_HYB fixed point (residual %.1e) "
+      "giving interior %+.9f at N = 32, edge ring %+.9f, net %.1e over %d light states (max|E| "
+      "%.1e, next %.5f)" % (res2d, rt32[3], rt32[4], rt32[5], rt32[0], rt32[1], rt32[2]),
+      res2d < 1e-13 and abs(rt32[3] - 0.999991511) < 1e-6 and rt32[4] < -0.99
+      and abs(rt32[5]) < 1e-9 and rt32[0] == 2)
+
+core4 = [Pr(1, (F(1), F(0), F(0))), Pr(1, (F(0), F(1), F(0))),
+         Pr(1, (F(-1), F(0), F(0))), Pr(1, (F(0), F(-1), F(0)))]
+Nsc = 25
+csc = Nsc // 2
+usc, vsc = grid(Nsc, Nsc)
+n0s = analytic_dirs(Nsc, [(usc[csc, csc], vsc[csc, csc], 1)])
+n0s[csc, csc] = [0.0, 0.0]
+pins = np.zeros((Nsc, Nsc), bool)
+pins[0, :] = pins[-1, :] = pins[:, 0] = pins[:, -1] = True
+pins[csc, csc] = True
+nsc, vnsc, ssc = relax2d(Nsc, n0s, pins)
+check("D7 [exact] a site-centred core is registered I by BOTH laws (neighbours at 0, 90, 180, 270 "
+      "deg, |v_core| = %.1e, relaxed 25x25): the mass zero there is the law's"
+      % float(vnsc[csc, csc]),
+      L_CONT(core4) == (("I", F(1)),) and L_HYB(core4) == (("I", F(1)),)
+      and float(vnsc[csc, csc]) < 1e-18)
+
+# ===================================================================== E -- T5 the fair coin
+rows = []
+for R in ROTS:
+    for i in range(3):
+        rows.append([R[i][j] - (F(1) if i == j else F(0)) for j in range(3)])
+
+
+def rank_exact(rws):
+    M = [list(r) for r in rws]
+    rk = 0
+    for c in range(3):
+        p = next((i for i in range(rk, len(M)) if M[i][c] != 0), None)
+        if p is None:
+            continue
+        M[rk], M[p] = M[p], M[rk]
+        pv = M[rk][c]
+        M[rk] = [x / pv for x in M[rk]]
+        for i in range(len(M)):
+            if i != rk and M[i][c] != 0:
+                f = M[i][c]
+                M[i] = [x - f * y for x, y in zip(M[i], M[rk])]
+        rk += 1
+    return rk
+
+
+r6 = rho_of_label(lam(SLOTS))
+Sb = L_HYB([Pr(1, m1)] * 6)
+check("E1 [exact] the dipole class map sends a fully recorded condition to lambda = %s; the "
+      "only Bloch vector fixed by all 24 rotations is 0 (rank %d), so rho = I/2 and the bulk menu "
+      "has odds %s, %s -- a fair coin"
+      % (str(lam(SLOTS)), rank_exact(rows),
+         born(r6, Pr(1, m1)), born(r6, Pr(1, neg(m1)))),
+      rank_exact(rows) == 3 and lam(SLOTS) == (0, 0, 0) and Sb[0][0] == "PDIR"
+      and born(r6, Pr(1, m1)) == F(1, 2) and born(r6, Pr(1, neg(m1))) == F(1, 2))
+
+rz = rho_of_label(lam([(0, 0, 1)]))
+Sd = L_CONT([Pr(1, m1)])
+odds_d = [born(rz, it) for it in Sd]
+mxz = (F(3, 5), F(0), F(4, 5))
+odds_t = [born(rz, it) for it in L_CONT([Pr(1, mxz)])]
+odds_ter = [born(r6, it) for it in L_CONT([Pr(1, m1), Pr(1, m2), Pr(1, m3)])]
+check("E2 [exact] a dimer with its phase circle normal to the axis (lambda = e_z, t = 2/3) gives "
+      "%s, %s; tilted onto the x-z circle %s, %s; ternary odds in the invariant fibre %s = c_k/2"
+      % (odds_d[0], odds_d[1], odds_t[0], odds_t[1], ", ".join(str(o) for o in odds_ter)),
+      odds_d == [F(1, 2), F(1, 2)] and odds_t == [F(23, 30), F(7, 30)]
+      and odds_ter == [cT[0] / 2, cT[1] / 2, cT[2] / 2])
+
+pw = {N: (N * N * math.log10(2), -N * N * math.log10(F(5) / 6)) for N in (24, 32, 48)}
+check("E3 [exact] one class tick re-registers the vortex unflipped with odds 2^-N^2 = 10^-%.1f, "
+      "10^-%.1f, 10^-%.1f (N = 24, 32, 48); with tilt 2/3, (5/6)^N^2 = 10^-%.1f, 10^-%.1f, 10^-%.1f" % (pw[24][0], pw[32][0], pw[48][0], pw[24][1], pw[32][1], pw[48][1]),
+      abs(pw[24][0] - 173.4) < 0.1 and abs(pw[48][0] - 693.6) < 0.1
+      and abs(pw[24][1] - 45.6) < 0.1)
+
+Nf = 24
+plf = Plane(Nf, Nf)
+H0f, Zif = plf.hop_matrices()
+cf = ((Nf - 1) / 2, (Nf - 1) / 2)
+nf, _, _, _, _, _ = relaxed_field(plf, [(cf[0], cf[1], 1)])
+golden = (1 + 5 ** 0.5) / 2
+qr = (plf.x * golden + plf.y * 2 ** 0.5) % 1.0
+FLIPS = [
+    ("none", np.ones(plf.D)),
+    ("isolated 1/9", np.where((plf.x % 3 == 0) & (plf.y % 3 == 0), -1.0, 1.0)),
+    ("declared ~1/2", np.where(qr < 0.5, -1.0, 1.0)),
+    ("declared ~1/6", np.where(qr < 1 / 6, -1.0, 1.0)),
+]
+flipres = {}
+for nm, s in FLIPS:
+    Hf, Vf = build_H(plf, nf * s[:, None], M0, H0f, Zif)
+    Ef, Uf = ingap_modes(Hf(np.pi + 0.1), 60, WGAP)
+    core = np.hypot(plf.x - cf[0], plf.y - cf[1]) < 5
+    sel = [j for j in range(len(Ef)) if (np.abs(Uf[:, j]) ** 2)[core].sum() > 0.6]
+    flipres[nm] = (float(np.mean(s)), len(sel), [float(Ef[j]) for j in sel])
+check("E4a [numerical] a coin-signed field has no string mode: density 1/2 (mean sign %+.3f) leaves "
+      "%d core modes on the 24x24 vortex; none (%+.3f) keeps %d at E = %s, 1/9 (%+.3f) keeps %d, "
+      "~1/6 (%+.3f) keeps %d"
+      % (flipres["declared ~1/2"][0], flipres["declared ~1/2"][1], flipres["none"][0],
+         flipres["none"][1], " ".join("%+.5f" % e for e in flipres["none"][2]),
+         flipres["isolated 1/9"][0], flipres["isolated 1/9"][1],
+         flipres["declared ~1/6"][0], flipres["declared ~1/6"][1]),
+      flipres["declared ~1/2"][1] == 0 and flipres["none"][1] == 2
+      and flipres["isolated 1/9"][1] == 2 and flipres["declared ~1/6"][1] == 2)
+
+Nq = 24
+n0q = analytic_dirs(Nq, [(0.0, 0.0, 1)])
+pinq = np.zeros((Nq, Nq), bool)
+pinq[0, :] = pinq[-1, :] = pinq[:, 0] = pinq[:, -1] = True
+uq, vq = grid(Nq, Nq)
+pinq |= (np.abs(uq) < 0.75) & (np.abs(vq) < 0.75)
+nq_, _, _ = relax2d(Nq, n0q, pinq)
+Xg, Yg = np.meshgrid(np.arange(Nq), np.arange(Nq), indexing="ij")
+qrt = (Xg * golden + Yg * 2 ** 0.5) % 1.0
+rt_flip = {}
+for nm, sg in (("none", np.ones((Nq, Nq))),
+               ("isolated 1/9", np.where((Xg % 3 == 0) & (Yg % 3 == 0), -1.0, 1.0)),
+               ("declared ~1/2", np.where(qrt < 0.5, -1.0, 1.0)),
+               ("declared ~1/6", np.where(qrt < 1 / 6, -1.0, 1.0))):
+    rt_flip[nm] = rt_profile(Nq, nq_ * sg[..., None], cut=0.30, pad=4, k=24)
+check("E4b [numerical] the coin fills H1's gap: density 1/2 -> %d light states (max|E| %.3f, next "
+      "%.3f), interior %+.3f; none -> %d, %+.9f; 1/9 -> %d, %+.9f; ~1/6 -> %d, %+.9f"
+      % (rt_flip["declared ~1/2"][0], rt_flip["declared ~1/2"][1], rt_flip["declared ~1/2"][2],
+         rt_flip["declared ~1/2"][3], rt_flip["none"][0], rt_flip["none"][3],
+         rt_flip["isolated 1/9"][0], rt_flip["isolated 1/9"][3],
+         rt_flip["declared ~1/6"][0], rt_flip["declared ~1/6"][3]),
+      rt_flip["declared ~1/2"][0] >= 18 and abs(rt_flip["declared ~1/2"][3]) < 0.2
+      and rt_flip["none"][0] == 2 and abs(rt_flip["none"][3] - 0.999951757) < 1e-6
+      and rt_flip["isolated 1/9"][0] == 2 and rt_flip["isolated 1/9"][3] > 0.99
+      and rt_flip["declared ~1/6"][0] == 2 and rt_flip["declared ~1/6"][3] > 0.99)
+
+tilt_rows = []
+for t in (F(0), F(1, 3), F(2, 3), F(9, 10)):
+    rho = float((1 - t) / 2)
+    io = 0.0
+    for _ in range(400):
+        rr_, io = flip_step(F(rho).limit_denominator(10 ** 9), t)
+        rho = float(rr_)
+    tilt_rows.append((t, rho, float(io), 1 - 2 * rho - float(io)))
+check("E5 [1e-3] a record-value class map with a supplied tilt t: at t = 0 the flip density is "
+      "%.4f, I-density %.4f, mean mass %+.4f (a director with a coin); t = 2/3 keeps %+.4f, "
+      "t = 9/10 %+.4f"
+      % (tilt_rows[0][1], tilt_rows[0][2], tilt_rows[0][3],
+         tilt_rows[2][3], tilt_rows[3][3]),
+      abs(tilt_rows[0][3]) < 1e-3 and abs(tilt_rows[2][3] - 0.6217) < 1e-3
+      and abs(tilt_rows[3][3] - 0.8979) < 1e-3)
+
+# ===================================================================== F -- solver certificate
+Nz = 12
+rz2 = analytic_dirs(Nz, [(0.0, 0.0, 1)])
+Dz = D4(Nz, Nz, M_DEF * rz2[..., 0], M_DEF * rz2[..., 1])
+ev_dense = np.linalg.eigvalsh(Dz.toarray())
+ev_sp = np.sort(spla.eigsh(Dz, k=20, sigma=0.0, which="LM", tol=1e-12)[0])
+near = np.sort(np.abs(ev_dense))[:20]
+dev = float(np.max(np.abs(np.sort(np.abs(ev_sp)) - near)))
+check("F1 [1e-9] solver certificate: sparse shift-invert agrees with dense LAPACK on a 12x12 "
+      "record-time square to %.1e over the 20 nearest zero; largest dense 1152; no seed" % dev,
+      dev < 1e-9)
+
+print("SUMMARY: a register; no field under the landed law; a field under a variant; a fair-coin "
+      "sign.  [%.1f s]" % (time.time() - T0))
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on the one object that could pay both roots at once: the continuum record alphabet of PR #7926, which lifts the Born abundance obstruction, and the winding site phase that handed matter needs (PRs #7935, #7949: "a charged scalar's phase by another name; the framework has nowhere to keep one"). **The alphabet keeps the winding phase as record content**: a record `cP(n_v)` on a declared great circle is a phase, `(cos φ_v, sin φ_v) = (n_v·e_1, n_v·e_2)` is determined by record content alone, the second mass couples to it covariantly, the gap at the node is `M_0` for every uniform phase and the Dirac mass is the cell average of the record-read mass. **The landed law does not support it as a field**: the complete support census of `L_CONT` over all `8^6 = 262,144` neighbourhood conditions gives the echo lemma (every rank-one direction in any support is a neighbour's direction or its antipode; rank-one effects appear only for 1 or 3 direction-recorded neighbours), a fully recorded bulk site is an `I` record, the Gibbs census on the `3×3` torus layer finds 64 of 40,353,607 supported configurations with direction degrees `{1: 108, 3: 216}`, and from no seed the law forms only `I` over all 40,320 orders; the densest supported winding, a dimer superlattice, is gapless in the staggered 3D matter law (`min |E| = 0.0000` against a uniform gap `1.5027`) though gapped and index-carrying in the record-time operator (`0.2672 = M/3`, interior index `+0.9516`). A minimal variant law (a construction, not landed) supports the smooth vortex as its own fixed point, and in it the pairing is untouched by where the phase is kept: `2n` co-moving modes per string with `v = 0.998`, bulk net handedness `+1.9983` inside a disc with the `−2n` on the boundary ring (splitting `3.1e-3 → 7.7e-6` for `N = 24 → 48`), a string and anti-string on a torus with a forced `2π` twist carrying `+2` and `−2` and nothing else, and interior chirality `+0.999991511` in the record-time geometry with the partner on the edge: **the compensating partner is never absent from the bulk in any geometry.** And **the fibred Born odds that pay Root A on the same alphabet register the phase's sign as a fair coin in the bulk**: the lattice-dipole class map sends a fully recorded condition to the rotation-invariant fibre, `ρ = I/2` exactly; a class tick re-registers the vortex unflipped with odds `2^{−N²}`; flip patterns of density `1/2` erase the string modes and fill the record-time gap (18 light states), while density `1/9` to about `1/6` keep them; a record-value class map with a supplied tilt keeps `0.62` of the mass at `t = 2/3`. So one supplied object, a Bloch direction per record, pays both registers and charges both alike; the unpaid item is the odds of the antipode.

- `docs/THE_CONTINUUM_RECORD_ALPHABET_KEEPS_THE_WINDING_PHASE_AS_RECORD_CONTENT_THE_ECHO_LAW_DOES_NOT_SUPPORT_IT_AS_A_FIELD_AND_THE_FIBRED_ODDS_REGISTER_ITS_SIGN_AS_A_FAIR_COIN_BOUNDED_THEOREM_NOTE_2026-09-04.md` (287 lines)
- `scripts/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.py` (`TOTAL: PASS=29 FAIL=0`, 20 s; exact rational census; sparse shift-invert for the planes; no seeds; stdout 5,497 characters)
- `logs/runner-cache/continuum_alphabet_winding_phase_echo_law_fair_coin_check_2026_09_04.txt`

## Theorems

- **T1** the register and the covariant coupling; **T2** the complete support census and the echo lemma (262,144 conditions; 1,152 rank-one supports at one direction neighbour, 960 at three, none otherwise); the Gibbs censuses; the formation census (40,320 / 57,264 / 2,880); **T3** the dilute winding gapless in the matter law, gapped in record time; **T4** the variant law's vortex, torus pair and record-time vortex with the numbers above; **T5** the fair-coin sign (`ρ = I/2`; odds `1/2, 1/2`, `23/30, 7/30`, `3/8, 5/16, 5/16` with invariant-vector rank 3), the flip-density table, the tilted class map.

## Boundary

- The continuum effect domain and `L_CONT` verbatim under the reading that `cI` records carry no direction; the variant law as defined; the fibred odds with `t = 2/3` and the dipole class map; the one-particle matter laws of PRs #7949 and #7935 with their parameters; the declared plane, torus and record-time sizes (the `n = ±2, −1` planes, the `p = 0, −0.1` tables, the cut-free index and the loop-winding histogram of the source campaign not recomputed); one numerical difference declared (the record-time whole-plane sum at `N = 32` reads `1e-11` under sparse shift-invert against a dense `3e-15`, an eigenvector-convergence effect on a near-degenerate pair, certified to `7e-15` on the 20 eigenvalues nearest zero). Nothing derived from the axioms.

## Context

- Parents (open PRs): the continuum alphabet (#7926), the fibred clause (#7931), the Born-from-ternaries note (#7950), the one-frame tick note (#7969), the record-time vortex (#7935), the string note (#7949), the tick line (#7947, #7968).
- Part of the owner-authorised readability campaign (2026-09-03/04), item 4 of the owner's ranked queue; rebuilt from the executor's transcript after a session crash wiped the scratchpad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKJXnnXsZxzNTe9rhRNnJn
