### PR TITLE
feat(law): a readable matter law exists on the 5x5x5 window; the parity completion keeps the fermion and every menu nonempty

### DIFF
--- a/docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_NOTE_2026-09-04.md
+++ b/docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_NOTE_2026-09-04.md
@@ -1,0 +1,321 @@
+---
+claim_id: a_readable_matter_law_exists_on_the_5x5x5_window_the_designed_laws_record_table_completed_by_a_covariant_parity_rule_has_every_menu_nonempty_is_read_from_partial_blocks_and_keeps_the_fermion_bounded_note_2026-09-04
+claim_type: bounded_theorem
+claim_scope: "Exact and finite. The object is the designed matter law of PR #7834 written over binary records: the minimal covariant support table T_min on a rotation-closed window, whose menu at each profile is the set of values the 48 template cylinders realise there and is empty at every never-realised profile. Six covariant completions of the never-realised profiles are treated -- constant 0, constant 1, the parity of the window's recorded values, its complement, a corrected parity that gives the all-0 profile 1 and the all-1 profile 0, and the permissive one -- on the windows NN (6 offsets), NN with the second axial orbit (12), L1<=2 (24), 3x3x3 (26), the 39-offset closing window of PR #7977 (38 offsets and the centre), 5x5x5 (124) and 7x7x7 (342) as a control. The tori are 4x2x2, 4x4x2 and 4x4x4 for the tabulated windows and 4x4x4 and 8x4x4 for the wide ones; the tables, the star readout and the censuses are on Z^3. On the 5x5x5 window the corrected parity completion has every menu nonempty, every complete entry read by one partially recorded 5x5x5 block, the 48 cylinders as its complete admissible set on 4x4x4, and the cylinders with 16 isolated weight-24 configurations on 8x4x4; the parity completion adds the all-0 configuration on each. Every extra is isolated under single flips, so the hop Hamiltonian of PR #7889 restricted to the admissible set is the direct sum of the 48 untouched cylinder blocks and a zero operator. No nearest-neighbour or radius-1 table containing the cylinders is both readable and pinning. The completeness of the two 8x4x4 extra lists is quoted from the source computation's output lines and re-verified member by member, not re-enumerated. Capped enumerations are reported as bounds and never as counts. No physical law is selected."
+upstream_dependencies:
+  - minimal_axioms
+  - extensional_nearest_neighbor_rule_deep_probe_2026-07-13
+  - finite_bksf_sign_and_superlattice_marker_census_bounded_theorem_note_2026-09-02
+runner: scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py
+registry_id: readable_matter_law_on_5x5x5_window_parity_completion_2026_09_04
+---
+
+# A readable matter law exists on the `5x5x5` window: the designed law's record table completed by a covariant parity rule has every menu nonempty, is read entry by entry from partially recorded `5x5x5` blocks, admits exactly the 48 sectors on `4x4x4` and 16 further isolated configurations on `8x4x4`, and leaves the emergent fermion's hop Hamiltonian block-diagonal; no nearest-neighbour or radius-1 table containing the sectors does so
+
+**Date:** 2026-09-04
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** unaudited candidate; effective status is pipeline-derived only after independent audit.
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py`](../scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py)
+**Runner cache:**
+[`logs/runner-cache/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.txt`](../logs/runner-cache/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.txt)
+**Parents:** [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md),
+[`EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md`](EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md),
+[`FINITE_BKSF_SIGN_AND_SUPERLATTICE_MARKER_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-02.md`](FINITE_BKSF_SIGN_AND_SUPERLATTICE_MARKER_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-02.md)
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Every count is an exact enumeration over a named finite torus or, for the tables, the star readout and the censuses, over Z^3 with the orbit totals supplied by Burnside. The complete admissible sets on the smallest torus are computed without a solver for all seven rules and agree with CaDiCaL as sets on the four rules re-run there. The star lemma is verified completely on the tabulated windows by an exact recount of the completions of every overlap pattern, and on the wide windows by a counting certificate with a margin of 16,625,822 at the worst offset. The two 8x4x4 extra lists are quoted for completeness and re-verified member by member. Capped enumerations are reported as bounds. No physical law is selected."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Decide the minimum of the extras over the space of completions rather than the six declared rules, and the extra count on a torus all of whose sides are at least 5."
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Setting
+
+PR #7834 puts a fermion on `Z^3` at one qubit per site by declaring a **superlattice role pattern**: a site's role is its coordinate parity, and a repeating arrangement of pinned values with period
+`(4, 2, 2)` along a chosen axis pins a corner to `(s[ax] / 2) mod 2`, a face to `0`, a cube centre to `1`, and leaves every coarse edge site free as a live qubit -- `48` sectors, each a cylinder of
+record configurations. PR #7977 read that pattern as a law over the five-symbol role alphabet and found it blind: the role table has an empty menu at every profile carrying one of the `17` ordered
+role adjacencies of `25` the pattern never realises, and the partial readout cannot see those entries at all. Over binary records, its control showed, every small partial pattern inside the `5x5x5`
+window is exercised instead.
+
+**The question here is the next one.** Is there a matter law of the readable kind -- PR #7934's class, binary records, every menu nonempty -- that still carries the emergent fermion: admits every
+cylinder, has the cylinders as its whole complete admissible set up to a declared finite set of separated configurations, and leaves the hop Hamiltonian of PR #7889 supported inside them? The answer
+is yes on the `5x5x5` window and no on any nearest-neighbour or radius-1 window tried. Records register; the lattice is physical; the pattern is an arrangement of pinned values.
+
+## Supplied surface (quoted)
+
+Admissibility and Record, current landed wording (`docs/MINIMAL_AXIOMS_2026-06-29.md`), with reading note (3) fixing "admissible":
+
+> "There is one fixed nearest-neighbor admissibility rule, covariant under lattice translations and proper cubic rotations."
+
+> "The distribution is a probability measure on the local possibility domain; 'available'/'admissible' denotes its support -- on finite menus,
+> exactly the possibilities of nonzero probability."
+
+> "Only records are readable. A readout value is determined by record content alone. A site with no record cannot be read."
+
+Supplied from the campaign: the pattern and its `48` templates (PR #7834); the record rule `R_W` on a rotation-closed window and the readable class of PR #7934 -- covariant tables over a binary record
+alphabet with no empty menu -- with two stipulations, no label-equivariance (the designed law is not flip-symmetric: faces `0`, centres `1`) and the ternary profiles not free law content; the hop
+Hamiltonian `T_e = (i/2) A_ij (B_i - B_j)`, the BKSF encoding, the KS sign field and the twist convention (PR #7889, PR #7885 and the landed BKSF and superlattice census); the six completion rules --
+constant `0`, constant `1`, the parity of the window's recorded values, its complement, a corrected parity that gives the all-0 profile `1` and the all-1 profile `0`, and the permissive one -- the
+tori; the caps.
+
+**Stipulation R, the marginal reading of an unrecorded neighbour.** For a partial profile the menu is the union, over the completions of the open offsets, of the complete table's menus, and a partial
+configuration is admissible when every recorded site's value lies in that union. This is the partial-configuration readout of PR #7928 and PR #7934 with the ternary table derived from the complete
+one, and on the exercised part it reproduces PR #7977's projection reading exactly: `496` of `496` one-offset, `61,008` of `61,008` two-offset and `4,814,888` of `4,961,984` three-offset patterns.
+
+**The designed law over records** is `T_min^W`: the menu at a profile is the set of values the cylinders realise there, empty at every never-realised profile. Every entry of `T_min` is exercised by a
+cylinder, so the readable laws carrying the cylinders are exactly the completions of `T_min^W`, one or two values at every never-realised profile orbit.
+
+## T1 -- the censuses, and the entries a completion must add
+
+The parent censuses reproduce with fresh code.
+
+```text
+torus                4x2x2        4x4x2         4x4x4              8x4x4
+cylinders               16           32            48                 48
+free edge bits           6           12            24                 48
+record configurations 1,024      131,072   805,306,368         48 x 2^48
+role table T0: 18 (role, profile) pairs, 17 profiles of 5^6, 6 rotation orbits; 8 of 25 ordered
+role adjacencies realised, 17 never; the nearest-neighbour role rule admits 32 / 128 / 2,048 and
+the 12-offset rule admits 16 / 32 / 48, equal to the sector sets as sets
+window                    NN      NN+AX2       L1<=2         3x3x3           5x5x5
+offsets                    6          12          24            26             124
+exercised entries        128       1,638     391,233       101,626    2^57.05 of 2^125
+profiles with both        64         640     193,600         3,089               0
+profile orbits            10         240     703,360     2,802,752               -
+NEVER-REALISED orbits      0         157     694,711     2,798,417               -
+4x2x2, outside every cylinder under T_min: 64,512 / 13,981 / 186 / 154 / 0
+```
+
+The never-realised orbit counts are the entries a readable completion must add: `0` at nearest neighbour, `157` at twelve offsets, `694,711` at `L1<=2`, `2,798,417` at `3x3x3`. On `5x5x5` the `48`
+template cylinders are pairwise inconsistent, `0` of `1,128` pairs, with `36`, `44`, `51` or `54` free sites per template, so the exercised entries number exactly `148,935,859,368,886,272`; on the
+39-offset window `159` of `1,128` pairs are consistent and the free sites number `0`, `7` or `24`. The odd-corner census of one sector on `4x4x4` is intact: `131,072 / 3,670,016 / 9,175,040 /
+3,670,016 / 131,072` over the `2^24` edge assignments. **At nearest neighbour the only table containing the cylinders is the all-permissive one:** all `128` of `128` star entries are exercised and all
+`64` profiles carry both values, so the minimal law is already permissive, admits every configuration, and excludes nothing.
+
+## T2 -- the tabulated windows: readable, and not pinning
+
+On `4x2x2` the complete admissible set of each of the seven rules is enumerated without a solver, and CaDiCaL agrees with it as a set for the minimal, constant-0, parity and corrected rules on all
+three windows.
+
+```text
+4x2x2, configurations outside every cylinder          4x4x4, admissible pinned flips of 1,920
+window     T_min      c0      c1     par    apar    corr    permissive     T_min     par     corr
+NN+AX2    13,981  13,981  64,512  40,349  23,056  40,349        64,512     1,920       -       -
+L1<=2        186     833     699     725     607     636        64,512         0     384      384
+3x3x3        154     175     883     187     887     210        20,714         0     768      768
+```
+
+The minimal law already admits thousands of configurations outside every cylinder at each of these windows, and where it does not, the parity completions open single flips out of the cylinders.
+**Readability, on the other hand, is cheap.** The star flexibility -- for every offset, neighbour value and recorded overlap pattern, does some completion of the open offsets keep that value available
+-- is decided completely: `144` triples at twelve offsets, `74,496` at `L1<=2` and `1,624,064` at `3x3x3`, of which `0` have no completion under the parity, anti-parity, corrected and permissive rules
+at every window; the minimal law fails `55,848` and `1,587,236` of them.
+
+```text
+Z^3 star readout, complete entries
+window   law                  in T*        read        not in T*       read        blind
+NN+AX2   T_min                1,638       1,638            6,554      6,554            0
+L1<=2    T_min              391,233     391,233       33,163,199      4,132   33,159,067
+L1<=2    c0              16,970,816     414,296       16,583,616     45,170   33,094,966
+L1<=2    par/apar/corr   16,970,816         all       16,583,616        all            0
+3x3x3    T_min              101,626     101,626      134,116,102      7,486  134,108,616
+3x3x3    c0              67,111,953     127,281       67,105,775  1,024,996  133,065,451
+3x3x3    c1              67,111,953     109,097       67,105,775    124,785  133,983,846
+3x3x3    par/apar/corr   67,111,953         all       67,105,775        all            0
+```
+
+Three readings. **The designed law over records is blind on any window wide enough to matter** -- `134,108,616` of `134,217,728` entries on `3x3x3`, `99.92` per cent -- and what causes it is the empty
+menus, not the role alphabet. **Nonempty menus alone do not buy readability:** the constant completions are in the readable class and are almost as blind. **A flexible completion reads everything**,
+in or out of the law.
+
+## T3 -- the pinning windows: `5x5x5` is where the completion costs nothing
+
+**Pinned-flip lemma.** If no template agrees with a template `tau` on `tau`'s non-centre pins inside `W` while pinning the centre to the other value, then a cylinder configuration with one pinned site
+flipped is inadmissible at that site under *every* completion, because its profile is realised and a completion never touches a realised menu. The count of such template pairs is `0` on the 39-offset
+window, on `5x5x5` and on `7x7x7`, and on the tori no pinned flip is admissible under any rule, `0` of `1,920` and `0` of `3,840`. Each cylinder is therefore a component of the admissible set under
+single flips, whatever the completion.
+
+```text
+configurations outside every cylinder
+torus / window            T_min       c0        c1      par     apar     corr
+4x4x4, W39 (39 offsets)       0    3,457   >= 5,000   3,457  >= 5,000  >= 5,000
+4x4x4, 5x5x5                  0        1          1        1        1        0
+8x4x4, 5x5x5                  0  >= 5,000         1       17  >= 5,000       16
+```
+
+On `4x4x4` the wrapped `5x5x5` window reaches every site and the parity rule reduces to the linear system `c_s = sum of the odd-multiplicity neighbours`, whose matrix has full rank `64` over `F2`
+(rank `128` of `128` on `8x4x4`): the all-0 configuration is the only extra of the parity rule, all-1 the only one of the anti-parity rule, and the corrected rule, which assigns `1` to the all-0
+profile and `0` to the all-1 profile, has none. The 39-offset window, which does pin the minimal law on both tori, admits `3,457` extras under the parity and constant-0 rules on `4x4x4` and thousands
+more on `8x4x4`, because it does not separate the templates locally: `159` of its `1,128` template pairs are consistent on the window.
+
+**The completion is invisible to complete records on a torus.** On `4x4x4` the parity and constant-0 rules have the same admissible set, the anti-parity and constant-1 rules likewise, and the
+corrected rule the same set as the minimal law. A torus every site of which carries a record cannot tell these laws apart; a `5x5x5` block of records with open surroundings reads every entry of each.
+The Z^3 census of exercised complete entries on `5x5x5`: the sea of one sector exercises `48` in `9` rotation orbits, adding every single hop within reach gives `2,298` in `114` orbits, adding every
+double complement `54,642` in `2,421` orbits, and the whole cylinder set exercises `T_min` itself.
+
+## T4 -- the physics survives
+
+The record-level Hamiltonian is PR #7889's, taken as supplied: qubits on the free edge sites of a sector, and a hop on edge site `e` is the map `y -> y XOR e` on record patterns. Restricting it to the
+admissible set keeps the matrix elements between admissible configurations.
+
+```text
+4x4x4, 5x5x5, par and corr: 10,296 hop transitions from the declared families, 0 leaving
+8x4x4, 5x5x5, par and corr: 18,096 hop transitions from the declared families, 0 leaving
+4x4x4, corr: nothing outside the cylinders; two-copy SAT for an admissible pair at Hamming
+             distance 1 with one member outside every cylinder: UNSAT
+8x4x4, corr: 16 extras, each of weight 24, each with exactly 32 template-consistent sites of 128,
+             each 16 pinned-site flips from the nearest cylinder, none a corner pin-field defect;
+             0 admissible neighbours in 2,048 direct solves (2,176 under par, which adds all-0)
+coarse graph  corners  bonds   E_sea          twist      gap        best even filling
+4x4x4               8     24   -8 sqrt 3      (0,0,0)    6.928203   N = 4
+8x4x4              16     48   -8 sqrt 10     (1,0,0)    6.324555   N = 8
+flux classes on 4x4x4: 131,072 bond-sign classes, 146 distinct half-filled energies, the minimum
+             -13.856406 attained by exactly one class, the KS / pi-flux class
+8x4x4 odd-corner census: parity-map rank 15 = corners - 1, fibre 2^33, C(16, N) 2^33 for even N
+```
+
+Every extra is isolated under single flips and no cylinder configuration has an admissible pinned flip, so `H` restricted to the admissible set is the direct sum of the `48` untouched cylinder blocks
+and a zero operator on the extras. `H` is off-diagonal in the record basis, so an isolated configuration is an exact eigenvector of eigenvalue `0`: the extras sit `13.856406` and `25.298221` above the
+sea on the two tori, degenerate with mid-spectrum states of the blocks and connected to nothing.
+
+## The star lemma
+
+Let `T` be a covariant support table on `W` and `T^loc` its marginal extension. For a complete entry `(v, P)` let its **star** be the partial configuration with the centre recorded `v`, the offsets of
+`W` recorded as `P`, and every other site open.
+
+1. `(v, P)` is exercised by the partial readout on `Z^3` exactly when its star is admissible, that is when `v` lies in `T(P)` and every neighbour's recorded value lies in `T^loc` of its ternary
+   profile. Any partial configuration realising `(v, P)` at a site refines the star, and `T^loc` is antitone under refinement, so the star is the easiest witness.
+2. Call `T` **flexible** when every neighbour of every star is in that sense available. Then `T' = T` for every support table `T'` on `W` with the same partial readout: for `v` in `T(P)` the star lies
+   in the readout of `T`, hence in that of `T'`, so `T` is contained in `T'`; then `T'^loc` contains `T^loc`, the neighbours stay available under `T'`, and for `v` outside `T(P)` the star is absent
+   from the shared readout only because `v` is outside `T'(P)`. **The fibre of a flexible law under the partial readout is a singleton** -- in the class of all covariant support tables on the window,
+   not only the nonempty-menu ones -- and every complete entry, present or absent, is read by one `5x5x5` block of records with everything else open.
+
+Flexibility is verified completely on the tabulated windows (`0` of `144`, `0` of `74,496`, `0` of `1,624,064` triples without a completion for the parity, anti-parity and corrected rules) and
+certified on the wide windows by counting: a neighbour at offset `d` has `n_d` open offsets and the template-consistent completions number at most `sum_tau 2^{e_tau}`, so never-realised non-uniform
+completions of either parity number at least `2^{n_d - 1} - sum_tau 2^{e_tau} - 2`, which is `16,625,822` at the worst offset of `5x5x5` and `255,065,528` on the 39-offset window.
+
+## Corollary
+
+**The answer is yes, conditionally, on the `5x5x5` window -- radius 2 over records -- and on no nearest-neighbour or radius-1 window tried.** Take `T_min` on `5x5x5` and give every never-realised
+profile the value the corrected parity rule names. Every menu is nonempty; every complete entry is read by one partially recorded `5x5x5` block; the complete admissible set is exactly the `48`
+cylinders on `4x4x4` and the cylinders with `16` isolated configurations on `8x4x4`; the hop Hamiltonian is block-diagonal with the sea still the ground state of each block. The plain parity rule does
+the same with one further configuration on each torus.
+
+**The price, itemised.**
+
+1. **The window.** Radius 2 over records, `124` offsets, against "one fixed nearest-neighbor admissibility rule". PR #7939 priced the role rule at radius 3 over records; this law is radius 2 and needs
+   no role alphabet at all.
+2. **The completion is supplied.** The axioms and the cylinders say nothing about never-realised profiles, and complete records on a torus cannot read the choice: the parity and constant-0 completions
+   have the same admissible set on `4x4x4`. Only partially recorded regions distinguish them, which is what the Record axiom permits -- a site with no record is not read, and the region around a
+   recorded block may be unrecorded. The parity rule is one covariant choice among many, preferred here because it is flexible and has the fewest extras of the six.
+3. **The extras.** None on `4x4x4` under the corrected rule, `16` of weight `24` on `8x4x4`, isolated and at energy `0`. Their number on larger commensurate tori, `8x8x4` and `8x8x8`, is not computed.
+4. **Stipulation R**, the marginal reading of an unrecorded neighbour. Under the projection reading the completion entries are exercised only by the extras and readability becomes a different,
+   undecided question.
+
+**Disagreements with the expectation, stated plainly.**
+
+- The expected trade-off "readability forces the wider window" is not what the computation shows: readability by partially recorded stars is available at twelve offsets and even for the minimal law.
+  **What forces the wider window is pinning** -- having the cylinders as the whole complete admissible set -- not readability.
+- PR #7977's 39-offset closing window is the wrong window for a readable law. It pins the minimal law on both tori, but every completion of it admits thousands of configurations outside the cylinders,
+  because `159` of its template pairs agree on the window. The `5x5x5` window, which separates all `48`, is where the completion costs `0` on `4x4x4`.
+- The blindness PR #7977 measured is not the role alphabet's alone: the designed law over records is `99.92` per cent blind on `3x3x3` under the partial readout, and what removes the blindness is the
+  completion, not the alphabet.
+- The completion is invisible to complete records on a torus, so "records determine the law" holds for it only through partially recorded regions.
+- The extras depend on the torus: none on `4x4x4`, `16` on `8x4x4` for the corrected rule. A window-independent statement needs a torus all of whose sides are at least `5`, which is outside this run.
+
+## Reading, not theorem
+
+A law with empty menus cannot be read where it is silent, and the designed law over records is silent almost everywhere: nearly every arrangement of `26` neighbouring records is one the pattern never
+builds, and about such an arrangement the law says nothing that any record can confirm or deny. Completing those silences with a coin the neighbours themselves determine -- the parity of what is recorded
+around the site -- costs nothing that complete records can see and buys everything the partial ones need: each silence now has an answer, and each answer shows up in some block of records that is
+surrounded by open sites. The surprise is which half of the job needs the wide window. Reading the law is easy and was available six offsets out; what needs `124` offsets is telling the pattern apart
+from everything else, and once the window is wide enough to do that, the filling costs one configuration on the smaller torus and sixteen on the larger, all of them frozen, all of them at zero energy,
+none of them reachable by a hop.
+
+## Interfaces
+
+- **PR #7977**, the readout-blindness note, is the parent this note answers: its role-level blindness, its record-level control and its 39-offset closing window are all reproduced here, and its
+  blindness is shown to be removable at the record level by the completion. **PR #7939**, the role-pattern note, supplies the role rule priced at radius 3 and the 12-offset table whose admissible set
+  is the sectors.
+- **PR #7928** and **PR #7934**, the readability notes, supply the partial-configuration readout and the class in which every menu is nonempty; this note runs their readout against a completed minimal
+  table and gives the exact condition, flexibility, under which the fibre is a singleton.
+- **PR #7889** and **PR #7891**, the shifting-record notes, supply the hop and the single- and double-complement families, shown here to stay inside the cylinders; **PR #7885**, the determinantal
+  statistics note, supplies the reading of a full set of records at the coarse modes, used here to name the excitation families. The landed BKSF and superlattice census supplies the encoding and the
+  sign field on the coarse graph.
+
+## Executable claim block
+
+```text
+registry_id: readable_matter_law_on_5x5x5_window_parity_completion_2026_09_04
+censuses_pairs_profiles_orbits_and_adjacencies: 18 / 17 of 15,625 / 6 and 8 of 25
+role_admissible_sets_nn_and_twelve_offset: 32 / 128 / 2,048 and 16 / 32 / 48 = the sectors
+record_tables_exercised_entries: 128 / 1,638 / 391,233 / 101,626 and 2^57.05 of 2^125
+free_sites_per_template_on_5x5x5_and_pairs_consistent: 36 / 44 / 51 / 54 and 0 of 1,128
+never_realised_profile_orbits: 0 / 157 / 694,711 / 2,798,417
+ladder_4x2x2_outside_every_cylinder: 64,512 / 13,981 / 186 / 154
+star_flexibility_triples_and_failures_par_apar_corr: 144 / 74,496 / 1,624,064 and 0
+minimal_law_star_failures_and_blind_entries_on_3x3x3: 1,587,236 and 134,108,616 of 134,217,728
+completed_table_entries_read_on_3x3x3: 67,111,953 in and 67,105,775 out, blind 0
+pinned_flip_lemma_pairs_w39_5x5x5_7x7x7_and_counting_margin: 0 / 0 / 0 and 16,625,822
+extras_4x4x4_5x5x5_min_c0_c1_par_apar_corr: 0 / 1 / 1 / 1 / 1 / 0
+extras_8x4x4_5x5x5_min_c1_par_corr: 0 / 1 / 17 / 16 (par and corr quoted, s3A.030 and s3B.005)
+extras_4x4x4_w39_par_and_c0: 3,457 each, weights 0, 4, 8; 159 consistent template pairs
+f2_rank_of_the_wrapped_parity_system: 64 of 64 and 128 of 128
+z3_entry_census_and_partial_patterns: 48 / 2,298 / 54,642 and 496 / 61,008 / 4,814,888
+hop_transitions_and_departures: 10,296 and 18,096, 0 leaving
+extras_isolated_direct_solves: 0 of 2,048 and 0 of 2,176; two-copy SAT on 4x4x4 UNSAT
+sea_energies_and_gaps: -8 sqrt 3 with gap 6.928203 and -8 sqrt 10 with gap 6.324555
+flux_class_minimum_and_multiplicity: -13.856406 over 131,072 classes, attained once, 146 energies
+odd_corner_census_4x4x4_and_8x4x4_rank: 131,072 / 3,670,016 / 9,175,040 and rank 15, fibre 2^33
+no_physical_law_is_selected: true
+runner_result_required: zero failed checks
+```
+
+## Proof boundary
+
+The theorem is the finite classification above and nothing wider.
+
+- **Named tori, periodic, no open blocks.** `4x2x2`, `4x4x2` and `4x4x4` for the tabulated windows; `4x4x4` and `8x4x4` for the 39-offset, `5x5x5` and `7x7x7` windows; `Z^3` for the tables, the star
+  readout and the censuses.
+- **Capped enumerations are reported as bounds and never as counts.** Where a row reads `>= 5,000` or `>= 20,000` the enumeration stopped at the cap, and no such row is used as a count anywhere above.
+  Six completion rules are treated, not the space of completions: the minimum of the extras over all completions is not computed, its lower bound on a pinning window being the cylinder count, attained
+  on `4x4x4` by the corrected rule.
+- **What is quoted, not recomputed.** The completeness of the two `8x4x4` extra lists on the `5x5x5` window -- `17` under the parity rule and `16` under the corrected rule -- is quoted from the source
+  computation's output lines s3A.030 and s3B.005, each of which cost about a thousand seconds; the runner re-verifies all `16` configurations member by member as admissible, outside every cylinder, of
+  weight `24`, with `32` template-consistent sites, `16` pinned-site flips from the nearest cylinder, and isolated. The capped `8x4x4` rows for the constant-0 and anti-parity rules are likewise quoted
+  as bounds. The corrected rule's list was closed once more away from the runner, by a single call with all `16` blocked that returned unsatisfiable
+  after about `2,000` seconds, so there is no seventeenth configuration; that call is outside the runner's budget and the runner does not repeat it.
+- **Undecided rows, named.** The single-flip adjacency question for the 39-offset window's extras on `8x4x4` is not decided; the `8x4x4` `7x7x7` corrected-rule row was not run; the extra count on a
+  torus all of whose sides are at least `5` is not computed; and the readability claim under the projection reading rather than Stipulation R is not decided.
+- **Supplied and stipulated.** The pattern and its templates, the record rule and the windows, the readable class with its two stipulations, Stipulation R, the six completion rules, the tori, the
+  caps, and the whole of the physics -- the hop Hamiltonian, the BKSF encoding, the KS sign field and the twist convention. The flux-class scan is a free-fermion statement per bond-sign class; the
+  identification of the classes with encoding sectors is the parents' supplied content, and no dynamics is derived here.
+- **The axiom-level observation is a tension, not a derivation:** the law found is radius 2 where Admissibility says nearest-neighbour, and its never-realised menus are readable only through regions
+  the Record axiom permits to be partly unrecorded. No axiom is edited, no physical law is selected, and nothing is derived from the axioms about which law holds. No sampling, no seed and no random
+  number generator is used anywhere.
+
+## Honest-auditor read
+
+The load-bearing objects are, in order: the pinned-flip lemma, a two-line argument that makes every cylinder a component of the admissible set under every completion and carries the whole
+block-diagonality claim; the `0 / 1 / 1 / 1 / 1 / 0` extras row on `4x4x4`, which is what makes the corrected rule's admissible set exactly the sectors and is a complete CaDiCaL enumeration with an
+UNSAT proof at the end; and the star lemma, whose flexibility hypothesis is decided completely at `3x3x3` and by a counting certificate above it. Attack them in that order; the first two need only a
+solver and the third only arithmetic. The weakest rows are the two `8x4x4` extra totals, quoted rather than re-enumerated, and the capped rows beside them. The claim most likely to be over-read is the
+headline: the completion is a supplied choice that complete records cannot see, so "readable" here means readable through partially recorded regions under Stipulation R, and the `16` extras on `8x4x4`
+say the sector structure is not yet torus-independent.
+
+## Review record
+
+This note answers a readability question about one designed law, prices the answer, and proposes no law of its own. Hard landing conditions are a fresh runner and cache pair, a current
+citation-manifest entry, and passing pipeline, strict-lint and changed-evidence gates; audit remains a separate lane.

--- a/logs/runner-cache/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.txt
+++ b/logs/runner-cache/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.txt
@@ -1,0 +1,92 @@
+===== runner cache v1 =====
+runner: scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py
+runner_sha256: f9208595585c8ba07b855aedbcd89456ff37e51f8d7d8a53d74aae437eb20ce1
+input_fingerprint_sha256: d564605137edf3dc835f100cb240c01dfe187b8c48a4d045f17a20ccd6695c4e
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 114.15
+status: ok
+----- stdout -----
+external_scientific_inputs: none bar the declared quoted rows
+integrity_reads: axioms, deep probe, BKSF census, this note
+construction: exact enumeration on named tori and over Z^3
+negative_scope: no nearest-neighbour or radius-1 table both readable and pinning
+AUDIT_INPUT_PATHS:
+  docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_NOTE_2026-09-04.md
+  docs/MINIMAL_AXIOMS_2026-06-29.md
+  docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md
+  docs/FINITE_BKSF_SIGN_AND_SUPERLATTICE_MARKER_CENSUS_BOUNDED_THEOREM_NOTE_2026-09-02.md
+AUDIT_TIMEOUT_SEC: 300
+cache_write: false
+scientific_dependency: minimal_axioms Lattice, Qubit, Admissibility, Record
+declared_math: cubic rotations, record windows, Burnside counts, F2 ranks, spectra
+quoted_rows: the 8x4x4 5x5x5 totals 17 and 16 (s3A.030, s3B.005), re-verified here
+solver_mode: pysat present; CaDiCaL on 4x2x2, 4x4x4, 8x4x4
+PASS: audit-input-paths declared inputs exist and are unique
+PASS: audit-timeout the declared timeout is 300 seconds
+PASS: axiom-admissibility the nearest-neighbor rule is quoted
+PASS: axiom-support admissible read as the support
+PASS: axiom-record a site with no record cannot be read
+PASS: parent-deep-probe the readable class of the deep probe is live
+PASS: parent-encoding the landed BKSF census is live
+PASS: T1-sectors 16 / 32 / 48 / 48 cylinders, 48 x 2^24 on 4x4x4
+PASS: T1-role-table T0: 18 pairs, 17 profiles of 5^6, 6 orbits
+PASS: T1-role-adjacency 8 of 25 role adjacencies realised, 17 never
+PASS: T1-role-rules NN admits 32 / 128 / 2,048; 12 offsets give the sectors
+PASS: T1-record-tables exercised entries 128 / 1,638 / 391,233 / 101,626
+PASS: T1-nn-permissive at NN the minimal law is already all-permissive
+PASS: T1-5x5x5-disjoint 5x5x5: 0 of 1,128 pairs, 2^57.05 of 2^125 exercised
+PASS: T1-W39-pairs W39: 159 of 1,128 template pairs consistent
+PASS: T1-ladder-422 4x2x2 extras 64,512 / 13,981 / 186 / 154
+PASS: T1-orbits never-realised orbits 0 / 157 / 694,711 / 2,798,417
+PASS: T1-odd-corner 4x4x4 odd corners 131,072 / 3,670,016 / 9,175,040
+PASS: T2-422-NN+AX2 the 4x2x2 sets of the seven rules match
+PASS: T2-422-cadical-NN+AX2 CaDiCaL agrees as sets for min, c0, par, corr
+PASS: T2-422-L1<=2 the 4x2x2 sets of the seven rules match
+PASS: T2-422-cadical-L1<=2 CaDiCaL agrees as sets for min, c0, par, corr
+PASS: T2-422-3x3x3 the 4x2x2 sets of the seven rules match
+PASS: T2-422-cadical-3x3x3 CaDiCaL agrees as sets for min, c0, par, corr
+PASS: T2-flip-leak 4x4x4 pinned flips 1,920 / 0 / 384 / 0 / 768
+PASS: T2-flexibility par, apar, corr: 0 of 144 / 74,496 / 1,624,064 fail
+PASS: T2-flex-min min fails 55,848 and 1,587,236; c0 28,008 and 797,466
+PASS: T2-readout-min the designed law is blind on 134,108,616 of 134,217,728
+PASS: T2-readout-const constant completions blind on 133,065,451 and 133,983,846
+PASS: T2-readout-flexible par/apar/corr read all 16,970,816 and 67,111,953 entries
+PASS: T2-menus menus nonempty for the six completions, empty for min
+PASS: T3-pinned-flip-lemma 0 pairs on W39, 5x5x5 and 7x7x7
+PASS: T3-flexibility-bound counting margin 16,625,822 at the worst 5x5x5 offset
+PASS: T3-F2-ranks wrapped parity system rank 64 of 64 and 128 of 128
+PASS: T3-extras-4x4x4 4x4x4 5x5x5 extras 0 / 1 / 1 / 1 / 1 / 0
+PASS: T3-complete-records-blind par and c0 share their 4x4x4 admissible set
+PASS: T3-W39-extras W39 on 4x4x4: 3,457 extras under par and c0
+PASS: T3-8x4x4-minimal 8x4x4: min 0 extras, c1 1, 0 of 3,840 pinned flips
+PASS: T3-z3-census Z^3 entries 48 / 2,298 / 54,642
+PASS: T3-partial-patterns 496, 61,008 and 4,814,888 of 4,961,984 patterns
+PASS: T4-hops 10,296 and 18,096 hop transitions, 0 leaving
+PASS: T4-extras-8x4x4 16 extras: weight 24, 32 sites, distance 16, no defect
+PASS: T4-extras-quoted completeness 16 and 17 quoted, not re-enumerated
+PASS: T4-isolation 0 admissible neighbours in 2,048 / 2,176 / 64 solves
+PASS: T4-two-copy 4x4x4 corr two-copy adjacency SAT: UNSAT
+PASS: T4-sea-4x4x4 E_sea = -8 sqrt 3, gap 6.928203, twist (0,0,0)
+PASS: T4-sea-8x4x4 E_sea = -8 sqrt 10, gap 6.324555, twist (1,0,0)
+PASS: T4-flux-classes 131,072 classes, KS the unique minimiser, 146 energies
+PASS: T4-extras-energy the extras are exact zero eigenvectors above the sea
+PASS: T4-odd-corner-8x4x4 8x4x4 parity-map rank 15, fibre 2^33
+PASS: note-length the note stays under 330 lines
+PASS: note-registry-id the note declares its registry id
+PASS: note-vocabulary the note avoids the banned vocabulary
+PASS: note-wording superlattice role pattern; nothing overclaimed
+PASS: note-scope no law selected; bounded scope stated
+PASS: note-interfaces the note names its parent pull requests
+PASS: note-numbers the note carries its counts
+PASS: note-boundary the quoted and undecided rows are named
+per_element: 2 record values, 48 templates, 124 offsets
+per_site: every site of every named torus and window
+per_mode: 8 and 16 coarse modes, free-fermion spectra
+per_block: 48 cylinder blocks, 16 isolated extras
+lattice_wide: 4x2x2, 4x4x2, 4x4x4, 8x4x4; Z^3 censuses
+elapsed_sec: 114.0
+TOTAL: PASS=58 FAIL=0
+
+----- stderr -----
+

--- a/scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py
+++ b/scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py
@@ -1,0 +1,1806 @@
+#!/usr/bin/env python3
+"""Exact checks: a readable matter law exists on the 5x5x5 window.  The
+designed law's record table, completed at every never-realised profile by a
+covariant parity rule, has every menu nonempty, is read entry by entry from
+partially recorded 5x5x5 blocks, admits exactly the 48 sectors on 4x4x4 and
+16 further isolated configurations on 8x4x4, and leaves the emergent
+fermion's hop Hamiltonian block-diagonal.  No nearest-neighbour or radius-1
+table containing the sectors does so.
+
+Self-contained.  Every definition below is copied from the probe scripts of
+the source computation and the block each copy reproduces is named here:
+
+  * the role pattern, the proper cubic rotations, the 48 templates, the
+    rotation-closed windows, the minimal record table T_min, the six
+    completion rules, the torus admissible masks and the CNF encodings
+                              -- source block `lib.py`;
+  * T1, the role and record censuses, the solver-free role search, the
+    4x2x2 ladder, the Burnside counts of never-realised profile orbits and
+    the odd-corner census
+                              -- source block `s1_census.py`;
+  * T2, the complete 4x2x2 admissible sets for the seven rules, the CaDiCaL
+    set equality, the pinned-flip counts on 4x4x4, the star flexibility and
+    the star readout table
+                              -- source block `s2_small_windows.py`;
+  * T3, the pinned-flip lemma on Z^3, the flexibility counting bound, the
+    extras and the F2 cross-check on 4x4x4 and 8x4x4, the Z^3 exercised-entry
+    census and the partial-pattern census
+                              -- source block `s3_big_windows.py`;
+  * T4, the hop families and their transitions, the structure and isolation
+    of the extras, the coarse graph, the KS sign field, the flux-class scan
+    and the 8x4x4 odd-corner census
+                              -- source block `s4_physics.py`.
+
+Two reductions keep the run inside its budget, both declared:
+
+  * the star flexibility of `s2_small_windows.py` is recomputed by a sparse
+    recount -- the realised and exercised profiles are bincounted by overlap
+    key, and the completions of each key are counted exactly rather than
+    scanned -- which reproduces the source's triple counts entry for entry;
+  * the extra configurations of the corrected and parity rules on 8x4x4 with
+    the 5x5x5 window are supplied as a declared certificate of 16 weight-24
+    configurations, each re-verified here as admissible, outside every
+    cylinder and isolated; that the list is complete, 16 for the corrected
+    rule and those 16 with the all-0 configuration for the parity rule, is
+    quoted from the source output lines s3B.005 and s3A.030 and is not
+    re-enumerated (each of those rows cost about 1,000 seconds).
+
+Capped enumerations are reported as bounds and never as counts.  No sampling,
+no seed and no random number generator is used anywhere.  CaDiCaL runs where
+pysat is importable; the complete solver-free enumeration on the smallest
+torus runs in every run.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import time
+from pathlib import Path
+
+import numpy as np
+
+AUDIT_TIMEOUT_SEC = 300
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTE_REL = (
+    "docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_"
+    "RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_"
+    "NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_"
+    "NOTE_2026-09-04.md"
+)
+AXIOM_REL = "docs/MINIMAL_AXIOMS_2026-06-29.md"
+PROBE_REL = "docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md"
+BKSF_REL = (
+    "docs/FINITE_BKSF_SIGN_AND_SUPERLATTICE_MARKER_CENSUS_BOUNDED_THEOREM_"
+    "NOTE_2026-09-02.md"
+)
+
+AUDIT_INPUT_PATHS = (
+    "docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_"
+    "RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_"
+    "NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_"
+    "NOTE_2026-09-04.md",
+    "docs/MINIMAL_AXIOMS_2026-06-29.md",
+    "docs/EXTENSIONAL_NEAREST_NEIGHBOR_RULE_DEEP_PROBE_2026-07-13.md",
+    "docs/FINITE_BKSF_SIGN_AND_SUPERLATTICE_MARKER_CENSUS_BOUNDED_THEOREM_"
+    "NOTE_2026-09-02.md",
+)
+
+assert AUDIT_INPUT_PATHS == (NOTE_REL, AXIOM_REL, PROBE_REL, BKSF_REL)
+
+NOTE_PATH = ROOT / NOTE_REL
+AXIOM_PATH = ROOT / AXIOM_REL
+PROBE_PATH = ROOT / PROBE_REL
+BKSF_PATH = ROOT / BKSF_REL
+
+CELL_CAP = 16_000_000          # no dense array above 4096 x 4096 entries
+SAT_CAP = 5000                 # capped enumerations are reported as bounds
+
+# the quoted rows (source output lines s3A.030 and s3B.005): the completeness
+# of the 8x4x4 extra lists under the parity and corrected rules on the 5x5x5
+# window.  Every other number below is recomputed here.
+QUOTED_8X4X4_PAR_EXTRAS = 17
+QUOTED_8X4X4_CORR_EXTRAS = 16
+
+# the declared certificate: the 16 weight-24 extras of the corrected rule on
+# 8x4x4 with the 5x5x5 window, site order itertools.product(range(8),
+# range(4), range(4)), bit i of the hex word = site i
+EXTRA_CERTIFICATE_8X4X4 = (
+    "000050500a0a505000000a0a50500a0a",
+    "a0a00505a0a000000505a0a005050000",
+    "a0a000000505a0a005050000a0a00505",
+    "a0a005050000a0a00505a0a000000505",
+    "50500a0a505000000a0a50500a0a0000",
+    "00000a0a50500a0a000050500a0a5050",
+    "0a0a50500a0a000050500a0a50500000",
+    "0000a0a00505a0a000000505a0a00505",
+    "50500a0a000050500a0a505000000a0a",
+    "0505a0a005050000a0a00505a0a00000",
+    "00000505a0a005050000a0a00505a0a0",
+    "0a0a505000000a0a50500a0a00005050",
+    "05050000a0a00505a0a000000505a0a0",
+    "0505a0a000000505a0a005050000a0a0",
+    "505000000a0a50500a0a000050500a0a",
+    "0a0a000050500a0a505000000a0a5050",
+)
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+class Checks:
+    def __init__(self) -> None:
+        self.passed = 0
+        self.failed = 0
+
+    def check(self, label: str, statement: str, condition: bool,
+              residual: object | None = None) -> None:
+        ok = bool(condition)
+        self.passed += int(ok)
+        self.failed += int(not ok)
+        print(f"{'PASS' if ok else 'FAIL'}: {label} {statement}")
+        if not ok and residual is not None:
+            print(f"  residual: {residual}")
+
+    def finish(self) -> int:
+        print(f"TOTAL: PASS={self.passed} FAIL={self.failed}")
+        return self.failed
+
+
+# ---- the pattern and the templates (source block lib.py) -------------------
+C0, C1, E, F, Q = range(5)
+
+
+def pat_sym(site, ax: int) -> int:
+    """Role of a fine site in the period-(4,2,2) pattern laid along `ax`."""
+    odd = (site[0] & 1) + (site[1] & 1) + (site[2] & 1)
+    if odd == 0:
+        return C0 + ((site[ax] // 2) % 2)
+    if odd == 1:
+        return E
+    if odd == 2:
+        return F
+    return Q
+
+
+def pat_bit(site, ax: int):
+    """Record value at a fine site; None on the free edge sites."""
+    role = pat_sym(site, ax)
+    if role == E:
+        return None
+    return 1 if role in (C1, Q) else 0
+
+
+def proper_cubic_rotations():
+    out = []
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product((1, -1), repeat=3):
+            m = [[0, 0, 0] for _ in range(3)]
+            for row in range(3):
+                m[row][perm[row]] = signs[row]
+            det = (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                   - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                   + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+            if det == 1:
+                out.append(tuple(tuple(r) for r in m))
+    return tuple(out)
+
+
+ROTATIONS = proper_cubic_rotations()
+assert len(ROTATIONS) == 24
+
+
+def act(m, v):
+    return tuple(sum(m[i][k] * v[k] for k in range(3)) for i in range(3))
+
+
+def transpose(m):
+    return tuple(tuple(m[j][i] for j in range(3)) for i in range(3))
+
+
+def sites(box):
+    return list(itertools.product(range(box[0]), range(box[1]), range(box[2])))
+
+
+def wrap(s, box):
+    return tuple(s[k] % box[k] for k in range(3))
+
+
+def record_templates():
+    out = []
+    for ax in (0, 1, 2):
+        for shift in itertools.product(range(4), range(2), range(2)):
+            origin = [0, 0, 0]
+            origin[ax] = shift[0]
+            origin[(ax + 1) % 3] = shift[1]
+            origin[(ax + 2) % 3] = shift[2]
+            out.append((ax, tuple(origin)))
+    return out
+
+
+TEMPLATES = record_templates()
+assert len(TEMPLATES) == 48
+
+
+def torus_sectors(box):
+    """The distinct (ax, origin) cylinders the torus supports, as pin tuples."""
+    seen = {}
+    for ax, origin in TEMPLATES:
+        period = [2, 2, 2]
+        period[ax] = 4
+        if any(box[i] % period[i] for i in range(3)):
+            continue
+        pins = tuple(pat_bit(tuple(s[k] + origin[k] for k in range(3)), ax)
+                     for s in sites(box))
+        seen.setdefault(pins, (ax, origin))
+    return [(k, v) for v, k in sorted((v, k) for k, v in seen.items())]
+
+
+ORBIT_SEEDS = [(1, 0, 0), (1, 1, 0), (1, 1, 1), (2, 0, 0), (2, 1, 0),
+               (2, 1, 1), (2, 2, 0), (2, 2, 1), (2, 2, 2),
+               (3, 0, 0), (3, 1, 0), (3, 1, 1), (3, 2, 0), (3, 2, 1),
+               (3, 2, 2), (3, 3, 0), (3, 3, 1), (3, 3, 2), (3, 3, 3),
+               (3, 1, 2)]
+ORBITS = [sorted({act(m, s) for m in ROTATIONS}) for s in ORBIT_SEEDS]
+
+
+def window(*seed_ids):
+    w = []
+    for i in seed_ids:
+        w += ORBITS[i]
+    return sorted(w)
+
+
+WINDOWS = {
+    "NN": window(0),                       # 6
+    "NN+AX2": window(0, 3),                # 12
+    "L1<=2": window(0, 1, 3),              # 24
+    "3x3x3": window(0, 1, 2),              # 26
+    "W39": window(2, 3, 4),                # 38 offsets + centre
+    "5x5x5": window(*range(9)),            # 124
+    "7x7x7": window(*range(20)),           # 342
+}
+TABULATED = ("NN", "NN+AX2", "L1<=2", "3x3x3")
+
+
+def template_pins(W, ax, origin, with_centre=True):
+    """Offset -> pinned value, over the offsets of W (and the centre)."""
+    pins = {}
+    offs = ([(0, 0, 0)] if with_centre else []) + list(W)
+    for o in offs:
+        v = pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax)
+        if v is not None:
+            pins[o] = v
+    return pins
+
+
+# ---- the minimal table and the completion rules (source block lib.py) ------
+def tabulate(W):
+    """T_min on W as tmin[v][P] over the 2^|W| offset-indexed profiles."""
+    w = len(W)
+    assert w <= 26
+    pos = {o: i for i, o in enumerate(W)}
+    tmin = [np.zeros(1 << w, dtype=bool), np.zeros(1 << w, dtype=bool)]
+    for ax, origin in TEMPLATES:
+        pins = template_pins(W, ax, origin)
+        centre = pins.get((0, 0, 0))
+        base = 0
+        free = []
+        for o in W:
+            if o in pins:
+                base |= pins[o] << pos[o]
+            else:
+                free.append(pos[o])
+        idx = np.array([base], dtype=np.int64)
+        for f in free:
+            idx = np.concatenate([idx, idx | (1 << f)])
+        for v in ((0, 1) if centre is None else (centre,)):
+            tmin[v][idx] = True
+    return tmin, tmin[0] | tmin[1]
+
+
+def popcount(a):
+    a = np.asarray(a, dtype=np.uint64)
+    c = np.zeros(a.shape, dtype=np.int64)
+    while True:
+        nz = a != 0
+        if not nz.any():
+            break
+        c += nz
+        a = a & (a - np.uint64(1))
+    return c
+
+
+def rule_values(name, W, P):
+    """The completion value at never-realised profiles: 0, 1, 2 = both."""
+    w = len(W)
+    P = np.asarray(P, dtype=np.int64)
+    if name == "min":
+        return np.full(P.shape, -1, dtype=np.int8)
+    if name == "all":
+        return np.full(P.shape, 2, dtype=np.int8)
+    if name == "c0":
+        return np.zeros(P.shape, dtype=np.int8)
+    if name == "c1":
+        return np.ones(P.shape, dtype=np.int8)
+    par = (popcount(P) & 1).astype(np.int8)
+    if name == "par":
+        return par
+    if name == "apar":
+        return (1 - par).astype(np.int8)
+    if name == "corr":
+        out = par.copy()
+        out[P == 0] = 1
+        out[P == (1 << w) - 1] = 0
+        return out
+    raise ValueError(name)
+
+
+RULES = ("min", "c0", "c1", "par", "apar", "corr", "all")
+
+
+def profile_ints(cfg_bits, box, W):
+    grid = sites(box)
+    idx = {s: i for i, s in enumerate(grid)}
+    N, n = cfg_bits.shape
+    out = np.zeros((N, n), dtype=np.int64)
+    for j, s in enumerate(grid):
+        acc = np.zeros(N, dtype=np.int64)
+        for i, o in enumerate(W):
+            u = idx[wrap(tuple(s[k] + o[k] for k in range(3)), box)]
+            acc |= cfg_bits[:, u].astype(np.int64) << i
+        out[:, j] = acc
+    return out
+
+
+def admissible_mask(cfg_bits, box, W, tmin, real, rule):
+    """Configurations admissible under T_min(W) completed by `rule`."""
+    P = profile_ints(cfg_bits, box, W)
+    N, n = cfg_bits.shape
+    ok = np.ones(N, dtype=bool)
+    for j in range(n):
+        c = cfg_bits[:, j].astype(np.int64)
+        p = P[:, j]
+        ex = np.where(c == 1, tmin[1][p], tmin[0][p])
+        rv = rule_values(rule, W, p)
+        ok &= ex | ((~real[p]) & ((rv == 2) | (rv == c)))
+    return ok
+
+
+def all_configs(box):
+    n = len(sites(box))
+    return ((np.arange(1 << n, dtype=np.int64)[:, None]
+             >> np.arange(n)) & 1).astype(np.int8)
+
+
+def cylinder_mask(cfg_bits, box):
+    N = cfg_bits.shape[0]
+    inside = np.zeros(N, dtype=bool)
+    for pins, _ in torus_sectors(box):
+        cyl = np.ones(N, dtype=bool)
+        for i, v in enumerate(pins):
+            if v is not None:
+                cyl &= cfg_bits[:, i] == v
+        inside |= cyl
+    return inside
+
+
+# ---- CNF encodings (source block lib.py) -----------------------------------
+class CNF:
+    def __init__(self, nvars: int) -> None:
+        self.n = nvars
+        self.clauses = []
+
+    def new(self) -> int:
+        self.n += 1
+        return self.n
+
+    def add(self, cl) -> None:
+        self.clauses.append(list(cl))
+
+    def and_gate(self, lits):
+        g = self.new()
+        for l in lits:
+            self.add([-g, l])
+        self.add([g] + [-l for l in lits])
+        return g
+
+    def or_gate(self, lits):
+        g = self.new()
+        for l in lits:
+            self.add([-l, g])
+        self.add([-g] + list(lits))
+        return g
+
+    def xor_chain(self, lits):
+        if not lits:
+            f = self.new()
+            self.add([-f])
+            return f
+        cur = lits[0]
+        for l in lits[1:]:
+            g = self.new()
+            self.add([-g, cur, l])
+            self.add([-g, -cur, -l])
+            self.add([g, -cur, l])
+            self.add([g, cur, -l])
+            cur = g
+        return cur
+
+    def iff_gate(self, a, b):
+        g = self.new()
+        self.add([-g, -a, b])
+        self.add([-g, a, -b])
+        self.add([g, a, b])
+        self.add([g, -a, -b])
+        return g
+
+
+def build_cnf(box, W, rule):
+    """CNF whose x-models are the configurations admissible under T_min(W)
+    completed by `rule`; wrapped offsets, coincident offsets cancel in a
+    parity exactly as the record rule's marker clauses apply."""
+    grid = sites(box)
+    idx = {s: i for i, s in enumerate(grid)}
+    n = len(grid)
+    cnf = CNF(n)
+
+    def x(s):
+        return idx[wrap(s, box)] + 1
+
+    for s in grid:
+        ms, ns = [], []
+        for ax, origin in TEMPLATES:
+            pins = template_pins(W, ax, origin)
+            dem_full, dem_prof, ok_full, ok_prof = {}, {}, True, True
+            for o, v in pins.items():
+                u = x(tuple(s[k] + o[k] for k in range(3)))
+                if o != (0, 0, 0):
+                    if dem_prof.get(u, v) != v:
+                        ok_prof = False
+                    dem_prof[u] = v
+                if dem_full.get(u, v) != v:
+                    ok_full = False
+                dem_full[u] = v
+            if ok_full:
+                ms.append(cnf.and_gate([u if v else -u
+                                        for u, v in dem_full.items()]))
+            if ok_prof:
+                ns.append(cnf.and_gate([u if v else -u
+                                        for u, v in dem_prof.items()]))
+        if rule == "min":
+            cnf.add(ms)
+            continue
+        if rule == "all":
+            for l in ns:
+                cnf.add(ms + [-l])
+            continue
+        mult = {}
+        for o in W:
+            u = x(tuple(s[k] + o[k] for k in range(3)))
+            mult[u] = mult.get(u, 0) + 1
+        par = cnf.xor_chain([u for u, m in mult.items() if m % 2 == 1])
+        c = x(s)
+        if rule == "c0":
+            r = -c
+        elif rule == "c1":
+            r = c
+        elif rule == "par":
+            r = cnf.iff_gate(c, par)
+        elif rule == "apar":
+            r = -cnf.iff_gate(c, par)
+        elif rule == "corr":
+            wins = sorted(mult)
+            u0 = cnf.and_gate([-u for u in wins])
+            u1 = cnf.and_gate([u for u in wins])
+            eq = cnf.iff_gate(c, par)
+            r = cnf.or_gate([cnf.and_gate([-u0, -u1, eq]),
+                             cnf.and_gate([u0, c]),
+                             cnf.and_gate([u1, -c])])
+        else:
+            raise ValueError(rule)
+        for l in ns:
+            cnf.add(ms + [-l])
+        cnf.add(ms + [r])
+    return cnf, n
+
+
+def cylinder_clauses(box):
+    """Clauses excluding every cylinder: what is left are the extras."""
+    out = []
+    for pins, _ in torus_sectors(box):
+        out.append([-(i + 1) if v == 1 else (i + 1)
+                    for i, v in enumerate(pins) if v is not None])
+    return out
+
+
+def enumerate_models(solver_cls, cnf, n, extra=(), cap=SAT_CAP):
+    models = []
+    with solver_cls(bootstrap_with=cnf.clauses + list(extra)) as s:
+        while len(models) < cap:
+            if not s.solve():
+                return models, False
+            m = s.get_model()
+            bits = tuple(1 if m[i] > 0 else 0 for i in range(n))
+            models.append(bits)
+            s.add_clause([-(i + 1) if b else (i + 1)
+                          for i, b in enumerate(bits)])
+    return models, True
+
+
+def pinned_flip_sat(solver_cls, box, cnf):
+    """(admissible pinned-flip configurations, pinned sites tried)."""
+    hits = total = 0
+    with solver_cls(bootstrap_with=cnf.clauses) as s:
+        for pins, _ in torus_sectors(box):
+            for f, v in enumerate(pins):
+                if v is None:
+                    continue
+                total += 1
+                assum = [((i + 1) if (u if i != f else 1 - u) else -(i + 1))
+                         for i, u in enumerate(pins) if u is not None]
+                if s.solve(assumptions=assum):
+                    hits += 1
+    return hits, total
+
+
+def cylinders_admissible(solver_cls, box, cnf):
+    with solver_cls(bootstrap_with=cnf.clauses) as s:
+        return all(s.solve(assumptions=[(i + 1) if v else -(i + 1)
+                                        for i, v in enumerate(pins)
+                                        if v is not None])
+                   for pins, _ in torus_sectors(box))
+
+
+# ---- Burnside (source block lib.py / s1_census.py) -------------------------
+def offset_cycles(W, m):
+    seen, cycles = set(), []
+    for o in W:
+        if o in seen:
+            continue
+        cyc, cur = [], o
+        while cur not in seen:
+            seen.add(cur)
+            cyc.append(cur)
+            cur = act(m, cur)
+        cycles.append(cyc)
+    return cycles
+
+
+def burnside_all(W):
+    tot = sum(1 << len(offset_cycles(W, m)) for m in ROTATIONS)
+    assert tot % 24 == 0
+    return tot // 24
+
+
+def orbit_counts(W, tmin, real):
+    """(profile orbits, realised orbits, exercised entries, never-realised
+    orbits) by Burnside; the identity is counted without materialising the
+    2^|W| index array."""
+    w = len(W)
+    pos = {o: i for i, o in enumerate(W)}
+    fix_never = int((~real).sum())
+    fix_real = int(real.sum())
+    fix_ent = [int(tmin[0].sum()), int(tmin[1].sum())]
+    n_orbits = 1 << w
+    for m in ROTATIONS[1:]:
+        cycles = offset_cycles(W, m)
+        k = len(cycles)
+        n_orbits += 1 << k
+        masks = np.array([sum(1 << pos[o] for o in cyc) for cyc in cycles],
+                         dtype=np.int64)
+        sel = ((np.arange(1 << k, dtype=np.int64)[:, None]
+                >> np.arange(k)) & 1).astype(np.int64)
+        P = (sel * masks[None, :]).sum(axis=1)
+        fix_never += int((~real[P]).sum())
+        fix_real += int(real[P].sum())
+        fix_ent[0] += int(tmin[0][P].sum())
+        fix_ent[1] += int(tmin[1][P].sum())
+    assert n_orbits % 24 == 0 and fix_never % 24 == 0 and fix_real % 24 == 0
+    return (n_orbits // 24, fix_real // 24,
+            (fix_ent[0] + fix_ent[1]) // 24, fix_never // 24)
+
+
+# ---- T1 roles (source block s1_census.py) ----------------------------------
+def rot_maps(support):
+    index = {o: i for i, o in enumerate(support)}
+    return [tuple(index[act(transpose(m), support[i])]
+                  for i in range(len(support))) for m in ROTATIONS]
+
+
+def realised_role_pairs(support, ax=0):
+    maps = rot_maps(support)
+    base = set()
+    for site in itertools.product(range(4), range(4), range(4)):
+        role = pat_sym(site, ax)
+        prof = tuple(pat_sym(tuple(site[k] + o[k] for k in range(3)), ax)
+                     for o in support)
+        base.add((role, prof))
+    out = set()
+    for role, prof in base:
+        for m in maps:
+            out.add((role, tuple(prof[m[i]] for i in range(len(support)))))
+    return out
+
+
+def neighbour_table(box, support):
+    index = {s: i for i, s in enumerate(sites(box))}
+    return [[index[wrap(tuple(s[k] + o[k] for k in range(3)), box)]
+             for o in support] for s in sites(box)]
+
+
+def dfs_role_admissible(box, support, pairs):
+    """Complete solver-free search for the role-rule admissible sets."""
+    nb = neighbour_table(box, support)
+    n = len(nb)
+    by_role = {}
+    for r, p in pairs:
+        by_role.setdefault(r, []).append(p)
+    involved = [[] for _ in range(n)]
+    for u in range(n):
+        involved[u].append(u)
+        for j in nb[u]:
+            if u not in involved[j]:
+                involved[j].append(u)
+    assign = [-1] * n
+    found = []
+
+    def ok(u):
+        r = assign[u]
+        if r == -1:
+            return True
+        for p in by_role.get(r, ()):
+            if all(assign[j] in (-1, p[i]) for i, j in enumerate(nb[u])):
+                return True
+        return False
+
+    def rec(v):
+        if v == n:
+            found.append(tuple(assign))
+            return
+        for r in range(5):
+            assign[v] = r
+            if all(ok(u) for u in involved[v]):
+                rec(v + 1)
+        assign[v] = -1
+
+    rec(0)
+    return found
+
+
+def sector_role_configs(box):
+    out = set()
+    for ax in (0, 1, 2):
+        period = [2, 2, 2]
+        period[ax] = 4
+        if any(box[i] % period[i] for i in range(3)):
+            continue
+        for shift in itertools.product(range(4), repeat=3):
+            out.add(tuple(pat_sym(tuple(s[k] + shift[k] for k in range(3)), ax)
+                          for s in sites(box)))
+    return out
+
+
+# ---- T2 the star lemma (source block s2_small_windows.py) ------------------
+def overlaps(W):
+    """For each offset d the pairs (bit i of the neighbour's profile, index
+    in the star) at which the star of the centre already records a value;
+    index -1 is the centre itself."""
+    star = {(0, 0, 0): -1}
+    for i, o in enumerate(W):
+        star[o] = i
+    ov = {}
+    for d in W:
+        ov[d] = [(i, star[tuple(d[k] + o2[k] for k in range(3))])
+                 for i, o2 in enumerate(W)
+                 if tuple(d[k] + o2[k] for k in range(3)) in star]
+    return ov
+
+
+def keyed_counts(W, tmin, real, ov):
+    """Sparse recount of the source's flexibility scan: for each offset d,
+    the number of realised profiles, of realised profiles of each parity and
+    of exercised entries of each value, bincounted by overlap key."""
+    w = len(W)
+    ridx = np.nonzero(real)[0].astype(np.int64)
+    eidx = [np.nonzero(tmin[u])[0].astype(np.int64) for u in (0, 1)]
+    rpar = popcount(ridx) & 1
+    out = {}
+    for d in W:
+        bits = [i for i, _ in ov[d]]
+        nk = 1 << len(bits)
+
+        def keys(P, bits=bits):
+            k = np.zeros(len(P), dtype=np.int64)
+            for b, i in enumerate(bits):
+                k |= ((P >> i) & 1) << b
+            return k
+
+        rk = keys(ridx)
+        out[d] = (nk, w - len(bits), np.bincount(rk, minlength=nk),
+                  [np.bincount(rk[rpar == u], minlength=nk) for u in (0, 1)],
+                  [np.bincount(keys(eidx[u]), minlength=nk) for u in (0, 1)],
+                  bits)
+    return out
+
+
+def bad_keys(W, kc, rule, real):
+    """(offset -> [bad key mask per neighbour value], triples with no
+    completion, triples tried).  A key is good for the value u when some
+    completion of the open offsets puts u in the completed menu; the count of
+    completions of each parity is exact, so nothing is scanned."""
+    w = len(W)
+    specials = [s for s in (0, (1 << w) - 1) if not real[s]]
+    bm, tot, tried = {}, 0, 0
+    for d, (nk, free, cr, crp, ce, bits) in kc.items():
+        assert free >= 1
+        half = 1 << (free - 1)
+        rows = []
+        for u in (0, 1):
+            zero = np.zeros(nk, dtype=bool)
+            if rule == "min":
+                good = ce[u] > 0
+            elif rule == "all":
+                good = (ce[u] > 0) | (cr < (1 << free))
+            elif rule == "c0":
+                good = (ce[u] > 0) | ((cr < (1 << free)) if u == 0 else zero)
+            elif rule == "c1":
+                good = (ce[u] > 0) | ((cr < (1 << free)) if u == 1 else zero)
+            elif rule == "par":
+                good = (ce[u] > 0) | ((half - crp[u]) > 0)
+            elif rule == "apar":
+                good = (ce[u] > 0) | ((half - crp[1 - u]) > 0)
+            elif rule == "corr":
+                nev = (half - crp[u]).astype(np.int64)
+                for s in specials:
+                    ps = bin(s).count("1") & 1
+                    cs = 1 if s == 0 else 0
+                    if ps == cs:
+                        continue
+                    key = 0
+                    for b, i in enumerate(bits):
+                        key |= ((s >> i) & 1) << b
+                    nev[key] += (1 if u == cs else 0) - (1 if u == ps else 0)
+                good = (ce[u] > 0) | (nev > 0)
+            else:
+                raise ValueError(rule)
+            rows.append(~good)
+            tot += int((~good).sum())
+            tried += nk
+        bm[d] = rows
+    return bm, tot, tried
+
+
+def star_readout(W, tmin, real, ov, bm, rule, chunk=1 << 21):
+    """(entries in T* read by their star, entries out of T* read by their
+    star).  A star is admissible when every neighbour is OK; the survivors
+    are compressed after each offset, so only the first pass is wide."""
+    w = len(W)
+    idx = {o: i for i, o in enumerate(W)}
+    order = sorted(
+        W, key=lambda d: (int(bm[d][0].sum()) + int(bm[d][1].sum()))
+        / (2 * len(bm[d][0])), reverse=True)
+    ok_in = ok_out = 0
+    for a in range(0, 1 << w, chunk):
+        for v in (0, 1):
+            P = np.arange(a, min(a + chunk, 1 << w), dtype=np.int64)
+            for d in order:
+                if not (bm[d][0].any() or bm[d][1].any()):
+                    continue
+                u = (P >> idx[d]) & 1
+                key = np.zeros(len(P), dtype=np.int64)
+                for b, (i, j) in enumerate(ov[d]):
+                    bit = (np.full(len(P), v, dtype=np.int64) if j == -1
+                           else ((P >> j) & 1))
+                    key |= bit << b
+                P = P[~np.where(u == 1, bm[d][1][key], bm[d][0][key])]
+                if len(P) == 0:
+                    break
+            if len(P) == 0:
+                continue
+            in_t = tmin[v][P]
+            if rule == "c0":
+                in_t = in_t | ((~real[P]) & (v == 0))
+            elif rule == "c1":
+                in_t = in_t | ((~real[P]) & (v == 1))
+            elif rule != "min":
+                raise ValueError(rule)
+            ok_in += int(in_t.sum())
+            ok_out += int((~in_t).sum())
+    return ok_in, ok_out
+
+
+def table_entries(W, tmin, real, rule):
+    """Entries of the completed table T*."""
+    w = len(W)
+    n_ex = int(tmin[0].sum() + tmin[1].sum())
+    n_never = (1 << w) - int(real.sum())
+    if rule == "min":
+        return n_ex
+    if rule == "all":
+        return n_ex + 2 * n_never
+    return n_ex + n_never
+
+
+# ---- T3 the pinning windows (source block s3_big_windows.py) ---------------
+def pinned_flip_pairs(W):
+    """Template pairs (tau, tau') agreeing on tau's non-centre pins inside W
+    while pinning the centre to the other value: 0 means every realised
+    profile at a pinned site has a singleton menu."""
+    pins = [template_pins(W, ax, o) for ax, o in TEMPLATES]
+    both = 0
+    for i, pi in enumerate(pins):
+        if (0, 0, 0) not in pi:
+            continue
+        for j, pj in enumerate(pins):
+            if j == i:
+                continue
+            if all(pj[o] == pi[o] for o in pi if o != (0, 0, 0) and o in pj):
+                if pj.get((0, 0, 0), pi[(0, 0, 0)]) != pi[(0, 0, 0)]:
+                    both += 1
+    return both
+
+
+def flexibility_bound(W):
+    """The counting certificate of the star lemma on a window too wide to
+    tabulate: at every offset d, never-realised non-uniform completions of
+    either parity number at least 2^(n_d - 1) - sum_tau 2^(e_tau) - 2."""
+    star = {(0, 0, 0)} | set(W)
+    rows = []
+    for d in W:
+        open_offs = [o2 for o2 in W
+                     if tuple(d[k] + o2[k] for k in range(3)) not in star]
+        n_d = len(open_offs)
+        e_max = 0
+        real_sum = 0
+        for ax, origin in TEMPLATES:
+            e = sum(1 for o2 in open_offs
+                    if pat_bit(tuple(origin[k] + o2[k] for k in range(3)), ax)
+                    is None)
+            e_max = max(e_max, e)
+            real_sum += 1 << e
+        rows.append((d, n_d, e_max, real_sum, (1 << (n_d - 1)) - real_sum - 2))
+    worst = min(rows, key=lambda r: r[4])
+    return worst, min(r[1] for r in rows), max(r[1] for r in rows)
+
+
+def f2_rank(M):
+    M = M.copy() % 2
+    r = 0
+    rows, cols = M.shape
+    for c in range(cols):
+        piv = next((i for i in range(r, rows) if M[i, c]), None)
+        if piv is None:
+            continue
+        M[[r, piv]] = M[[piv, r]]
+        for i in range(rows):
+            if i != r and M[i, c]:
+                M[i] ^= M[r]
+        r += 1
+        if r == rows:
+            break
+    return r
+
+
+def parity_system_rank(box, W):
+    """Rank of (I + A_odd) over F2, and whether the wrapped window reaches
+    every site: where it does, a non-cylinder configuration has every profile
+    never-realised and the parity rule reduces to this linear system."""
+    grid = sites(box)
+    idx = {s: i for i, s in enumerate(grid)}
+    n = len(grid)
+    M = np.zeros((n, n), dtype=np.int64)
+    cover = set()
+    for s in grid:
+        mult = {}
+        for o in W:
+            u = idx[wrap(tuple(s[k] + o[k] for k in range(3)), box)]
+            mult[u] = mult.get(u, 0) + 1
+        cover |= set(mult)
+        M[idx[s], idx[s]] = 1
+        for u, m in mult.items():
+            if m % 2 == 1:
+                M[idx[s], u] ^= 1
+    return f2_rank(M), n, len(cover) == n
+
+
+def z3_entry_census(W):
+    """Complete entries the sea, the single hops and the double complements
+    of the 48 templates exercise on Z^3, with their rotation orbits."""
+    pos = {o: i for i, o in enumerate(W)}
+    bw = {o: 1 << i for i, o in enumerate(W)}
+    sea, hop1, hop2 = set(), set(), set()
+
+    def flip(v, P, o):
+        return (v ^ 1, P) if o == (0, 0, 0) else (v, P ^ bw[o])
+
+    for ax, origin in TEMPLATES:
+        vals = {}
+        for o in [(0, 0, 0)] + list(W):
+            v = pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax)
+            vals[o] = 0 if v is None else v
+        P0 = 0
+        for o in W:
+            if vals[o]:
+                P0 |= bw[o]
+        v0 = vals[(0, 0, 0)]
+        sea.add((v0, P0))
+        edge = [o for o in [(0, 0, 0)] + list(W)
+                if pat_bit(tuple(origin[k] + o[k] for k in range(3)), ax)
+                is None]
+        ones = [flip(v0, P0, o) for o in edge]
+        hop1.update(ones)
+        for a in range(len(edge)):
+            for b in range(a + 1, len(edge)):
+                hop2.add(flip(ones[a][0], ones[a][1], edge[b]))
+    perms = [[pos[act(m, o)] for o in W] for m in ROTATIONS]
+
+    def orbits(S):
+        S = sorted(S)
+        n = len(S)
+        bits = np.zeros((n, len(W)), dtype=np.uint8)
+        vs = np.zeros((n, 1), dtype=np.uint8)
+        for r, (v, P) in enumerate(S):
+            vs[r, 0] = v
+            for i in range(len(W)):
+                bits[r, i] = (P >> i) & 1
+        best = None
+        for pm in perms:
+            q = np.zeros_like(bits)
+            q[:, pm] = bits
+            pk = np.packbits(q, axis=1)
+            if best is None:
+                best = pk.copy()
+                continue
+            lt = np.zeros(n, dtype=bool)
+            eq = np.ones(n, dtype=bool)
+            for c in range(pk.shape[1]):
+                lt |= eq & (pk[:, c] < best[:, c])
+                eq &= pk[:, c] == best[:, c]
+            best[lt] = pk[lt]
+        return len({r.tobytes()
+                    for r in np.concatenate([vs, best], axis=1)})
+
+    a, b, c = sea, hop1 | sea, hop2 | hop1 | sea
+    return ((len(a), len(b), len(c)),
+            (orbits(a), orbits(b), orbits(c)))
+
+
+def partial_pattern_census(W, k):
+    """Partial patterns of the centre and k recorded offsets that are
+    template-consistent: R5's projection reading, which the marginal reading
+    reproduces on the exercised part."""
+    off_idx = {(0, 0, 0): 0}
+    for i, o in enumerate(W):
+        off_idx[o] = i + 1
+    A = np.full((48, len(W) + 1), 3, dtype=np.uint8)
+    for t, (ax, origin) in enumerate(TEMPLATES):
+        for o, v in template_pins(W, ax, origin).items():
+            A[t, off_idx[o]] = 1 << v
+    npos = k + 1
+    n_code = 1 << npos
+    C = np.zeros((npos, 4), dtype=np.uint32)
+    for p in range(npos):
+        for s in range(4):
+            m = 0
+            for code in range(n_code):
+                if (s >> ((code >> p) & 1)) & 1:
+                    m |= 1 << code
+            C[p, s] = m
+    combos = np.array(list(itertools.combinations(range(1, len(W) + 1), k)),
+                      dtype=np.int64)
+    acc = np.zeros(len(combos), dtype=np.uint32)
+    for t in range(48):
+        m = np.full(len(combos), C[0, A[t, 0]], dtype=np.uint32)
+        for j in range(k):
+            m &= C[j + 1, A[t, combos[:, j]]]
+        acc |= m
+    return int(np.unpackbits(acc.view(np.uint8)).sum()), len(combos) * n_code
+
+
+# ---- T4 the physics (source block s4_physics.py) ---------------------------
+NN6 = WINDOWS["NN"]
+
+
+def sector_data(box, which=0):
+    secs = torus_sectors(box)
+    pins, (ax, origin) = secs[which]
+    grid = sites(box)
+    es = [i for i, v in enumerate(pins) if v is None]
+    corners = [i for i, s in enumerate(grid)
+               if pat_sym(tuple(s[k] + origin[k] for k in range(3)), ax)
+               in (C0, C1)]
+    return secs, pins, ax, origin, grid, es, corners
+
+
+def families(box, pins, grid, es, corners):
+    """The declared excitation families of one sector: the sea, every single
+    complement (hop), the double complements in lexicographic order, and one
+    representative of each vertex-parity class in breadth-first order."""
+    base = [(v if v is not None else 0) for v in pins]
+    star = {c: [grid.index(wrap(tuple(grid[c][k] + d[k] for k in range(3)),
+                                box)) for d in NN6] for c in corners}
+    fam = {"sea": [tuple(base)], "hop": [], "double": []}
+    for e in es:
+        c = list(base)
+        c[e] ^= 1
+        fam["hop"].append(tuple(c))
+    for a, b in list(itertools.combinations(es, 2))[
+            :(276 if len(es) == 24 else 200)]:
+        c = list(base)
+        c[a] ^= 1
+        c[b] ^= 1
+        fam["double"].append(tuple(c))
+
+    def parity(cfg):
+        return tuple(sum(cfg[e] for e in star[c] if pins[e] is None) % 2
+                     for c in corners)
+
+    classes = {parity(base): tuple(base)}
+    frontier = [tuple(base)]
+    cap = min(1 << (len(corners) - 1), 128)
+    while frontier and len(classes) < cap:
+        nxt = []
+        for cfg in frontier:
+            for e in es:
+                c2 = list(cfg)
+                c2[e] ^= 1
+                p = parity(c2)
+                if p not in classes:
+                    classes[p] = tuple(c2)
+                    nxt.append(tuple(c2))
+        frontier = nxt
+    fam["parity class"] = [classes[k] for k in sorted(classes)][:cap]
+    return fam
+
+
+def hop_transitions(solver_cls, box, cnf, fam, es):
+    """Every edge-site complement applied to every family member, re-tested
+    under assumptions: the hops of the shifting-record notes."""
+    tested = bad = 0
+    with solver_cls(bootstrap_with=cnf.clauses) as s:
+        for cfgs in fam.values():
+            for cfg in cfgs:
+                for e in es:
+                    c2 = list(cfg)
+                    c2[e] ^= 1
+                    tested += 1
+                    if not s.solve(assumptions=[(i + 1) if b else -(i + 1)
+                                                for i, b in enumerate(c2)]):
+                        bad += 1
+    return tested, bad
+
+
+def extra_structure(box, W, extras):
+    """Weights, distance to the nearest cylinder in pinned-site mismatches,
+    template-consistent sites, and whether any extra is a corner pin-field
+    defect."""
+    secs = torus_sectors(box)
+    grid = sites(box)
+    idx = {s: i for i, s in enumerate(grid)}
+    tpins = [template_pins(W, ax, o) for ax, o in TEMPLATES]
+    wts, dists, cons_counts, pinfield = set(), [], set(), 0
+    for x in extras:
+        wts.add(sum(x))
+        dists.append(min(sum(1 for i, v in enumerate(p)
+                             if v is not None and v != x[i])
+                         for p, _ in secs))
+        cons = 0
+        for s in grid:
+            for tp in tpins:
+                if all(x[idx[wrap(tuple(s[k] + o[k] for k in range(3)),
+                                  box)]] == v for o, v in tp.items()):
+                    cons += 1
+                    break
+        cons_counts.add(cons)
+        for p, (ax_, o_) in secs:
+            if all(x[i] == v for i, v in enumerate(p)
+                   if v is not None
+                   and pat_sym(tuple(grid[i][k] + o_[k] for k in range(3)),
+                               ax_) not in (C0, C1)):
+                pinfield += 1
+                break
+    return sorted(wts), (min(dists), max(dists)), sorted(cons_counts), pinfield
+
+
+def isolated(solver_cls, cnf, n, extras):
+    """Admissible configurations at single-flip distance from an extra."""
+    nadj = 0
+    with solver_cls(bootstrap_with=cnf.clauses) as s:
+        for x in extras:
+            for i in range(n):
+                y = [b ^ (1 if j == i else 0) for j, b in enumerate(x)]
+                if s.solve(assumptions=[(j + 1) if b else -(j + 1)
+                                        for j, b in enumerate(y)]):
+                    nadj += 1
+    return nadj, len(extras) * n
+
+
+def two_copy_unsat(solver_cls, box, W, rule):
+    """Is there an admissible non-cylinder configuration with an admissible
+    configuration at Hamming distance 1?  Two copies of the CNF and a one-hot
+    selector for the flipped site."""
+    cnf1, n = build_cnf(box, W, rule)
+    cnf2, _ = build_cnf(box, W, rule)
+    off = cnf1.n
+    clauses = list(cnf1.clauses)
+    for cl in cnf2.clauses:
+        clauses.append([(l + off) if l > 0 else (l - off) for l in cl])
+    clauses.extend(cylinder_clauses(box))
+    top = cnf1.n + cnf2.n
+    ys = list(range(top + 1, top + 1 + n))
+    clauses.append(ys)
+    for i in range(n):
+        for j in range(i + 1, n):
+            clauses.append([-ys[i], -ys[j]])
+    for s in range(n):
+        x1, x2, y = s + 1, s + 1 + off, ys[s]
+        clauses += [[-y, x1, x2], [-y, -x1, -x2], [y, -x1, x2], [y, x1, -x2]]
+    with solver_cls(bootstrap_with=clauses) as s:
+        return not s.solve()
+
+
+def coarse_graph(box, which=0):
+    """Corners as vertices, edge sites as bonds; a coarse direction of length
+    2 carries doubled bonds."""
+    secs, pins, ax, origin, grid, es, corners = sector_data(box, which)
+    cidx = {c: i for i, c in enumerate(corners)}
+    bonds = []
+    for e in es:
+        s = grid[e]
+        t = tuple(s[k] + origin[k] for k in range(3))
+        a = [k for k in range(3) if t[k] & 1][0]
+        u = wrap(tuple(s[k] - (1 if k == a else 0) for k in range(3)), box)
+        v = wrap(tuple(s[k] + (1 if k == a else 0) for k in range(3)), box)
+        bonds.append((cidx[grid.index(u)], cidx[grid.index(v)], a, u))
+    return corners, bonds, ax, origin
+
+
+def ks_matrix(box, twist, which=0):
+    """The KS sign field on the coarse graph, with a twist on the wrap."""
+    corners, bonds, ax, origin = coarse_graph(box, which)
+    V = len(corners)
+    M = np.zeros((V, V))
+    grid = sites(box)
+    L = [box[k] // 2 for k in range(3)]
+    for i, j, a, u in bonds:
+        cv = [((grid[corners[i]][k] + origin[k]) // 2) % L[k]
+              for k in range(3)]
+        if a == 0:
+            eta = 1
+        elif a == 1:
+            eta = (-1) ** cv[0]
+        else:
+            eta = (-1) ** (cv[0] + cv[1])
+        if twist[a] and cv[a] == L[a] - 1:
+            eta = -eta
+        M[i, j] += eta
+        M[j, i] += eta
+    return M, len(bonds)
+
+
+def sea_energy(box):
+    rows = []
+    for twist in itertools.product((0, 1), repeat=3):
+        M, nb = ks_matrix(box, twist)
+        ev = np.sort(np.linalg.eigvalsh(M))
+        V = len(ev)
+        half = ev[:V // 2].sum()
+        best = min((ev[:N].sum(), N) for N in range(0, V + 1, 2))
+        rows.append((half, twist, best, ev[V // 2] - ev[V // 2 - 1], ev, nb))
+    rows.sort(key=lambda r: (r[0], r[1]))
+    return rows[0]
+
+
+def flux_scan(box):
+    """Every bond-sign class on the coarse graph, gauge fixed to +1 on a
+    spanning tree; the minimum half-filled free-fermion energy."""
+    corners, bonds, ax, origin = coarse_graph(box)
+    V = len(corners)
+    tree, seen, frontier = set(), {0}, [0]
+    adj = {}
+    for b, (i, j, a, u) in enumerate(bonds):
+        adj.setdefault(i, []).append((j, b))
+        adj.setdefault(j, []).append((i, b))
+    while frontier:
+        nxt = []
+        for i in frontier:
+            for j, b in adj[i]:
+                if j not in seen:
+                    seen.add(j)
+                    tree.add(b)
+                    nxt.append(j)
+        frontier = nxt
+    assert len(tree) == V - 1
+    free_b = [b for b in range(len(bonds)) if b not in tree]
+    pos = {b: i for i, b in enumerate(free_b)}
+    nfree = len(free_b)
+    hist = {}
+    best = None
+    chunk = 1 << 17
+    assert chunk * V * V <= CELL_CAP * 8
+    for start in range(0, 1 << nfree, chunk):
+        codes = np.arange(start, min(start + chunk, 1 << nfree))
+        Ms = np.zeros((len(codes), V, V))
+        for b, (i, j, a, u) in enumerate(bonds):
+            sgn = (np.ones(len(codes)) if b in tree
+                   else 1.0 - 2.0 * ((codes >> pos[b]) & 1))
+            Ms[:, i, j] += sgn
+            Ms[:, j, i] += sgn
+        ev = np.sort(np.linalg.eigvalsh(Ms), axis=1)
+        half = ev[:, :V // 2].sum(axis=1)
+        k = int(np.argmin(half))
+        if best is None or half[k] < best:
+            best = float(half[k])
+        for h in np.round(half, 6):
+            hist[float(h)] = hist.get(float(h), 0) + 1
+    return nfree, best, hist[min(hist)], len(hist)
+
+
+def odd_corner_census(box):
+    """The vertex-parity map of one sector over F2: its rank is corners - 1
+    (the product of all B_v is the identity), so the edge assignments split
+    as C(corners, N) 2^(edges - rank) over the even N."""
+    secs, pins, ax, origin, grid, es, corners = sector_data(box)
+    star = {c: [grid.index(wrap(tuple(grid[c][k] + d[k] for k in range(3)),
+                                box)) for d in NN6] for c in corners}
+    M = np.zeros((len(corners), len(es)), dtype=np.int64)
+    for a, c in enumerate(corners):
+        for e in star[c]:
+            M[a, es.index(e)] = 1
+    r = f2_rank(M)
+    counts = {N: math.comb(len(corners), N) * (1 << (len(es) - r))
+              for N in range(0, len(corners) + 1, 2)}
+    return len(es), len(corners), r, counts
+
+
+# ---- the run ---------------------------------------------------------------
+def main() -> int:                                          # noqa: C901
+    t0 = time.time()
+    checks = Checks()
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    axiom = AXIOM_PATH.read_text(encoding="utf-8")
+    probe = PROBE_PATH.read_text(encoding="utf-8")
+    bksf = BKSF_PATH.read_text(encoding="utf-8")
+    note_flat = normalize(note)
+    axiom_flat = normalize(axiom)
+
+    try:
+        from pysat.solvers import Cadical153
+        have_sat = True
+    except Exception:
+        Cadical153 = None
+        have_sat = False
+
+    print("external_scientific_inputs: none bar the declared quoted rows")
+    print("integrity_reads: axioms, deep probe, BKSF census, this note")
+    print("construction: exact enumeration on named tori and over Z^3")
+    print("negative_scope: no nearest-neighbour or radius-1 table both "
+          "readable and pinning")
+    print("AUDIT_INPUT_PATHS:")
+    for path in AUDIT_INPUT_PATHS:
+        print(f"  {path}")
+    print(f"AUDIT_TIMEOUT_SEC: {AUDIT_TIMEOUT_SEC}")
+    print("cache_write: false")
+    print("scientific_dependency: minimal_axioms Lattice, Qubit, "
+          "Admissibility, Record")
+    print("declared_math: cubic rotations, record windows, Burnside counts, "
+          "F2 ranks, spectra")
+    print("quoted_rows: the 8x4x4 5x5x5 totals 17 and 16 (s3A.030, s3B.005), "
+          "re-verified here")
+    print("solver_mode: pysat present; CaDiCaL on 4x2x2, 4x4x4, 8x4x4"
+          if have_sat else
+          "solver_mode: pysat absent; the solver-free 4x2x2 enumeration and "
+          "the Z^3 censuses still run")
+
+    checks.check("audit-input-paths", "declared inputs exist and are unique",
+                 all((ROOT / p).is_file() for p in AUDIT_INPUT_PATHS)
+                 and len(AUDIT_INPUT_PATHS) == len(set(AUDIT_INPUT_PATHS)))
+    checks.check("audit-timeout", "the declared timeout is 300 seconds",
+                 AUDIT_TIMEOUT_SEC == 300)
+
+    # ---------- supplied surface -------------------------------------------
+    checks.check(
+        "axiom-admissibility", "the nearest-neighbor rule is quoted",
+        "There is one fixed nearest-neighbor admissibility rule, covariant "
+        "under lattice translations and proper cubic rotations." in axiom_flat
+        and "one fixed nearest-neighbor admissibility rule" in note_flat)
+    checks.check(
+        "axiom-support", "admissible read as the support",
+        "denotes its support -- on finite menus, exactly the possibilities of "
+        "nonzero probability" in axiom_flat
+        and "denotes its support" in note_flat)
+    checks.check(
+        "axiom-record", "a site with no record cannot be read",
+        "Only records are readable. A readout value is determined by record "
+        "content alone. A site with no record cannot be read." in axiom_flat
+        and "A site with no record cannot be read" in note_flat)
+    checks.check(
+        "parent-deep-probe", "the readable class of the deep probe is live",
+        "number of covariant label-equivariant tables = 3^24" in probe)
+    checks.check(
+        "parent-encoding", "the landed BKSF census is live",
+        "claim_type: bounded_theorem" in bksf
+        and "superlattice marker" in normalize(bksf))
+
+    # ---------- T1 : the censuses ------------------------------------------
+    boxes = ((4, 2, 2), (4, 4, 2), (4, 4, 4), (8, 4, 4))
+    nsec, nfree = [], []
+    for box in boxes:
+        secs = torus_sectors(box)
+        free = {sum(1 for v in pins if v is None) for pins, _ in secs}
+        assert len(free) == 1
+        nsec.append(len(secs))
+        nfree.append(free.pop())
+    checks.check(
+        "T1-sectors", "16 / 32 / 48 / 48 cylinders, 48 x 2^24 on 4x4x4",
+        nsec == [16, 32, 48, 48] and nfree == [6, 12, 24, 48]
+        and nsec[0] * (1 << nfree[0]) == 1024
+        and nsec[2] * (1 << nfree[2]) == 805306368,
+        (nsec, nfree))
+
+    NN = WINDOWS["NN"]
+    AX2 = WINDOWS["NN+AX2"]
+    pairs_nn = realised_role_pairs(NN)
+    profs = {p for _, p in pairs_nn}
+    maps_nn = rot_maps(NN)
+    orbits_nn = {min(tuple(p[m[i]] for i in range(len(NN))) for m in maps_nn)
+                 for p in profs}
+    checks.check("T1-role-table", "T0: 18 pairs, 17 profiles of 5^6, 6 orbits",
+                 (len(pairs_nn), len(profs), len(orbits_nn)) == (18, 17, 6)
+                 and 5 ** 6 == 15625,
+                 (len(pairs_nn), len(profs), len(orbits_nn)))
+    adj = {(r, s) for r, p in pairs_nn for s in p}
+    checks.check("T1-role-adjacency", "8 of 25 role adjacencies realised, 17 never", (len(adj), 25 - len(adj)) == (8, 17), len(adj))
+    pairs_ax2 = realised_role_pairs(AX2)
+    role_rows = []
+    for box in ((4, 2, 2), (4, 4, 2), (4, 4, 4)):
+        a_nn = dfs_role_admissible(box, NN, pairs_nn)
+        a_ax = dfs_role_admissible(box, AX2, pairs_ax2)
+        secs = sector_role_configs(box)
+        role_rows.append((len(a_nn), len(a_ax), len(secs),
+                          set(a_ax) == secs, secs <= set(a_nn)))
+    checks.check(
+        "T1-role-rules", "NN admits 32 / 128 / 2,048; 12 offsets give the sectors",
+        [r[0] for r in role_rows] == [32, 128, 2048]
+        and [r[1] for r in role_rows] == [16, 32, 48]
+        and [r[2] for r in role_rows] == [16, 32, 48]
+        and all(r[3] and r[4] for r in role_rows)
+        and len(pairs_ax2) == 22,
+        role_rows)
+
+    TAB = {}
+    ex_rows, real_rows, both_rows = [], [], []
+    for name in TABULATED:
+        tmin, real = tabulate(WINDOWS[name])
+        TAB[name] = (tmin, real)
+        ex_rows.append(int(tmin[0].sum() + tmin[1].sum()))
+        real_rows.append(int(real.sum()))
+        both_rows.append(int((tmin[0] & tmin[1]).sum()))
+    checks.check(
+        "T1-record-tables", "exercised entries 128 / 1,638 / 391,233 / 101,626",
+        ex_rows == [128, 1638, 391233, 101626]
+        and real_rows == [64, 998, 197633, 98537]
+        and both_rows == [64, 640, 193600, 3089],
+        (ex_rows, real_rows, both_rows))
+    checks.check(
+        "T1-nn-permissive", "at NN the minimal law is already all-permissive",
+        ex_rows[0] == 2 * (1 << 6) and both_rows[0] == 64
+        and bool(TAB["NN"][1].all()))
+
+    disj = {}
+    for name in ("W39", "5x5x5"):
+        W = WINDOWS[name]
+        pins = [template_pins(W, ax, o) for ax, o in TEMPLATES]
+        cons = sum(1 for i in range(48) for j in range(i + 1, 48)
+                   if all(pins[i][o] == pins[j][o] for o in pins[i]
+                          if o in pins[j]))
+        free = sorted({len(W) + 1 - len(p) for p in pins})
+        tot = sum(1 << (len(W) + 1 - len(p)) for p in pins)
+        disj[name] = (cons, free, tot)
+    checks.check(
+        "T1-5x5x5-disjoint", "5x5x5: 0 of 1,128 pairs, 2^57.05 of 2^125 exercised",
+        disj["5x5x5"][0] == 0 and disj["5x5x5"][1] == [36, 44, 51, 54]
+        and disj["5x5x5"][2] == 148935859368886272
+        and abs(math.log2(disj["5x5x5"][2]) - 57.05) < 0.01,
+        disj["5x5x5"])
+    checks.check(
+        "T1-W39-pairs", "W39: 159 of 1,128 template pairs consistent",
+        disj["W39"][0] == 159 and disj["W39"][1] == [0, 7, 24],
+        disj["W39"][:2])
+
+    box422 = (4, 2, 2)
+    cfg422 = all_configs(box422)
+    inside422 = cylinder_mask(cfg422, box422)
+    ladder = []
+    for name in TABULATED:
+        tmin, real = TAB[name]
+        adm = admissible_mask(cfg422, box422, WINDOWS[name], tmin, real, "min")
+        ladder.append((int(adm.sum()), int((adm & ~inside422).sum()),
+                       bool((adm | ~inside422).all())))
+    checks.check(
+        "T1-ladder-422", "4x2x2 extras 64,512 / 13,981 / 186 / 154",
+        [r[1] for r in ladder] == [64512, 13981, 186, 154]
+        and [r[0] for r in ladder] == [65536, 15005, 1210, 1178]
+        and all(r[2] for r in ladder) and int(inside422.sum()) == 1024,
+        ladder)
+
+    orb = [orbit_counts(WINDOWS[n], *TAB[n]) for n in TABULATED]
+    checks.check(
+        "T1-orbits", "never-realised orbits 0 / 157 / 694,711 / 2,798,417",
+        [r[3] for r in orb] == [0, 157, 694711, 2798417]
+        and [r[0] for r in orb] == [10, 240, 703360, 2802752]
+        and all(burnside_all(WINDOWS[n]) == r[0]
+                for n, r in zip(TABULATED, orb)),
+        orb)
+
+    e24, c24, r24, cnt24 = odd_corner_census((4, 4, 4))
+    checks.check(
+        "T1-odd-corner", "4x4x4 odd corners 131,072 / 3,670,016 / 9,175,040",
+        (e24, c24, r24) == (24, 8, 7)
+        and cnt24 == {0: 131072, 2: 3670016, 4: 9175040, 6: 3670016,
+                      8: 131072}
+        and sum(cnt24.values()) == 1 << 24,
+        (e24, c24, r24))
+    # ---------- T2 : the tabulated windows ---------------------------------
+    exp422 = {
+        "NN+AX2": {"min": 13981, "c0": 13981, "c1": 64512, "par": 40349,
+                   "apar": 23056, "corr": 40349, "all": 64512},
+        "L1<=2": {"min": 186, "c0": 833, "c1": 699, "par": 725, "apar": 607,
+                  "corr": 636, "all": 64512},
+        "3x3x3": {"min": 154, "c0": 175, "c1": 883, "par": 187, "apar": 887,
+                  "corr": 210, "all": 20714},
+    }
+    for name in ("NN+AX2", "L1<=2", "3x3x3"):
+        W = WINDOWS[name]
+        tmin, real = TAB[name]
+        got, sets = {}, {}
+        for rule in RULES:
+            adm = admissible_mask(cfg422, box422, W, tmin, real, rule)
+            got[rule] = int((adm & ~inside422).sum())
+            sets[rule] = adm
+        checks.check(
+            f"T2-422-{name}", "the 4x2x2 sets of the seven rules match",
+            got == exp422[name]
+            and all(bool((sets[r] | ~inside422).all()) for r in RULES),
+            got)
+        if have_sat:
+            eq = []
+            for rule in ("min", "c0", "par", "corr"):
+                cnf, n = build_cnf(box422, W, rule)
+                models, capped = enumerate_models(Cadical153, cnf, n,
+                                                  cap=70000)
+                want = {tuple(int(b) for b in cfg422[i])
+                        for i in np.nonzero(sets[rule])[0]}
+                eq.append((not capped) and set(models) == want)
+            checks.check(
+                f"T2-422-cadical-{name}", "CaDiCaL agrees as sets for min, c0, par, corr",
+                all(eq), eq)
+    del sets
+
+    if have_sat:
+        flips = []
+        for name, rule in (("NN+AX2", "min"), ("L1<=2", "min"),
+                           ("L1<=2", "par"), ("L1<=2", "corr"),
+                           ("3x3x3", "min"), ("3x3x3", "par"),
+                           ("3x3x3", "corr")):
+            cnf, n = build_cnf((4, 4, 4), WINDOWS[name], rule)
+            flips.append(pinned_flip_sat(Cadical153, (4, 4, 4), cnf))
+        checks.check(
+            "T2-flip-leak", "4x4x4 pinned flips 1,920 / 0 / 384 / 0 / 768",
+            [h for h, _ in flips] == [1920, 0, 384, 384, 0, 768, 768]
+            and {t for _, t in flips} == {1920},
+            flips)
+
+    exp_tried = {"NN+AX2": 144, "L1<=2": 74496, "3x3x3": 1624064}
+    exp_bad = {"NN+AX2": {"min": 0, "c0": 0, "c1": 0},
+               "L1<=2": {"min": 55848, "c0": 28008, "c1": 27840},
+               "3x3x3": {"min": 1587236, "c0": 797466, "c1": 789770}}
+    exp_read = {
+        "NN+AX2": {"min": (1638, 1638, 6554, 6554),
+                   "c0": (4736, 4736, 3456, 3456),
+                   "c1": (4736, 4736, 3456, 3456)},
+        "L1<=2": {"min": (391233, 391233, 33163199, 4132),
+                  "c0": (16970816, 414296, 16583616, 45170),
+                  "c1": (16970816, 416332, 16583616, 10503)},
+        "3x3x3": {"min": (101626, 101626, 134116102, 7486),
+                  "c0": (67111953, 127281, 67105775, 1024996),
+                  "c1": (67111953, 109097, 67105775, 124785)}}
+    tried_got, bad_got, flex_got, read_got, menus = {}, {}, {}, {}, {}
+    for name in ("NN+AX2", "L1<=2", "3x3x3"):
+        W = WINDOWS[name]
+        tmin, real = TAB[name]
+        ov = overlaps(W)
+        kc = keyed_counts(W, tmin, real, ov)
+        bad_got[name], flex_got[name], read_got[name] = {}, {}, {}
+        menus[name] = {}
+        for rule in RULES:
+            bm, tot, tried = bad_keys(W, kc, rule, real)
+            tried_got[name] = tried
+            menus[name][rule] = (rule != "min") or bool(real.all())
+            if rule in ("par", "apar", "corr", "all"):
+                flex_got[name][rule] = tot
+                continue
+            bad_got[name][rule] = tot
+            n_in = table_entries(W, tmin, real, rule)
+            n_out = 2 * (1 << len(W)) - n_in
+            if tot == 0:
+                read_got[name][rule] = (n_in, n_in, n_out, n_out)
+                continue
+            ok_in, ok_out = star_readout(W, tmin, real, ov, bm, rule)
+            read_got[name][rule] = (n_in, ok_in, n_out, ok_out)
+        del kc
+    checks.check(
+        "T2-flexibility", "par, apar, corr: 0 of 144 / 74,496 / 1,624,064 fail",
+        all(v == 0 for d in flex_got.values() for v in d.values())
+        and [tried_got[n] for n in ("NN+AX2", "L1<=2", "3x3x3")]
+        == [144, 74496, 1624064],
+        (flex_got, tried_got))
+    checks.check(
+        "T2-flex-min", "min fails 55,848 and 1,587,236; c0 28,008 and 797,466",
+        bad_got == exp_bad, bad_got)
+    checks.check(
+        "T2-readout-min", "the designed law is blind on 134,108,616 of 134,217,728",
+        all(read_got[n]["min"] == exp_read[n]["min"]
+            for n in ("NN+AX2", "L1<=2", "3x3x3")),
+        {n: read_got[n]["min"] for n in read_got})
+    checks.check(
+        "T2-readout-const", "constant completions blind on 133,065,451 and 133,983,846",
+        all(read_got[n][r] == exp_read[n][r]
+            for n in ("NN+AX2", "L1<=2", "3x3x3") for r in ("c0", "c1")),
+        {n: read_got[n] for n in ("L1<=2", "3x3x3")})
+    checks.check(
+        "T2-readout-flexible", "par/apar/corr read all 16,970,816 and 67,111,953 entries",
+        [table_entries(WINDOWS[n], *TAB[n], "par")
+         for n in ("NN+AX2", "L1<=2", "3x3x3")]
+        == [4736, 16970816, 67111953]
+        and all(v == 0 for d in flex_got.values() for v in d.values()))
+    checks.check(
+        "T2-menus", "menus nonempty for the six completions, empty for min",
+        all(menus[n][r] for n in menus for r in RULES if r != "min")
+        and not any(menus[n]["min"] for n in ("NN+AX2", "L1<=2", "3x3x3")),
+        menus)
+
+    # ---------- T3 : the pinning windows -----------------------------------
+    W555 = WINDOWS["5x5x5"]
+    checks.check(
+        "T3-pinned-flip-lemma", "0 pairs on W39, 5x5x5 and 7x7x7",
+        [pinned_flip_pairs(WINDOWS[n]) for n in ("W39", "5x5x5", "7x7x7")]
+        == [0, 0, 0])
+    bounds = {n: flexibility_bound(WINDOWS[n])
+              for n in ("W39", "5x5x5", "7x7x7")}
+    w5, lo5, hi5 = bounds["5x5x5"]
+    checks.check(
+        "T3-flexibility-bound", "counting margin 16,625,822 at the worst 5x5x5 offset",
+        w5[0] == (-1, 0, 0) and (w5[1], w5[2], w5[3], w5[4])
+        == (25, 13, 151392, 16625822) and (lo5, hi5) == (25, 98)
+        and bounds["W39"][0][4] == 255065528
+        and bounds["7x7x7"][0][4] > 2.8e14,
+        (w5, lo5, hi5, bounds["W39"][0][4], bounds["7x7x7"][0][4]))
+
+    r4, n4, whole4 = parity_system_rank((4, 4, 4), W555)
+    r8, n8, whole8 = parity_system_rank((8, 4, 4), W555)
+    checks.check(
+        "T3-F2-ranks", "wrapped parity system rank 64 of 64 and 128 of 128",
+        (r4, n4, whole4, r8, n8, whole8) == (64, 64, True, 128, 128, True),
+        (r4, n4, r8, n8))
+
+    if have_sat:
+        ex444, cyl444, flip444 = {}, {}, {}
+        for rule in ("min", "c0", "c1", "par", "apar", "corr"):
+            cnf, n = build_cnf((4, 4, 4), W555, rule)
+            models, capped = enumerate_models(
+                Cadical153, cnf, n, extra=cylinder_clauses((4, 4, 4)))
+            assert not capped
+            ex444[rule] = models
+            cyl444[rule] = cylinders_admissible(Cadical153, (4, 4, 4), cnf)
+            flip444[rule] = pinned_flip_sat(Cadical153, (4, 4, 4), cnf)
+        counts444 = [len(ex444[r]) for r in
+                     ("min", "c0", "c1", "par", "apar", "corr")]
+        zero = tuple([0] * 64)
+        one = tuple([1] * 64)
+        checks.check(
+            "T3-extras-4x4x4", "4x4x4 5x5x5 extras 0 / 1 / 1 / 1 / 1 / 0",
+            counts444 == [0, 1, 1, 1, 1, 0]
+            and all(cyl444.values())
+            and {v for v in flip444.values()} == {(0, 1920)}
+            and ex444["c0"][0] == zero and ex444["par"][0] == zero
+            and ex444["c1"][0] == one and ex444["apar"][0] == one,
+            counts444)
+        checks.check(
+            "T3-complete-records-blind", "par and c0 share their 4x4x4 admissible set",
+            set(ex444["par"]) == set(ex444["c0"])
+            and set(ex444["apar"]) == set(ex444["c1"])
+            and ex444["corr"] == ex444["min"] == [])
+        exW39 = {}
+        for rule in ("par", "c0"):
+            cnf, n = build_cnf((4, 4, 4), WINDOWS["W39"], rule)
+            models, capped = enumerate_models(
+                Cadical153, cnf, n, extra=cylinder_clauses((4, 4, 4)))
+            exW39[rule] = (len(models), capped,
+                           sorted({sum(m) for m in models}))
+        checks.check(
+            "T3-W39-extras", "W39 on 4x4x4: 3,457 extras under par and c0",
+            all(v == (3457, False, [0, 4, 8]) for v in exW39.values()),
+            exW39)
+        ex844 = {}
+        for rule in ("min", "c1"):
+            cnf, n = build_cnf((8, 4, 4), W555, rule)
+            models, capped = enumerate_models(
+                Cadical153, cnf, n, extra=cylinder_clauses((8, 4, 4)))
+            ex844[rule] = (len(models), capped,
+                           cylinders_admissible(Cadical153, (8, 4, 4), cnf),
+                           pinned_flip_sat(Cadical153, (8, 4, 4), cnf))
+        checks.check(
+            "T3-8x4x4-minimal", "8x4x4: min 0 extras, c1 1, 0 of 3,840 pinned flips",
+            ex844["min"][:3] == (0, False, True)
+            and ex844["c1"][:3] == (1, False, True)
+            and {v[3] for v in ex844.values()} == {(0, 3840)},
+            ex844)
+
+    sizes, orbs = z3_entry_census(W555)
+    checks.check(
+        "T3-z3-census", "Z^3 entries 48 / 2,298 / 54,642",
+        sizes == (48, 2298, 54642) and orbs == (9, 114, 2421),
+        (sizes, orbs))
+    part = [partial_pattern_census(W555, k) for k in (1, 2, 3)]
+    checks.check(
+        "T3-partial-patterns", "496, 61,008 and 4,814,888 of 4,961,984 patterns",
+        part == [(496, 496), (61008, 61008), (4814888, 4961984)], part)
+
+    # ---------- T4 : the physics -------------------------------------------
+    if have_sat:
+        hops = {}
+        cnf844 = {}
+        for box in ((4, 4, 4), (8, 4, 4)):
+            secs, pins, ax, origin, grid, es, corners = sector_data(box)
+            fam = families(box, pins, grid, es, corners)
+            for rule in ("par", "corr"):
+                cnf, n = build_cnf(box, W555, rule)
+                if box == (8, 4, 4):
+                    cnf844[rule] = (cnf, n)
+                hops[(box, rule)] = hop_transitions(Cadical153, box, cnf,
+                                                    fam, es)
+        checks.check(
+            "T4-hops", "10,296 and 18,096 hop transitions, 0 leaving",
+            [hops[((4, 4, 4), r)] for r in ("par", "corr")]
+            == [(10296, 0), (10296, 0)]
+            and [hops[((8, 4, 4), r)] for r in ("par", "corr")]
+            == [(18096, 0), (18096, 0)],
+            hops)
+
+        cert = []
+        for word in EXTRA_CERTIFICATE_8X4X4:
+            v = int(word, 16)
+            cert.append(tuple((v >> i) & 1 for i in range(128)))
+        assert len(cert) == len(set(cert)) == 16
+        wts, dist, cons, pinfield = extra_structure((8, 4, 4), W555, cert)
+        cert_par = cert + [tuple([0] * 128)]
+        adm_cert = {}
+        for rule, xs in (("corr", cert), ("par", cert_par)):
+            cnf, n = cnf844[rule]
+            with Cadical153(bootstrap_with=cnf.clauses) as s:
+                adm_cert[rule] = sum(
+                    s.solve(assumptions=[(i + 1) if b else -(i + 1)
+                                         for i, b in enumerate(x)])
+                    for x in xs)
+        checks.check(
+            "T4-extras-8x4x4", "16 extras: weight 24, 32 sites, distance 16, no defect",
+            adm_cert["corr"] == 16 and adm_cert["par"] == 17
+            and wts == [24] and dist == (16, 16) and cons == [32]
+            and pinfield == 0
+            and all(not any(all(x[i] == v for i, v in enumerate(p)
+                                if v is not None)
+                            for p, _ in torus_sectors((8, 4, 4)))
+                    for x in cert),
+            (wts, dist, cons, pinfield, adm_cert))
+        checks.check(
+            "T4-extras-quoted", "completeness 16 and 17 quoted, not re-enumerated",
+            (QUOTED_8X4X4_CORR_EXTRAS, QUOTED_8X4X4_PAR_EXTRAS) == (16, 17)
+            and len(cert) == QUOTED_8X4X4_CORR_EXTRAS
+            and len(cert_par) == QUOTED_8X4X4_PAR_EXTRAS)
+        iso = {}
+        for rule, xs in (("corr", cert), ("par", cert_par)):
+            cnf, n = cnf844[rule]
+            iso[rule] = isolated(Cadical153, cnf, n, xs)
+        cnf, n = build_cnf((4, 4, 4), W555, "par")
+        iso444 = isolated(Cadical153, cnf, n, [tuple([0] * 64)])
+        checks.check(
+            "T4-isolation", "0 admissible neighbours in 2,048 / 2,176 / 64 solves",
+            iso["corr"] == (0, 2048) and iso["par"] == (0, 2176)
+            and iso444 == (0, 64),
+            (iso, iso444))
+        checks.check(
+            "T4-two-copy", "4x4x4 corr two-copy adjacency SAT: UNSAT",
+            two_copy_unsat(Cadical153, (4, 4, 4), W555, "corr"))
+
+    sea4 = sea_energy((4, 4, 4))
+    sea8 = sea_energy((8, 4, 4))
+    checks.check(
+        "T4-sea-4x4x4", "E_sea = -8 sqrt 3, gap 6.928203, twist (0,0,0)",
+        abs(sea4[0] + 8 * math.sqrt(3)) < 1e-9 and sea4[1] == (0, 0, 0)
+        and sea4[2][1] == 4 and abs(sea4[3] - 6.928203) < 1e-6
+        and sea4[5] == 24 and len(sea4[4]) == 8
+        and all(abs(abs(v) - 2 * math.sqrt(3)) < 1e-9 for v in sea4[4]),
+        (sea4[0], sea4[1], sea4[3]))
+    checks.check(
+        "T4-sea-8x4x4", "E_sea = -8 sqrt 10, gap 6.324555, twist (1,0,0)",
+        abs(sea8[0] + 8 * math.sqrt(10)) < 1e-9 and sea8[1] == (1, 0, 0)
+        and sea8[2][1] == 8 and abs(sea8[3] - 6.324555) < 1e-6
+        and sea8[5] == 48 and len(sea8[4]) == 16
+        and all(abs(abs(v) - math.sqrt(10)) < 1e-9 for v in sea8[4]),
+        (sea8[0], sea8[1], sea8[3]))
+    nfree, best, attain, ndist = flux_scan((4, 4, 4))
+    checks.check(
+        "T4-flux-classes", "131,072 classes, KS the unique minimiser, 146 energies",
+        (nfree, attain, ndist) == (17, 1, 146)
+        and abs(best + 8 * math.sqrt(3)) < 1e-6,
+        (nfree, best, attain, ndist))
+    checks.check(
+        "T4-extras-energy", "the extras are exact zero eigenvectors above the sea",
+        abs(0.0 - sea4[0] - 13.856406) < 1e-5
+        and abs(0.0 - sea8[0] - 25.298221) < 1e-5)
+    e48, c48, r48, cnt48 = odd_corner_census((8, 4, 4))
+    checks.check(
+        "T4-odd-corner-8x4x4", "8x4x4 parity-map rank 15, fibre 2^33",
+        (e48, c48, r48) == (48, 16, 15)
+        and cnt48[0] == 1 << 33 and cnt48[8] == math.comb(16, 8) * (1 << 33)
+        and sum(cnt48.values()) == 1 << 48,
+        (e48, c48, r48))
+
+    # ---------- note hygiene ------------------------------------------------
+    lines = len(note.splitlines())
+    checks.check("note-length", "the note stays under 330 lines", lines < 330,
+                 lines)
+    checks.check(
+        "note-registry-id", "the note declares its registry id",
+        "readable_matter_law_on_5x5x5_window_parity_completion_2026_09_04"
+        in note)
+    scan = "\n".join(
+        ln for ln in note.lower().splitlines()
+        if not ln.startswith(("audit_required_before_effective_retained",
+                              "bare_retained_allowed")))
+    banned = ("measurement", "observer", "collapse", "exhausted", "exhaustive",
+              "crystal", "swap", "layers", "closes the route", "only route",
+              "last route", "no-go", "retained")
+    hits = [w for w in banned if w in scan]
+    checks.check("note-vocabulary", "the note avoids the banned vocabulary",
+                 not hits, hits)
+    checks.check(
+        "note-wording", "superlattice role pattern; nothing overclaimed",
+        "superlattice role pattern" in note_flat
+        and "the matter law is derived" not in note_flat
+        and "readable at nearest neighbour" not in note_flat)
+    checks.check(
+        "note-scope", "no law selected; bounded scope stated",
+        "no physical law is selected" in note_flat and "claim_scope:" in note
+        and "promoted" not in note.lower() and "new axiom" not in note.lower())
+    checks.check(
+        "note-interfaces", "the note names its parent pull requests",
+        all(tok in note for tok in
+            ("#7977", "#7939", "#7928", "#7934", "#7889", "#7891", "#7885")))
+    checks.check(
+        "note-numbers", "the note carries its counts",
+        all(tok in note for tok in
+            ("2,798,417", "1,624,064", "134,108,616", "16,625,822", "3,457",
+             "16,970,816", "10,296", "18,096", "54,642", "4,814,888",
+             "2^57.05", "131,072")))
+    checks.check(
+        "note-boundary", "the quoted and undecided rows are named",
+        all(tok in note for tok in ("s3B.005", "8x4x4", "7x7x7"))
+        and "nothing is derived from the axioms" in note_flat
+        and "not computed" in note_flat)
+
+    print("per_element: 2 record values, 48 templates, 124 offsets")
+    print("per_site: every site of every named torus and window")
+    print("per_mode: 8 and 16 coarse modes, free-fermion spectra")
+    print("per_block: 48 cylinder blocks, 16 isolated extras")
+    print("lattice_wide: 4x2x2, 4x4x2, 4x4x4, 8x4x4; Z^3 censuses")
+    print(f"elapsed_sec: {time.time() - t0:.1f}")
+    return checks.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Bounded note + exact runner + cache answering the question PR #7977 left open: is there a matter law of the readable kind, a binary support rule over records with every menu nonempty, that still carries the emergent fermion? **Yes, conditionally, on the `5×5×5` window (radius 2 over records), and on no nearest-neighbour or radius-1 window.** Take the designed law's minimal record table on `5×5×5` (its exercised value-profile pairs, `2^57.05` of `2^125`) and give every never-realised profile the value a covariant parity rule names (a corrected variant fixes the two uniform profiles). Then every menu is nonempty, and every complete entry, present or absent, is read by one partially recorded `5×5×5` block with everything else open: a star lemma, proved in the note, that a flexible completion's fibre under the partial readout is a singleton among all covariant support tables on the window (flexibility complete on `3×3×3`, 0 failing of 1,624,064 triples; a counting bound with margin 16,625,822 on `5×5×5`). Blind entries: none, where the designed law itself over records is blind on 134,108,616 of 134,217,728 entries on `3×3×3` and constant completions are almost as blind, so nonempty menus alone do not buy readability, the flexible completion does. The law carries the fermion: the complete admissible set on `4×4×4` is exactly the 48 cylinders under the corrected rule (the cylinders plus the all-zero configuration under plain parity) and on `8×4×4` the cylinders plus 16 isolated weight-24 configurations (every extra isolated under single flips; a blocking SAT call closes the list at 16); the hops of PR #7889 stay inside the cylinders (10,296 and 18,096 transitions, none leaving), so the record-level hop Hamiltonian is block-diagonal, with `E_sea = −8√3` on `4×4×4` and `−8√10` on `8×4×4`, the pi-flux class the unique minimiser of 131,072 bond-sign classes, the extras at `E = 0` and dynamically disconnected. The price, itemised: the window (radius 2 against Admissibility's "one fixed nearest-neighbor admissibility rule"; at nearest neighbour the only table containing the cylinders is the all-permissive one, and at 12 offsets, `L1 ≤ 2` and `3×3×3` the minimal law already admits non-cylinder configurations); the completion, supplied and invisible to complete records on a torus (parity and constant-0 have identical admissible sets on `4×4×4`), read only through partly recorded regions, which the Record axiom permits; the extras, torus-dependent (a window-independent statement needs all sides at least 5); and the marginal reading of an unrecorded neighbour. Disagreements with the expectation: readability does not force the wider window, pinning does; PR #7977's 39-offset closing window is the wrong window for a readable law (159 locally consistent template pairs, thousands of extras); and the blindness PR #7977 found is not the role alphabet's alone, the record-level law is 99.9 % blind too, and the completion removes it.

- `docs/A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_THE_DESIGNED_LAWS_RECORD_TABLE_COMPLETED_BY_A_COVARIANT_PARITY_RULE_HAS_EVERY_MENU_NONEMPTY_IS_READ_FROM_PARTIAL_BLOCKS_AND_KEEPS_THE_FERMION_BOUNDED_NOTE_2026-09-04.md` (321 lines)
- `scripts/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.py` (`TOTAL: PASS=58 FAIL=0`, 114 s; the solver-free path closes at `PASS=45` without `pysat`; two declared reductions: the flexibility scan by an exact sparse recount, the two `8×4×4` extra totals quoted with all 16 extras re-verified member by member; no seeds; stdout 5,183 characters)
- `logs/runner-cache/readable_matter_law_on_5x5x5_window_parity_completion_check_2026_09_04.txt`

## Theorems

- **T1** the censuses (role classes and windows; the nearest-neighbour and sector sets as set equalities; the `4×2×2` ladder; free sites and the `2^57.05` sum; the never-realised orbit counts by Burnside; the all-permissive nearest-neighbour table).
- **T2** the small windows: the complete admissible sets for seven completion rules with CaDiCaL agreement; the flexibility triples; the blindness of the designed and constant-completed laws; the readout table.
- **T3** the big windows: the pinned-flip lemma; the counting-bound margins; the extras `0 / 1 / 1 / 1 / 1 / 0` on `4×4×4` (the source's summary line had the parity and corrected entries transposed; the note carries the recomputed values) and `0 / ≥ 5,000 / 1 / 17 / ≥ 5,000 / 16` on `8×4×4`; the F2 ranks; the 39-offset window's 3,457 extras; the `Z³` censuses; the invisibility of the completion to complete records.
- **T4** the physics: the admissible sets, the isolation of the extras, the block-diagonal hop Hamiltonian, the sea energies, the flux-class minimum, the odd-corner census.

## Boundary

- The tori and windows named; capped enumerations as bounds; six completion rules, not the space of completions; undecided: the 39-offset window's `8×4×4` adjacency and the `8×4×4` `7×7×7` corrected-rule row. Nothing derived from the axioms; the axiom-level observation is a tension, not a derivation: radius 2 where Admissibility says nearest-neighbour, and never-realised menus readable only through partly unrecorded regions.

## Context

- Parents (open PRs): the matter-law readout note (#7977), the role-pattern note (#7939), the readability notes (#7928, #7934), the shifting-record notes (#7889, #7891), the determinantal statistics (#7885); the encoding notes on main.
- Item 1 of the owner's third-campaign queue (2026-09-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
