### PR TITLE
feat(born): the Born-price wordings priced as formation events; homogeneity payable on the continuum law, collinear menus need scale reading, four-outcome pays free

### DIFF
--- a/docs/THE_BORN_PRICE_WORDINGS_HOMOGENEITY_IS_PAYABLE_ON_THE_CONTINUUM_LAW_AS_IT_STANDS_THE_COLLINEAR_MENUS_NEED_A_SCALE_READING_RULE_THE_FOUR_OUTCOME_MENU_PAYS_WITH_NO_CLAUSE_AND_NONE_REMOVES_THE_FAIR_COIN_BOUNDED_NOTE_2026-09-05.md
+++ b/docs/THE_BORN_PRICE_WORDINGS_HOMOGENEITY_IS_PAYABLE_ON_THE_CONTINUUM_LAW_AS_IT_STANDS_THE_COLLINEAR_MENUS_NEED_A_SCALE_READING_RULE_THE_FOUR_OUTCOME_MENU_PAYS_WITH_NO_CLAUSE_AND_NONE_REMOVES_THE_FAIR_COIN_BOUNDED_NOTE_2026-09-05.md
@@ -1,0 +1,329 @@
+---
+claim_id: born_price_wordings_homogeneity_collinear_menus_four_outcome_fair_coin_2026_09_05
+claim_type: bounded_theorem
+claim_scope: "Exact rational one-site algebra under a Z^3 nearest-neighbour law on the continuum record alphabet {cP(n)} u {cI} of PR #7926, plus one labelled float64 recomputation of PR #7973's string-mode count. SUPPLIED, none of it read out of any axiom: the alphabet; the record-echo law L_CONT of PR #7926 under PR #7973's reading R1 (a cI record carries no Bloch direction); the modifications M1, M2, M3 declared here and the symmetric-mean reading in M2; the lattice-dipole class map, L_FIB and its tilt t = 2/3; a record-value class map and its tilt; PR #7950's definitions of menu, grading, menu-independence and the families, and its direction-measurability clause where used; the named elementary theorem that a bounded additive function on an interval is linear; PR #7973's L_HYB, relaxed vortex, declared flip patterns, M_0 and plane size. (T1) Complete over all 21^6 = 85766121 conditions of a declared 21-letter alphabet (230230 multisets), L_CONT realises exactly {I, binary, coin, balanced ternary}; the collinear ternary, the mixed coin ternary and the four-outcome collinear menu never occur, and L_CONT is scale-blind on every condition. The smallest covariant modifications that read the record scales on the collinear conditions are M1 (one record, collinear ternary at a = c), M2 (an antipodal pair, mixed coin at c = (c1+c2)/2) and M3 (an equal-direction pair, four-outcome menu); L_A = L_CONT + M1 + M2 differs from L_CONT on exactly 17496 + 43740 conditions and L_4 = L_A + M3 on exactly 29160 more. Both keep the echo lemma, the bulk I record on all 18^6 = 34012224 fully recorded conditions, covariance on 684024 checks with 0 mismatches, and PR #7926's abundance; the new menus sweep all grid scales at 1840/1840, 529/529 and 253/253. The lattice dipole's coordinate sum is the recorded-slot count mod 2, so a two-record menu reaches the fibre e_x only with an I-record pad. (T2) Without homogeneity, on the radius grid j/24 and all angle modes k <= 12: L_CONT's family has nullity 13, 3, 1, 2, 1 and alternating 2/1 thereafter, carrying the counting rogue and 11 free coin values; L_A's family has nullity 0 at every mode except k = 1, where the kernel is exactly the homogeneous Born vector h_1(c) = c, and pins u(c) = c without the ternary coin, under PR #7950's direction-measurability clause; L_4's family, per point on a ray with no ansatz, has 23 collinear and 132 four-outcome rows on 24 unknowns of rank 23 and nullity 1 with kernel W(c) = cW(1), so homogeneity is forced, bounded additivity extends it to real scales, and the 52-direction stage of rank 50 with kernel span{x, y} closes the Born form with no clause. (T3) The bulk fibre is rho = I/2 by an exact rank-3 certificate; for every state the +m members of any collinear-type menu total tr(rho P(m)), the binary's odds, so a collinear ternary at a bulk site registers a scale and not a sign; the bulk sign odds are 1/2, 1/2, re-registration costs 2^-N^2 unchanged, and a record-value map of tilt t biases the coin without fixing it since the antipode stays in the support and t < 1. PR #7973's flip-density-1/2 row is recomputed at 0 core modes in labelled float64. (T4) Homogeneity is satisfied by L_FIB, violated by the counting rogue, and insufficient without abundance on L_BIN; its status is a clause on L_CONT's family, a measurability-conditional theorem on L_A's, and an exact theorem on L_4's. No axiom is changed, no status is set, and no axiom-side Born forcing is claimed."
+upstream_dependencies:
+  - minimal_axioms
+  - born_form_from_binary_ternary_scaled_projector_frame_lift_bounded_theorem_note_2026-08-09
+runner: scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py
+---
+
+# The continuum alphabet pays the grading-side wording of the Born price with its own formation events and the menu-side wording only once the support rule reads record scales; the four-outcome collinear menu makes homogeneity a theorem; and no wording removes the bulk fair-coin sign, which the class map alone sets
+
+**Date:** 2026-09-05 | **Type:** bounded_theorem | **Audit:** unset; independent audit remains a separate lane
+**Status authority:** independent audit only; this note authors no audit verdict and changes no axiom, primitive, registry, queue, or policy.
+**Primary runner:** [`scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py`](../scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py)
+**Runner cache:** [`logs/runner-cache/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.txt`](../logs/runner-cache/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.txt)
+**Open sibling branches, none on main:** PR #7919 (menu-independence and abundance as separate items of the price); PR #7926 (the continuum record alphabet, `L_CONT`, `L_FIB` and the lattice-dipole class map); PR #7931 (the fibred menu-independence clause); PR #7950 (the two wordings of the price, Theorems A and B, and the counting rogue); PR #7969 (the matter law's own ticks in one frame); PR #7973 (the winding phase and the fair-coin sign). All six are open pull requests.
+
+## Result Up Front
+
+PR #7950 leaves the price of the Born form in two wordings: **(A)** a fibred menu-independence clause plus abundance enlarged to carry the collinear and mixed coin menus, or
+**(B)** the same clause plus abundance plus a homogeneity clause on the grading. Which one a formation event on the continuum alphabet can realise, and at what cost, is settled
+below.
+
+The answer separates them. **(B) is payable by `L_CONT` exactly as it stands**: over a complete census its supports are `{I}`, binaries, coins and balanced ternaries and nothing
+else, which is the abundance (B) asks for, so the homogeneity clause is the whole remaining cost. **(A) is not payable by any scale-blind rule**, and `L_CONT` is scale-blind on all
+`21^6` of its conditions. The smallest covariant repair reads the record scale exactly where `L_CONT` is degenerate and gives `L_A`; under it (A) is payable up to PR #7950's
+direction-measurability clause. One step further, at arity four, the four-outcome collinear menu makes homogeneity a **theorem** with no clause at all.
+
+What no wording touches is the sign. In the bulk fibre the state is `I/2`, and for every state the outcomes of a collinear-type menu sharing the direction `+m` have total odds
+`tr(rho P(m))`, exactly the binary's odds. A collinear ternary at a bulk site registers a **scale**, not a sign, and the fair coin of PR #7973 survives both wordings.
+
+## Machine Status And Trace
+
+```yaml
+actual_current_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "The census is complete over a declared finite alphabet and the certificates are exact rational eliminations over Q on declared grids, but the family, the law, its modifications, the class map and the tilt are all supplied, the mode certificates carry PR #7950's direction-measurability clause, and one labelled float64 row is a model construction."
+trace_class: upstream_support
+target_claim_id: born_form_scaled_projector_arity_three_threshold
+target_blocker_text: "prove ternary scaled-projector sufficiency or find a rogue"
+source_of_blocker_text: frontier_question
+reachability_to_target: advances
+artifact_role: theorem
+campaign_native_target_reachability: advances
+next_trace_action: "Decide whether any covariant nearest-neighbour rule on this alphabet realises the four-outcome collinear menu without reading two equal-direction record scales, or settle the regularity-free question left open on L_A's family."
+conditional_surface_status: "exact rational algebra conditional on the supplied alphabet, the supplied laws L_CONT, L_A, L_4 and L_HYB, the supplied class maps and tilt, the declared rational grids, and — for the mode certificates only — direction-measurability at each scale"
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+```
+
+## Setting
+
+Work at one site with `H = C^2`. For a unit vector `n` write `P(n) = (I + n dot sigma)/2` and take the scaled domain `S = {cP(n) : 0 < c <= 1} union {cI : 0 < c <= 1}`. A **menu**
+is a finite family of members of `S` summing to `I`; a **grading** is a map `w: S -> [0,1]` depending on the effect and not on the menu it appears in, written `W(c, n) = w(cP(n)) =
+c/2 + K(cn)` and `u(c) = w(cI) = c + utilde(c)`, the Born form being `K(v) = gamma dot v`, `utilde = 0`. A **formation event** is one site, one record, the support a function of
+the six nearest-neighbour records, the record locking one member of the support. Every load-bearing computation is exact over `Q`; no seed is used; the one float64 block is
+labelled in its own output lines.
+
+## The Supplied Surface, Quoted
+
+From `docs/MINIMAL_AXIOMS_2026-06-29.md` on main, the two clauses this note reads and never extends — Admissibility's support clause,
+
+> The distribution is a probability measure on the local possibility domain; "available"/"admissible" denotes its support -- on finite menus, exactly the possibilities of nonzero
+> probability.
+
+and Record's one-possibility clause,
+
+> When present, a record locks exactly one admissible local possibility. A site never carries more than one record; records are permanent.
+
+together with Admissibility's own variation clause, "For each site, the probability distribution over the possibilities is determined by, and varies with, the nearest-neighbor
+conditions." Nothing below is read out of either; both fix only what a menu and a formation event are.
+
+From **PR #7926**, supplied whole: the continuum record alphabet; `L_CONT` — one record echoes as the binary of its own direction, three coplanar positively spanning records as
+their ternary, two records as a coin, anything else `{I}` — the lattice-dipole class map `lambda(n)`, the sum of the recorded slot directions, and `L_FIB` with `rho` at `e_x` equal
+to `(I + (2/3) sigma_x)/2`. From **PR #7973**: reading R1, `L_HYB`, the relaxed `24x24` vortex, the flip patterns and `M_0`. From **PR #7950**: menu, grading and menu-independence,
+the families, the direction-measurability clause, and the two wordings, quoted verbatim,
+
+> The price reads either **fibred clause plus abundance with collinear menus** or **fibred clause plus abundance plus a homogeneity clause**; the frame item is gone in both, and
+> the count of supplied items does not grow in the first.
+
+From **PR #7969**, supplied as context: on the matter law's own ticks every realised effect has scale 1 and the realised menus lie in one frame, so the abundance item is unpaid
+there. M1, M2, M3 and the symmetric mean in M2 are supplied here and landed nowhere.
+
+## T1 — What `L_CONT` Realises, Complete, And The Smallest Covariant Modification
+
+**The census.** Declare 21 letters per slot: blank, `I`, `I/2`, and `cP(d)` for `c` in `{1, 1/2, 1/4}` and six directions `{m_1, m_2, m_3, -m_1, ±e_z}` with `m_1 = (1,0,0)`, `m_2 =
+(-3/5, 4/5, 0)`, `m_3 = (-3/5, -4/5, 0)`. All three laws read the multiset of records, so the census runs over the **230230** multisets weighted by multiplicity and covers all
+`21^6 = 85766121` conditions. By the number `kP` of direction-recorded neighbours:
+
+| `kP` | `L_CONT` support | conditions |
+|---|---|---|
+| 0 | `{I}` | 729 |
+| 1 | binary `{P(m), P(-m)}` | 26244 |
+| 2 | coin `{aI, (1-a)I}`, else `{I}` | 284310 / 109350 |
+| 3 | balanced ternary, else `{I}` | 87480 / 3061800 |
+| 4, 5, 6 | `{I}` | 14171760 / 34012224 / 34012224 |
+
+> **Proposition 1.** `L_CONT` realises exactly `{I, binary, coin, balanced ternary}`. The collinear ternary `{aP(n), (1-a)P(n), P(-n)}`, the mixed coin ternary `{cP(n), cP(-n),
+> (1-c)I}` and the four-outcome collinear menu **never occur**, at any condition.
+
+The structural reason is one line: **`L_CONT` is scale-blind.** On all `85766121` conditions the support is unchanged when every recorded scale is set to `1`. The only scalars it
+reads are inner products of recorded directions — the coin's `a = (1 + m_1 dot m_2)/2` — and a scale-blind rule has no scalar to attach to a single direction, while each absent
+menu needs exactly that.
+
+**The modification.** Read the record scales on the collinear conditions, where `L_CONT` is degenerate.
+
+| branch | condition | support |
+|---|---|---|
+| M1 | one record `cP(m)`, `c < 1` | `{cP(m), (1-c)P(m), P(-m)}`, the collinear ternary at `a = c` |
+| M2 | antipodal `c_1 P(m), c_2 P(-m)` | `{cP(m), cP(-m), (1-c)I}` with `c = (c_1+c_2)/2`, the mixed coin |
+| M3 (`L_4` only) | equal-direction `c_1 P(m), c_2 P(m)`, `c_1 + c_2 <= 1` | `{c_1 P(m), c_2 P(m), (1-c_1-c_2)P(m), P(-m)}` |
+
+`L_A = L_CONT + M1 + M2`; `L_4 = L_A + M3`; every other branch is `L_CONT`'s. `L_A` realises exactly `{I, binary, coin, balanced ternary, collinear ternary, mixed coin}` and `L_4`
+adds the four-outcome menu. `L_A` differs from `L_CONT` on exactly the one-record conditions with `c < 1` (**17496**) and the two-antipodal-record conditions (**43740**); `L_4`
+differs from `L_A` on exactly the two-equal-direction conditions with `c_1 + c_2 <= 1` (**29160**). The new menus occur only where they must: under `L_A` the collinear ternary only
+at `kP = 1` and the mixed coin only at `kP = 2`, and under `L_4` the four-outcome menu only at `kP = 2`.
+
+**What is kept.** The echo lemma — every rank-one direction in every support is a recorded direction or its antipode — holds for all three laws with **0** failures; all `18^6 =
+34012224` fully direction-recorded bulk sites are `I` records under all three; every realised support resolves `I_2` exactly; covariance holds on **684024** checks with **0**
+mismatches for `L_A` and `L_4`. PR #7926's abundance is kept whole: every binary (**160/160**), every non-collinear balanced ternary of three declared planes (**756/756** at unit
+and at `1/3` record scales), the coin branch at **77** distinct exact `a`. The new menus sweep the grid: the collinear ternary **1840/1840** over 23 scales `j/24` and 80
+directions, the mixed coin **529/529** with **45** distinct `c`, the four-outcome menu **253/253**.
+
+**A parity fact about the fibres.** The lattice dipole's coordinate sum equals the number of recorded slots mod 2, so without an `I`-record pad a two-record menu sits in an even
+fibre and a one- or three-record menu in an odd one, and `e_x` is reachable unpadded only by the odd family — binary, collinear ternary, balanced ternary. With one `I` record in a
+third slot, reading R1, every menu type reaches both `e_x` and the invariant fibre `0`; witnesses are `{+x: (1/3)P(m_2), +y: (1/2)P(-m_2), -y: I}` for the mixed coin, the same with
+equal directions for the four-outcome menu, `{+x: (1/3)P(m_2)}` for the collinear ternary. In that collinear ternary two of the three outcomes share the direction and differ only
+in scale, `1/4` and `3/4`: the record registers the sign of the axis and, on the echoed sign, a scale. Under `L_CONT` that scale is readable by Record and conditions no support
+anywhere; under `L_A` it conditions the support on 61236 conditions.
+
+## T2 — The Rank Certificates, With No Homogeneity Assumed Anywhere
+
+Write `F_CONT`, `F_A` and `F_4` for the families the three laws realise, and `M_all` for PR #7950's arity-three family with the ternary coin, which no law here realises. The
+unknowns are the values of a menu-independent grading; homogeneity is assumed in no row of any system below.
+
+**Part 1, angle modes on the radius grid `j/24`, every mode `0 <= k <= 12`.** PR #7950's instrument, extended to all modes and to the four families, on the **48** perimeter-2 grid
+triangles (its 44 with `s_1 < s_2` plus the 4 isosceles ones its `combinations` omitted). Triangle rows alone reproduce PR #7950's control nullities `3, 3, 2, 2, 2` at `k = 0, 1,
+3, 5, 7`.
+
+| family | k = 0 | k = 1 | k = 2 | k = 3 | k = 4 | ... | k = 12 |
+|---|---|---|---|---|---|---|---|
+| `F_CONT` | 13 | 3 | 1 | 2 | 1 | alternating 2/1 | 1 |
+| `F_A` | 0 | **1** | 0 | 0 | 0 | 0 | 0 |
+| `F_4` | 0 | **1** | 0 | 0 | 0 | 0 | 0 |
+| `M_all` | 0 | **1** | 0 | 0 | 0 | 0 | 0 |
+
+`F_CONT`'s nullity 13 at `k = 0` carries the counting rogue `h_0(c) = c - 2/3` on the interior with `h_0(1) = 0`, and **11** of the 13 are free coin values: on the family `L_CONT`
+realises, the coin grading is constrained by nothing beyond `u(a) + u(1-a) = 1`.
+
+> **Proposition 2.** On `F_A` the mode-`k` system has nullity **0** at every mode `k <= 12` except `k = 1`, where the kernel is exactly `h_1(c) = c`, the Born vector, homogeneous
+> in the scale. The counting rogue is not in the `k = 0` kernel, and the radius `1/24` that PR #7950 reported uncovered is covered by the collinear row `h(1/24) + h(23/24) - h(1)`.
+> `F_4` and `M_all` agree with `F_A` mode by mode, so the ternary coin adds nothing that the collinear and mixed coin menus have not already added.
+
+Under PR #7950's clause — the angle-Fourier coefficients of `K(c n(phi))` exist at each scale, direction-measurability — `F_A` forces `W(c, n) = c(1/2 + gamma dot n)` almost
+everywhere in direction at each scale and `u(c) = c`: Theorem B of PR #7950 on a family a law realises, **minus the ternary coin**. With `h_0(1) = 0` from the binary and `h_0(a) =
+-h_0(1-a)` from the collinear ternary, the triangle rows with one side `1/2` make `phi(x) = h_0(x + 1/2)` additive with `phi(1/2) = 0`, hence zero. A regularity-free proof on `F_A`
+is not obtained, as it was not in PR #7950.
+
+**Part 2, `F_4` with no ansatz at all.** Per-point unknowns `W(c)` on one ray: **23** collinear rows and **132** four-outcome rows on 24 unknowns have rank **23**, nullity **1**,
+kernel exactly `W(c) = c W(1)` — **homogeneity is forced on the grid**. The collinear rows alone, `F_A`'s whole ray content, leave nullity **12**, which is why `F_A` needs the mode
+argument and its clause. For real scales the four-outcome menu, the collinear ternary and the binary give `W(an) + W(bn) = W((a+b)n)` for `a, b > 0` with `a + b <= 1`, and `W` has
+range `[0,1]`; a bounded function additive on an interval is linear — a named elementary theorem, not recomputed — so `W(cn) = c W(n)` exactly, and the mixed coin gives `u(c) = c`
+exactly.
+
+**Part 3, the Theorem A stage.** PR #7950's untruncated circle certificate, recomputed: **52** grid directions, **5200** non-collinear balanced ternaries, per-direction unknowns,
+rank **50**, nullity **2**, kernel exactly `span{x, y}`. With homogeneity from Part 2, the balanced ternaries alone give `f(n) = 1/2 + beta dot n` on the circle and PR #7950's
+Lemma 2 glues the circles.
+
+> **Proposition 3.** On `F_4` the Born form follows with no homogeneity assumption, no frame theorem and no regularity clause. On `F_A` it follows up to direction-measurability at
+> each scale. On `F_CONT` it does not follow: the counting rogue survives.
+
+The fibred version is unchanged: the fibre `e_x` contains all of `F_A` and `F_4` with `I`-padding, so each per-fibre grading meets the same certificates, and covariance restricts
+`rho_{e_x} = (I + t sigma_x)/2` with `t` free. The tilt stays supplied.
+
+## T3 — The Fair Coin Is Untouched By Either Wording
+
+The class map reads slots, so every fully recorded condition has `lambda = (0,0,0)`; the stacked `R - 1` over the 24 proper cubic rotations has rank **3**, the invariant Bloch
+space is `{0}`, and the bulk fibre carries `rho = I/2` under every support rule. In that fibre:
+
+| condition | menu | odds |
+|---|---|---|
+| `{cP(m), five I}` under `L_A` | collinear ternary | `(c/2, (1-c)/2, 1/2)`; `+m` total `1/2`, `P(-m)` `1/2` |
+| `{(1/4)P(m), (3/4)P(-m), four I}` under `L_A` | mixed coin | `(1/4, 1/4, 1/2)` |
+| `{(1/4)P(m), (1/2)P(m), four I}` under `L_4` | four-outcome | `(1/8, 1/4, 1/8, 1/2)`; `+m` total `1/2` |
+| six direction records | `{I}` | no direction, hence no sign, registered at all |
+
+> **Sign lemma.** For every state `rho` and every menu of the new family, the total odds of the `+m` members equal `tr(rho P(m))`, the binary's odds — the `+m` members sum to
+> `P(m)` as effects. Checked on 5 states across 7 scales for the collinear, four-outcome and mixed menus.
+
+So the sign odds are a property of the fibre's state alone and no menu of `L_A` or `L_4` changes them: `1/2, 1/2` in the bulk, PR #7973's `23/30, 7/30` on the tilted circle
+unchanged. **A collinear ternary at a bulk site registers a scale, not a sign.** One class tick therefore re-registers an `N x N` winding field unflipped with odds `2^-N^2 =
+10^-173.4, 10^-308.3, 10^-693.6` at `N = 24, 32, 48`, identical to PR #7973. A record-value class map with a supplied tilt `t` gives the field's own sign odds `(1+t)/2` and the
+antipode `(1-t)/2`; the antipode is in the support, so by Admissibility's support clause `t < 1` strictly and the flip density `(1-t)/2` is positive for every admissible tilt — the
+sign is a biased coin, never definite, and at `t = 2/3` the unflipped path costs `(5/6)^N^2 = 10^-45.6, 10^-81.1, 10^-182.4`. In labelled float64 with PR #7973's own helper code,
+the relaxed `24x24` vortex is an `L_HYB` fixed point at residual `9.9e-15` over 960 unpinned sites, and the declared flip pattern at density `1/2` leaves **0** core modes while no
+flips, density `1/9` and about `1/6` keep 2 each; the input to that count, the per-site flip odds, is exactly `1/2` under `L_A` and `L_4` as under `L_CONT`.
+
+## T4 — Homogeneity As A Clause, In The Axioms' Register
+
+> **The clause.** Within a class, the odds the law assigns to a possibility scale with the possibility: where one admissible possibility is a fraction of another admissible
+> possibility of the class, its odds are that fraction of the other's.
+
+The register is possibility, odds, admissible and class, as in PR #7931's fibred wording. It compares two conditions of one class, so it is not the per-condition sentence PR #7919
+found vacuous under Admissibility. Three facts fix its status.
+
+- `L_CONT` with `L_FIB` **satisfies** it: in the fibre `e_x`, `w(cP(n))/c = w(P(n))` on all **126** `x`-`y`-plane ternaries and their binaries, every ternary summing to 1.
+- The counting rogue **violates** it, `w(P/2)/(1/2) = 2/3` against `w(P) = 1/2`, while staying normalised on all 126: on `L_CONT`'s realised odds the clause is non-vacuous.
+- Homogeneity alone **does not pay abundance**. On `L_BIN`, whose supports are binaries only, `w(cP(u)) = c(1 + u_z^3)/2` is homogeneous, menu-independent, normalised on every
+  binary and not Born (`64/125` against `4/5`); on the matter law of PR #7969 every realised scale is 1, so the clause is vacuous while the supports lie in one frame. Wording (B)
+  needs abundance as its own item, and `L_CONT` pays it with its own events.
+
+> **Status by family.** `F_CONT` — homogeneity is a **clause**. `F_A` — a **theorem under direction-measurability**. `F_4` — a **theorem with no clause**. Wording (B) supplies as a
+> clause exactly what the four-outcome menu supplies as a support.
+
+## Corollary — The Two Wordings, Priced Against Actual Formation Events
+
+**Wording (B), the fibred clause plus abundance plus homogeneity, is payable by `L_CONT` unmodified.** Its formation events — binaries at `kP = 1`, balanced ternaries at `kP = 3` —
+are exactly the abundance (B) asks for, its own events, needing no support rule that is not already there; with the homogeneity clause the Born form follows with no regularity and
+no frame theorem. The price is a supplied clause on the grading that the realised menus do not force: on `F_CONT` the counting rogue is menu-independent, normalised and not Born.
+
+**Wording (A), the fibred clause plus abundance with the collinear menus, is payable only after the scale-reading modification.** No scale-blind rule offers those menus at any
+condition, and `L_CONT` is scale-blind everywhere. `L_A` is the smallest covariant repair: it reads the record scale on the one-record and antipodal-pair conditions and changes
+nothing else, keeping the echo lemma, the bulk `I` record, covariance and PR #7926's abundance. Under `L_A` the Born form follows **up to direction-measurability at each scale**,
+with `u(c) = c` obtained without the ternary coin; PR #7950's regularity-free residue stays open.
+
+**The four-outcome collinear menu pays with no clause at all.** As a formation event it needs `L_4`, which reads two equal-direction record scales and has arity four, outside the
+arity-three surface; in exchange homogeneity becomes a theorem on the grid and, through bounded additivity, for real scales, and the 52-direction stage then gives the Born form
+outright.
+
+**Neither wording removes the fair-coin sign.** It is set by the class map's fibre, which no support rule touches: the bulk fibre is `rho = I/2` by an exact rank-3 certificate, and
+the sign lemma makes every collinear-type menu carry the binary's sign odds for every state. A collinear ternary at a bulk site registers a scale, not a sign, so a menu family
+cannot buy the sign back; a directed record-value class map biases it, and the antipode stays in the support, so the bias is never a certainty.
+
+The honest price of the Born form, in one sentence: **the Born form costs a fibred menu-independence clause with a directed class map and a supplied tilt, plus either a homogeneity
+clause on the grading (payable by `L_CONT`'s own formation events, exactly) or a support rule that reads record scales (payable by `L_A`'s events up to direction-measurability, by
+`L_4`'s events at arity four exactly), and in every version the bulk sign of a registered direction is a coin set by the class map, which no support rule changes.**
+
+## The Six Disagreements With The Expectation, Stated Plainly
+
+1. A collinear ternary at a bulk site does **not** give the bulk a director with a definite sign: it registers a scale, and its sign odds equal the binary's for every state.
+2. Wording (B) needs **no modification** of `L_CONT`: (B)'s formation events are already realised, (A)'s are not, and (A) requires `L_A`.
+3. The mixed coin ternary shares a fibre with the binaries and balanced ternaries only with an `I`-record pad — a parity obstruction absent from PRs #7926 and #7950.
+4. `F_A` pins `u(c) = c` **without** the ternary coin `M_all` used; and on `L_CONT`'s family the coin grading is essentially free, 11 free grid values.
+5. Under `L_A` two antipodal unit records give the binary, not `{I}` as under `L_CONT` — a side effect of the mean reading in M2, flagged and not load-bearing.
+6. PR #7973's string-mode count, 0 modes at flip density `1/2`, is recomputed here rather than only quoted; its input is exact and unchanged by either modification.
+
+## Reading, Not Theorem
+
+There are two ways to say what quantum odds cost, and they sound like the same sentence. One says: let the rule be told that half of an alternative gets half the odds. The other
+says: let the alternatives on offer include the ones where an alternative is split in two along the same direction. The rule this alphabet actually gives you already offers
+everything the first sentence needs and nothing the second needs — it reads which way its neighbours point and never how much of them there is, so it can never put a scale on a
+single direction. Teach it to read that scale on the one kind of neighbourhood where it currently has nothing to say, and the second sentence comes true too; let it read two such
+neighbours and the scaling rule stops being something you say and becomes something that follows. None of this reaches the sign. Which way the direction a site records points is
+settled by the coarse label the site sits under, and in the bulk that label is blind to direction, so the answer is a coin toss. Splitting an alternative finer tells you more about
+how much, and nothing about which way.
+
+## Executable claim block
+
+```text
+alphabet: 21 letters per slot -- blank, I, I/2, cP(d) for c in {1, 1/2, 1/4} and 6 exact rational unit directions; 230230 multisets, complete over 21^6 = 85766121 conditions, not reduced
+L_CONT realised menus: {I, binary, coin, balanced ternary}; collinear ternary, mixed coin ternary, four-outcome menu never occur; scale-blind on 85766121 of 85766121
+L_A = L_CONT + M1 + M2: differs on 17496 + 43740 conditions; L_4 = L_A + M3: differs on 29160 more
+kept: echo lemma 0 failures; bulk I on 18^6 = 34012224; covariance 684024 checks 0 mismatches; binaries 160/160; ternaries 756/756 at unit and 756/756 at 1/3; 77 exact coin values
+new sweeps: collinear 1840/1840; mixed coin 529/529 with 45 distinct c; four-outcome 253/253; dipole parity = recorded-slot count mod 2, e_x unpadded only for odd arity
+mode nullities, grid j/24, 48 triangles, k <= 12: F_CONT 13 3 1 2 1 ...; F_A = F_4 = M_all 0 1 0 0 ... with kernel h_1(c) = c
+ray certificate: 23 collinear + 132 four-outcome rows, 24 unknowns, rank 23, nullity 1, kernel W(c) = cW(1); collinear alone nullity 12
+Theorem A stage: 52 directions, 5200 balanced ternaries, rank 50, nullity 2, kernel span{x, y}; homogeneity satisfied by L_FIB on 126 ternaries, violated by the counting rogue, insufficient alone on L_BIN (64/125 against 4/5)
+fair coin: invariant fibre rank 3, rho = I/2; sign lemma on 5 states x 7 scales; bulk odds 1/2, 1/2; 2^-N^2 = 10^-173.4, 10^-308.3, 10^-693.6; tilt gives (1+t)/2 and (1-t)/2 > 0, so t < 1 strictly, and 10^-45.6, 10^-81.1, 10^-182.4 at t = 2/3
+labelled float64: relaxed 24x24 vortex residual 9.9e-15 over 960 sites; flip density 1/2 leaves 0 core modes, none/1-9/~1-6 keep 2
+arithmetic: exact rational (fractions.Fraction) on every load-bearing check; no seed anywhere; one labelled float64 block; runner_result_required: zero failed checks
+```
+
+## Interfaces
+
+**PR #7919.** Its three-item price is what the Corollary re-prices; its finding that the per-condition sentence is vacuous under Admissibility is why the homogeneity clause here
+compares two conditions of one class. **PR #7926.** `L_CONT`, `L_FIB`, the class map and the abundance construction are taken whole; the census states completely what that law
+offers, and `L_A` and `L_4` keep every property it was built for. **PR #7931.** Its fibred clause is untouched and supplies the register in which the homogeneity clause is written.
+**PR #7950.** Its two wordings are the object priced here, its Theorems A and B are used on families a law realises, its mode tables are extended to every mode `k <= 12` and to the
+new families, and its uncovered radius `1/24` is covered on `F_A`. **PR #7969.** Its one-frame result shows homogeneity vacuous where every scale is 1, so abundance is a separate
+item. **PR #7973.** Its R1, `L_HYB`, flip patterns and fair-coin result are supplied; the sign lemma extends its bulk binary statement to every menu of the new families.
+
+## Proof boundary
+
+Proved, on the declared families and grids: the complete census and Proposition 1; scale blindness; the exact difference sets of `L_A` and `L_4`; the echo lemma, the bulk `I`
+record, the resolution of every support and covariance for both modified laws; abundance kept and the three new grid sweeps; the dipole parity fact and the padded fibre witnesses;
+the mode nullities of the four families and Proposition 2; the ray certificate and Proposition 3's `F_4` reading up to the named additivity theorem; the 52-direction stage; the
+invariant-fibre rank, the bulk odds of each new menu, the sign lemma and the strict tilt bound; and the homogeneity clause on `L_FIB`, its violation by the counting rogue and its
+insufficiency on `L_BIN`.
+
+Boundaries, exactly: one `M_2(C)` site under a `Z^3` nearest-neighbour law; the declared 21-letter alphabet (6 directions x 3 scales, `I`, `I/2`, blank) for the complete census,
+run whole and not reduced to a sub-census; the 80 stereographic directions; three declared planes giving 378 ternaries; the radius grid `j/24`; the 52 Pythagorean circle directions
+giving 5200 ternaries; modes `k <= 12`; `L_A` and `L_4` with the symmetric-mean reading in M2 and reading R1; the lattice-dipole class map and `L_FIB` at `t = 2/3`; the `24x24`
+open plane, `M_0 = 0.7` and PR #7973's declared flip patterns for the one float64 block, labelled as such in its own output lines.
+
+Not covered: any law other than `L_CONT`, `L_A`, `L_4` and `L_HYB`; a regularity-free Born proof on `F_A`; arities above four; polynomial or Fourier content above mode 12 on the
+mode certificates, the per-point ray and 52-direction certificates having no such bound; any class map other than the lattice dipole and the record-value map named; the infinite
+lattice; many-body content. Nothing here is derived from the axioms: the alphabet, the laws, their modifications, the class maps, the tilt, the grading definitions and both clauses
+are supplied, and no axiom-side Born forcing is claimed.
+
+## Honest Auditor Read
+
+Audit this as a bounded theorem about supplied laws and supplied menu families. Established: a complete census of what one declared law offers; that it offers wording (B)'s
+abundance and cannot offer wording (A)'s menus at all; that a named smallest modification offers them while keeping every property the law was built for; exact certificates fixing
+homogeneity's status on each family; and that the bulk sign odds are `1/2` under all of them. Do not audit it as a claim that the Born rule is derived, that homogeneity is proved
+from the axioms, that `L_CONT`, `L_A` or `L_4` is the framework's law, or that the class map or the tilt is established beyond what is supplied.
+
+## Imports And Claim Boundary
+
+| Item | Role | Provenance | Open-bridge status |
+|---|---|---|---|
+| continuum alphabet, `L_CONT`, `L_FIB`, lattice-dipole class map | declared law and map | PR #7926, open, not on main | one law and one map, not a classification |
+| reading R1, `L_HYB`, flip patterns, `M_0`, plane size | declared reading and model construction | PR #7973, open, not on main | model constructions, not landed fields |
+| M1, M2, M3 and the symmetric mean in M2 | declared modifications | stated here; landed nowhere | smallest covariant repair, argued not classified |
+| menu, grading, menu-independence, the families, the two wordings | declared definitions | PR #7950, open, not on main | the object being priced |
+| direction-measurability at each scale; bounded additive on an interval is linear | regularity clause where used; named elementary theorem | PR #7950; classical, quoted | not discharged; used once, not recomputed |
+| homogeneity clause; the tilt `t` of any directed class map | grading clause when assumed; supplied parameter | stated here in PR #7931's register; PRs #7926 and #7973 | not supplied by `L_CONT`'s menus; bounded below 1 here |
+| observations, fits, target probabilities | none | not used | not applicable |
+
+## Review Record
+
+This note prices two wordings of the Born price against actual formation events on a continuum record alphabet and separates them: one is payable by `L_CONT`'s own events
+with a clause, the other only after the support rule is taught to read record scales, and a fourth outcome at arity four turns the clause into a theorem. It also reports, against
+the expectation, that the new menus register scale and never sign, so the fair coin of PR #7973 survives every wording. It does not advance current-surface physical Born closure:
+the alphabet, the laws, the modifications, the class map and the tilt are all supplied.
+
+Independent audit remains required before the repository may assign any effective claim status.

--- a/logs/runner-cache/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.txt
+++ b/logs/runner-cache/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.txt
@@ -1,0 +1,63 @@
+===== runner cache v1 =====
+runner: scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py
+runner_sha256: 80826dbc1ad664819a1a63edb084fe8ba618e250f4ccd3cae6d0332323b6084d
+timeout_sec: 300
+exit_code: 0
+elapsed_sec: 93.55
+status: ok
+----- stdout -----
+PASS C0 [exact] alphabet: 21 letters per slot (blank, I, I/2, cP(d), c in {1,1/2,1/4}, 6 unit directions)
+     counts over 21^6: L_CONT bin 26244 coin 284310 bal3 87480 | L_A +col3 17496 +mix3 38880 (bin 13608) | L_4 +col4 21870
+PASS C1 [exact] complete census: 230230 multisets of 6 letters = 21^6 = 85766121 conditions
+PASS C2 [exact] L_CONT realises exactly {I, binary, coin, balanced3}: col3, mix3, col4 never occur
+PASS C3 [exact] L_CONT is scale-blind: support unchanged with all scales set to 1, 0/85766121 failures
+PASS C4 [exact] L_A realises exactly {I, binary, coin, balanced3, collinear3, mixed3}
+PASS C5 [exact] L_4 realises that family plus collinear4
+PASS C6 [exact] L_A differs from L_CONT exactly on 1-record c<1 (17496) and 2-antipodal (43740)
+PASS C7 [exact] L_4 differs from L_A exactly on 2-equal-direction c1+c2<=1 conditions (29160)
+PASS C8 [exact] echo lemma, all three laws: every support direction is recorded or its antipode, 0 fails
+PASS C9 [exact] all 18^6 = 34012224 fully direction-recorded conditions give {I}, all three laws
+PASS C10 [exact] every realised support of every law resolves I_2 exactly
+PASS C11 [exact] L_A: col3 only at kP=1 (17496), mix3 only at kP=2 (38880); L_4: col4 only at kP=2 (21870)
+PASS C12 [exact] covariance S(g.n) = g.S(n): 684024 checks, 0 mismatches, L_A and L_4
+PASS C13a [exact] 80 declared rational unit directions (PR #7926's table)
+PASS C13b [exact] abundance kept: every binary is the unit-record support, L_A and L_4, 160/160
+PASS C13c [exact] abundance kept: 378 balanced ternaries, 756/756 at unit and 756/756 at 1/3 scales
+PASS C13d [exact] abundance kept: coin branch unchanged and scale-blind, 77 distinct exact a
+PASS C13e [exact] col3 sweeps the grid: 1840/1840 over 23 scales j/24 x 80 directions
+PASS C13f [exact] mix3 at c = (c1+c2)/2: 529/529 grid pairs, 45 distinct c
+PASS C13g [exact] col4 under L_4: 253/253 grid pairs with a+b<1
+PASS C14a [exact] parity: dipole sum = recorded slots mod 2; unpadded e_x reaches only the odd-arity menus
+PASS C14b [exact] with one I-record pad every menu type reaches fibre e_x and the invariant fibre 0
+PASS C14c [exact] witnesses: mix3 and col4 at e_x with an I pad, col3 at e_x unpadded and at fibre 0
+PASS C15 [exact] col3 outcomes 1/4 and 3/4 share the direction: the record registers a scale, not a sign
+PASS R0 [exact] 48 perimeter-2 triangles on the grid j/24 (PR #7950's 44 plus 4 isosceles)
+     mode nullity k=0..12: F_CONT 13 3 1 2 1 2 1 2 1 2 1 2 1 | F_A = F_4 = M_all 0 1 0 0 0 0 0 0 0 0 0 0 0
+PASS R1 [exact] control, triangle rows alone: nullities [3, 3, 2, 2, 2] at k = 0, 1, 3, 5, 7
+PASS R2 [exact] F_CONT k=0 nullity 13 holds the counting rogue c - 2/3; 11 are free coin values
+PASS R3 [exact] F_A: nullity 0 at every mode k <= 12 but k = 1, kernel exactly the Born vector h_1(c) = c
+PASS R4 [exact] F_4: the same, nullity 0 at every mode but the Born vector at k = 1
+PASS R5 [exact] M_all agrees with F_A mode by mode: the ternary coin adds nothing
+PASS R6 [exact] the rogue is outside F_A's k=0 kernel; radius 1/24 is covered by the collinear row
+PASS R9 [exact] F_4 on one ray, no ansatz: 23 + 132 rows, 24 unknowns, rank 23, nullity 1, kernel W(c) = cW(1)
+PASS R10 [exact] the collinear rows alone leave nullity 12: F_A's ray content fixes no scale law
+PASS R12 [exact] 52 directions, 5200 balanced ternaries, rank 50, nullity 2, kernel span{x, y}
+PASS S1 [exact] every fully recorded condition has dipole (0, 0, 0); stacked R - 1 has rank 3, so the bulk fibre is rho = I/2
+PASS S2a [exact] L_A bulk {cP(m), five I}: col3 odds (c/2, (1-c)/2, 1/2); +m total 1/2, -m 1/2
+PASS S2b [exact] L_A bulk {(1/4)P(m), (3/4)P(-m), four I}: mix3 odds ['1/4', '1/4', '1/2']
+PASS S2c [exact] L_4 bulk {(1/4)P(m), (1/2)P(m), four I}: odds ['1/8', '1/4', '1/8', '1/2'], +m total 1/2
+PASS S2d [exact] six direction records give {I}: no direction and no sign is registered
+PASS S3 [exact] sign lemma, 5 states x 7 scales: the +m members of every new menu total tr(rho P(m))
+PASS S4 [exact odds, float log10] bulk sign 1/2, so 2^-N^2 = 10^-173.4, 10^-308.3, 10^-693.6 at N = 24, 32, 48
+PASS S5 [exact] tilt t: sign odds (1+t)/2, antipode (1-t)/2 > 0 at t = 0, 2/3, 9/10, 99/100, so t < 1
+PASS S5a [float log10] at t = 2/3 the unflipped path costs (5/6)^N^2 = 10^-45.6, 10^-81.1, 10^-182.4
+PASS S6a [float64, model] the 24x24 relaxed vortex is an L_HYB fixed point: residual 9.9e-15, 960 sites, min n.vhat +1.0000
+PASS S6b [float64, model] flip density 1/2 (mean +0.000) leaves 0 core modes; none, 1/9, ~1/6 keep 2, 2, 2
+PASS R13 [exact] L_CONT + L_FIB satisfies the clause in fibre e_x on all 126 ternaries and their binaries
+PASS R14 [exact] the counting rogue violates it, 2/3 against 1/2, while normalised on all 126 ternaries
+PASS R15 [exact] L_BIN with c(1 + u_z^3)/2: homogeneous, normalised on every binary, not Born (64/125 against 4/5)
+PASS R17 [exact] status: F_CONT a clause, F_A a theorem under direction-measurability, F_4 a theorem
+TOTAL: PASS=49 FAIL=0
+
+----- stderr -----
+

--- a/scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py
+++ b/scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py
@@ -1,0 +1,1222 @@
+#!/usr/bin/env python3
+"""Checks for the note on which Born-price wording the continuum record alphabet
+realises as a formation event, and what each wording costs.
+
+Class A throughout: every printed check is an algebraic identity, a complete
+enumeration by index arithmetic, or an exact rank and kernel certificate computed
+over `Q` from declared inputs.  Nothing is compared against an external number, no
+seed is used anywhere, and the one labelled float64 block is a model construction
+recomputed with the code of the note it reproduces.
+
+The runner is self-contained.  Each copied block names its source below; the sources
+are the probe scripts `b7_census.py`, `b7_rank.py`, `b7_sign.py` and `h3_helpers.py`
+that this note lands.
+
+  T1, the census (`b7_census.py:41-115` vector helpers, exact solve and the ternary
+      weights; `:118-181` the laws `L_CONT`, `L_A`, `L_4` and the reading R1 of
+      PR #7973; `:184-233` the menu classifier; `:236-252` the declared 21-letter
+      alphabet; `:255-330` the complete multiset census; `:333-372` the covariance
+      sweep; `:375-455` the abundance and the new grid sweeps; `:458-500` the
+      lattice-dipole fibres).  `L_CONT` reproduces PR #7926's record-echo law
+      verbatim in its branch structure.
+  T2, the rank certificates (`b7_rank.py:44-104` the exact elimination over `Q` and
+      the Chebyshev blocks, themselves PR #7950's routines; `:107-232` the angle-mode
+      row builder and the four families; `:296-330` the per-point ray certificate;
+      `:333-378` PR #7950's 52-direction stage recomputed).
+  T3, the fair coin (`b7_sign.py:47-100` the laws again and the Born value;
+      `:103-160` the invariant fibre; `:163-205` the bulk odds of each new menu;
+      `:208-232` the sign lemma; `:235-258` the tilt bound).  The float64 block
+      copies `h3_helpers.py:9-160,196-206,240-283`, which is PR #7973's runner
+      lines 261-537 verbatim (cell algebra, `Plane`, `build_H`, `ingap_modes`, the
+      XY relaxation, `M0`, `WGAP`).
+  T4, homogeneity as a clause (`b7_rank.py:381-430`).
+
+Exact rational arithmetic (`fractions.Fraction`) carries every load-bearing check.
+The single float64 block is labelled in its own output lines.
+"""
+
+import math
+from fractions import Fraction as F
+from itertools import combinations, combinations_with_replacement, product
+from math import factorial
+
+AUDIT_TIMEOUT_SEC = 300
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("PASS " + label)
+    else:
+        FAIL += 1
+        print("FAIL " + label)
+
+
+# ===================================================================== T1, the census
+# --- exact vector helpers (b7_census.py:41-115) -------------------------------
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+def add(a, b):
+    return tuple(x + y for x, y in zip(a, b))
+
+
+def neg(a):
+    return tuple(-x for x in a)
+
+
+def smul(s, a):
+    return tuple(s * x for x in a)
+
+
+def solve_exact(A, b):
+    """Unique exact solution of an overdetermined rational system, else None."""
+    n = len(A[0])
+    m = [list(r) + [bb] for r, bb in zip(A, b)]
+    pivots = []
+    rank = 0
+    for col in range(n):
+        sel = None
+        for i in range(rank, len(m)):
+            if m[i][col] != 0:
+                sel = i
+                break
+        if sel is None:
+            continue
+        m[rank], m[sel] = m[sel], m[rank]
+        piv = m[rank][col]
+        m[rank] = [x / piv for x in m[rank]]
+        for i in range(len(m)):
+            if i != rank and m[i][col] != 0:
+                f = m[i][col]
+                m[i] = [x - f * y for x, y in zip(m[i], m[rank])]
+        pivots.append(col)
+        rank += 1
+    for i in range(rank, len(m)):
+        if m[i][n] != 0:
+            return None
+    if rank < n:
+        return None
+    x = [F(0)] * n
+    for r, pc in enumerate(pivots):
+        x[pc] = m[r][n]
+    return tuple(x)
+
+
+def ternary_weights(n1, n2, n3):
+    A = [[n1[0], n2[0], n3[0]], [n1[1], n2[1], n3[1]], [n1[2], n2[2], n3[2]],
+         [F(1), F(1), F(1)]]
+    c = solve_exact(A, [F(0), F(0), F(0), F(2)])
+    if c is None or any(x <= 0 for x in c):
+        return None
+    return c
+
+
+def circle_dir(t):
+    d = 1 + t * t
+    return ((1 - t * t) / d, 2 * t / d, F(0))
+
+
+def unit_from_stereo(p, q):
+    d = p * p + q * q + 1
+    return (2 * p / d, 2 * q / d, (p * p + q * q - 1) / d)
+
+
+# --- the laws (b7_census.py:118-181) ------------------------------------------
+def dirs_of(cond):
+    """Reading R1 of PR #7973: a `cI` record carries no Bloch direction."""
+    return [rec[2] for rec in cond if rec[0] == "P"]
+
+
+def recs_P(cond):
+    return [(rec[1], rec[2]) for rec in cond if rec[0] == "P"]
+
+
+ONE_I = (("I", F(1)),)
+
+
+def L_CONT(cond):
+    """PR #7926's record-echo law, verbatim in its branch structure."""
+    ms = dirs_of(cond)
+    if len(ms) == 1:
+        m = ms[0]
+        return (("P", F(1), m), ("P", F(1), neg(m)))
+    if len(ms) == 3:
+        c = ternary_weights(*ms)
+        if c is not None:
+            return tuple(("P", c[k], ms[k]) for k in range(3))
+        return ONE_I
+    if len(ms) == 2:
+        a = (1 + dot(ms[0], ms[1])) / 2
+        if 0 < a < 1:
+            return (("I", a), ("I", 1 - a))
+        return ONE_I
+    return ONE_I
+
+
+def L_MOD(cond, m3=False):
+    """`L_CONT` with the record scales read on the collinear conditions.
+
+    M1  one record `cP(m)`:                {cP(m), (1-c)P(m), P(-m)}
+    M2  antipodal `c1P(m), c2P(-m)`:       {cP(m), cP(-m), (1-c)I}, c = (c1+c2)/2
+    M3  (`L_4` only) equal `c1P(m), c2P(m)` with c1 + c2 <= 1:
+                                           {c1P(m), c2P(m), (1-c1-c2)P(m), P(-m)}
+    Every other branch is `L_CONT`'s; the degenerate member is dropped at c = 1."""
+    ps = recs_P(cond)
+    if len(ps) == 1:
+        c, m = ps[0]
+        if c == 1:
+            return (("P", F(1), m), ("P", F(1), neg(m)))
+        return (("P", c, m), ("P", 1 - c, m), ("P", F(1), neg(m)))
+    if len(ps) == 2:
+        (c1, m1), (c2, m2) = ps
+        if m2 == neg(m1):
+            c = (c1 + c2) / 2
+            if c == 1:
+                return (("P", F(1), m1), ("P", F(1), neg(m1)))
+            return (("P", c, m1), ("P", c, neg(m1)), ("I", 1 - c))
+        if m3 and m2 == m1 and c1 + c2 <= 1:
+            if c1 + c2 == 1:
+                return (("P", c1, m1), ("P", c2, m1), ("P", F(1), neg(m1)))
+            return (("P", c1, m1), ("P", c2, m1), ("P", 1 - c1 - c2, m1),
+                    ("P", F(1), neg(m1)))
+    return L_CONT(cond)
+
+
+def L_A(cond):
+    return L_MOD(cond, m3=False)
+
+
+def L_4(cond):
+    return L_MOD(cond, m3=True)
+
+
+LAWS = [("L_CONT", L_CONT), ("L_A", L_A), ("L_4", L_4)]
+
+
+# --- menu classifier (b7_census.py:184-233) -----------------------------------
+def resolves(S):
+    tr = sum(2 * it[1] if it[0] == "I" else it[1] for it in S)
+    v = (F(0), F(0), F(0))
+    for it in S:
+        if it[0] == "P":
+            v = add(v, smul(it[1], it[2]))
+    return tr == 2 and v == (F(0), F(0), F(0)) and all(0 < it[1] <= 1 for it in S)
+
+
+def menu_type(S):
+    if not resolves(S):
+        return "NOT-A-RESOLUTION"
+    Ps = [it for it in S if it[0] == "P"]
+    Is = [it for it in S if it[0] == "I"]
+    if not Ps:
+        if len(Is) == 1:
+            return "I"
+        if len(Is) == 2:
+            return "coin"
+        return "coin-arity-%d" % len(Is)
+    if not Is:
+        ds = [it[2] for it in Ps]
+        if len(Ps) == 2 and ds[1] == neg(ds[0]) and Ps[0][1] == 1 and Ps[1][1] == 1:
+            return "binary"
+        if len(Ps) == 3:
+            same = [i for i in range(3) if sum(1 for j in range(3) if ds[j] == ds[i]) == 2]
+            if len(same) == 2:
+                k = [i for i in range(3) if i not in same][0]
+                if ds[k] == neg(ds[same[0]]) and Ps[k][1] == 1:
+                    return "collinear3"
+            if len({ds[0], ds[1], ds[2]}) == 3 and ternary_weights(*ds) is not None:
+                return "balanced3"
+        if len(Ps) == 4:
+            cnt = {}
+            for d in ds:
+                cnt[d] = cnt.get(d, 0) + 1
+            if sorted(cnt.values()) == [1, 3]:
+                mm = [d for d, c in cnt.items() if c == 3][0]
+                k = [i for i in range(4) if ds[i] == neg(mm)]
+                if k and Ps[k[0]][1] == 1:
+                    return "collinear4"
+        return "rank-one-other-%d" % len(Ps)
+    if len(Ps) == 2 and len(Is) == 1 and Ps[1][2] == neg(Ps[0][2]) \
+            and Ps[0][1] == Ps[1][1] and Is[0][1] == 1 - Ps[0][1]:
+        return "mixed3"
+    return "mixed-other"
+
+
+# --- the declared alphabet (b7_census.py:236-252) -----------------------------
+m1 = circle_dir(F(0))
+m2 = circle_dir(F(2))
+m3d = circle_dir(F(-2))
+ez = (F(0), F(0), F(1))
+D6 = [m1, m2, m3d, neg(m1), ez, neg(ez)]
+SCALES = [F(1), F(1, 2), F(1, 4)]
+LETTERS = [None, ("I", F(1)), ("I", F(1, 2))] + [("P", c, d) for c in SCALES for d in D6]
+NL = len(LETTERS)
+SLOTS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+
+check("C0 [exact] alphabet: %d letters per slot (blank, I, I/2, cP(d), c in {1,1/2,1/4}, "
+      "6 unit directions)" % NL,
+      NL == 21 and all(dot(d, d) == 1 for d in D6))
+
+
+# --- the complete multiset census (b7_census.py:255-330) ----------------------
+def multiplicity(idx):
+    cnt = {}
+    for i in idx:
+        cnt[i] = cnt.get(i, 0) + 1
+    mm = factorial(6)
+    for v in cnt.values():
+        mm //= factorial(v)
+    return mm
+
+
+tab = {name: {} for name, _ in LAWS}
+echo_fail = {name: 0 for name, _ in LAWS}
+bulk_bad = {name: 0 for name, _ in LAWS}
+scale_blind_fail = 0
+diff_A = {}
+diff_4 = {}
+nms = 0
+ncond = 0
+for idx in combinations_with_replacement(range(NL), 6):
+    cond = [LETTERS[i] for i in idx if LETTERS[i] is not None]
+    mult = multiplicity(idx)
+    nms += 1
+    ncond += mult
+    ms = dirs_of(cond)
+    kP = len(ms)
+    S = {}
+    for name, law in LAWS:
+        S[name] = law(cond)
+        t = menu_type(S[name])
+        tab[name][(kP, t)] = tab[name].get((kP, t), 0) + mult
+        if not all(it[2] in ms or neg(it[2]) in ms for it in S[name] if it[0] == "P"):
+            echo_fail[name] += mult
+        if kP == 6 and S[name] != ONE_I:
+            bulk_bad[name] += mult
+    unit = [("P", F(1), r[2]) if r[0] == "P" else r for r in cond]
+    if L_CONT(unit) != S["L_CONT"]:
+        scale_blind_fail += mult
+    if S["L_A"] != S["L_CONT"]:
+        ps = recs_P(cond)
+        if kP == 1:
+            cls = "1 record, c < 1"
+        elif kP == 2 and ps[1][1] == neg(ps[0][1]):
+            cls = "2 antipodal records"
+        else:
+            cls = "OTHER"
+        diff_A[cls] = diff_A.get(cls, 0) + mult
+    if S["L_4"] != S["L_A"]:
+        ps = recs_P(cond)
+        if kP == 2 and ps[1][1] == ps[0][1] and ps[0][0] + ps[1][0] <= 1:
+            cls = "2 equal-direction records, c1 + c2 <= 1"
+        else:
+            cls = "OTHER"
+        diff_4[cls] = diff_4.get(cls, 0) + mult
+
+by_type = {}
+for name, _ in LAWS:
+    d = {}
+    for (kP, t), v in tab[name].items():
+        d[t] = d.get(t, 0) + v
+    by_type[name] = d
+print("     counts over 21^6: L_CONT bin %d coin %d bal3 %d | L_A +col3 %d +mix3 %d (bin %d) | "
+      "L_4 +col4 %d" % (by_type["L_CONT"]["binary"], by_type["L_CONT"]["coin"],
+                        by_type["L_CONT"]["balanced3"], by_type["L_A"]["collinear3"],
+                        by_type["L_A"]["mixed3"], by_type["L_A"]["binary"],
+                        by_type["L_4"]["collinear4"]))
+
+check("C1 [exact] complete census: %d multisets of 6 letters = 21^6 = %d conditions"
+      % (nms, ncond), nms == 230230 and ncond == 21 ** 6)
+types = {name: {t for (_, t) in tab[name]} for name, _ in LAWS}
+check("C2 [exact] L_CONT realises exactly {I, binary, coin, balanced3}: col3, mix3, col4 "
+      "never occur",
+      types["L_CONT"] == {"I", "binary", "coin", "balanced3"})
+check("C3 [exact] L_CONT is scale-blind: support unchanged with all scales set to 1, "
+      "%d/%d failures" % (scale_blind_fail, ncond), scale_blind_fail == 0)
+check("C4 [exact] L_A realises exactly {I, binary, coin, balanced3, collinear3, mixed3}",
+      types["L_A"] == {"I", "binary", "coin", "balanced3", "collinear3", "mixed3"})
+check("C5 [exact] L_4 realises that family plus collinear4",
+      types["L_4"] == {"I", "binary", "coin", "balanced3", "collinear3", "mixed3", "collinear4"})
+check("C6 [exact] L_A differs from L_CONT exactly on 1-record c<1 (%d) and 2-antipodal (%d)"
+      % (diff_A.get("1 record, c < 1", -1), diff_A.get("2 antipodal records", -1)),
+      set(diff_A) == {"1 record, c < 1", "2 antipodal records"}
+      and diff_A["1 record, c < 1"] == 17496 and diff_A["2 antipodal records"] == 43740)
+check("C7 [exact] L_4 differs from L_A exactly on 2-equal-direction c1+c2<=1 conditions (%d)"
+      % diff_4.get("2 equal-direction records, c1 + c2 <= 1", -1),
+      set(diff_4) == {"2 equal-direction records, c1 + c2 <= 1"}
+      and diff_4["2 equal-direction records, c1 + c2 <= 1"] == 29160)
+check("C8 [exact] echo lemma, all three laws: every support direction is recorded or its "
+      "antipode, 0 fails", all(v == 0 for v in echo_fail.values()))
+check("C9 [exact] all 18^6 = %d fully direction-recorded conditions give {I}, all three laws"
+      % tab["L_CONT"].get((6, "I"), 0),
+      all(v == 0 for v in bulk_bad.values()) and tab["L_CONT"].get((6, "I"), 0) == 18 ** 6)
+check("C10 [exact] every realised support of every law resolves I_2 exactly",
+      all(t in {"I", "binary", "coin", "balanced3", "collinear3", "mixed3", "collinear4"}
+          for name, _ in LAWS for t in types[name]))
+kA = {(k, t): v for (k, t), v in tab["L_A"].items() if t in ("collinear3", "mixed3")}
+k4 = {(k, t): v for (k, t), v in tab["L_4"].items() if t == "collinear4"}
+check("C11 [exact] L_A: col3 only at kP=1 (%d), mix3 only at kP=2 (%d); L_4: col4 only at "
+      "kP=2 (%d)" % (kA.get((1, "collinear3"), -1),
+                                            kA.get((2, "mixed3"), -1),
+                                            k4.get((2, "collinear4"), -1)),
+      set(k for k, _ in kA) == {1, 2}
+      and all(t == "collinear3" for (k, t) in kA if k == 1)
+      and all(t == "mixed3" for (k, t) in kA if k == 2)
+      and set(k for k, _ in k4) == {2})
+
+
+# --- covariance (b7_census.py:333-372) ----------------------------------------
+def _rots():
+    out = []
+    for perm in [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]:
+        for signs in product([1, -1], repeat=3):
+            R = [[F(0)] * 3 for _ in range(3)]
+            for i in range(3):
+                R[i][perm[i]] = F(signs[i])
+            det = (R[0][0] * (R[1][1] * R[2][2] - R[1][2] * R[2][1])
+                   - R[0][1] * (R[1][0] * R[2][2] - R[1][2] * R[2][0])
+                   + R[0][2] * (R[1][0] * R[2][1] - R[1][1] * R[2][0]))
+            if det == 1:
+                out.append(R)
+    return out
+
+
+ROTS = _rots()
+
+
+def matvec(R, v):
+    return tuple(sum(R[i][j] * v[j] for j in range(3)) for i in range(3))
+
+
+def rot_rec(R, rec):
+    if rec[0] == "P":
+        return ("P", rec[1], matvec(R, rec[2]))
+    return rec
+
+
+D5 = [m1, neg(m1), m2, m3d, ez]
+COVLET = [("P", c, d) for c in (F(1), F(1, 2)) for d in D5] + [("I", F(1))]
+cov = {}
+for name, law in (("L_A", L_A), ("L_4", L_4)):
+    nchk = 0
+    mism = 0
+    for kk in (1, 2, 3):
+        for slots in combinations(range(6), kk):
+            for recs in product(COVLET, repeat=kk):
+                cond = {SLOTS[s]: r for s, r in zip(slots, recs)}
+                S = law(list(cond.values()))
+                for R in ROTS:
+                    condR = {tuple(int(x) for x in matvec(R, tuple(F(a) for a in sl))):
+                             rot_rec(R, rc) for sl, rc in cond.items()}
+                    nchk += 1
+                    if set(law(list(condR.values()))) != set(rot_rec(R, it) for it in S):
+                        mism += 1
+    cov[name] = (nchk, mism)
+check("C12 [exact] covariance S(g.n) = g.S(n): %d checks, %d mismatches, L_A and L_4"
+      % (cov["L_A"][0], cov["L_A"][1]),
+      cov["L_A"][1] == 0 and cov["L_4"][1] == 0
+      and cov["L_A"][0] == cov["L_4"][0] == 24 * (6 * 11 + 15 * 121 + 20 * 1331))
+
+# --- abundance kept, and the new grid sweeps (b7_census.py:375-455) -----------
+STEREO_P = [F(0), F(1), F(-1), F(1, 2), F(2), F(-1, 3), F(3, 2), F(1, 4), F(-2, 3), F(5, 2)]
+STEREO_Q = [F(0), F(1), F(-1), F(1, 3), F(2), F(-3, 2), F(1, 5), F(4, 3)]
+SAMPLE_DIRS = []
+for p in STEREO_P:
+    for q in STEREO_Q:
+        u = unit_from_stereo(p, q)
+        if u not in SAMPLE_DIRS:
+            SAMPLE_DIRS.append(u)
+check("C13a [exact] %d declared rational unit directions (PR #7926's table)"
+      % len(SAMPLE_DIRS), len(SAMPLE_DIRS) == 80 and all(dot(u, u) == 1 for u in SAMPLE_DIRS))
+
+bin_ok = sum(1 for u in SAMPLE_DIRS for law in (L_A, L_4)
+             if law([("P", F(1), u)]) == (("P", F(1), u), ("P", F(1), neg(u))))
+check("C13b [exact] abundance kept: every binary is the unit-record support, L_A and L_4, "
+      "%d/160" % bin_ok, bin_ok == 160)
+
+TPAR = [F(0), F(1), F(-1), F(1, 2), F(-1, 2), F(2), F(-2), F(1, 3), F(3)]
+
+
+def plane_pts(e, f):
+    pts = []
+    for t in TPAR:
+        d = 1 + t * t
+        co, si = (1 - t * t) / d, 2 * t / d
+        pts.append(add(smul(co, e), smul(si, f)))
+    pts += [neg(p) for p in pts]
+    return pts
+
+
+E1 = (F(1), F(0), F(0))
+E2 = (F(0), F(1), F(0))
+E3 = (F(0), F(0), F(1))
+ternaries = []
+for e, f in ((E1, E2), ((F(3, 5), F(0), F(4, 5)), E2), (E2, E3)):
+    pts = plane_pts(e, f)
+    for i, j, k in combinations(range(len(pts)), 3):
+        n1, n2, n3 = pts[i], pts[j], pts[k]
+        if len({n1, n2, n3}) < 3:
+            continue
+        c = ternary_weights(n1, n2, n3)
+        if c is not None:
+            ternaries.append(((c[0], n1), (c[1], n2), (c[2], n3)))
+ter_ok = 0
+ter_scaled_ok = 0
+for mn in ternaries:
+    cond = [("P", F(1), n) for _, n in mn]
+    cond_scaled = [("P", F(1, 3), n) for _, n in mn]
+    target = set(("P", c, n) for c, n in mn)
+    for law in (L_A, L_4):
+        ter_ok += set(law(cond)) == target
+        ter_scaled_ok += set(law(cond_scaled)) == target
+check("C13c [exact] abundance kept: %d balanced ternaries, %d/%d at unit and %d/%d at 1/3 "
+      "scales" % (len(ternaries), ter_ok, 2 * len(ternaries),
+                                      ter_scaled_ok, 2 * len(ternaries)),
+      len(ternaries) == 378 and ter_ok == 756 and ter_scaled_ok == 756)
+
+coin_vals = set()
+coin_ok = True
+for u in SAMPLE_DIRS[:20]:
+    for v in SAMPLE_DIRS[:20]:
+        a = (1 + dot(u, v)) / 2
+        if 0 < a < 1:
+            coin_vals.add(min(a, 1 - a))
+            for law in (L_A, L_4):
+                coin_ok &= set(law([("P", F(1), u), ("P", F(1, 2), v)])) == {("I", a), ("I", 1 - a)}
+check("C13d [exact] abundance kept: coin branch unchanged and scale-blind, %d distinct "
+      "exact a" % len(coin_vals), coin_ok and len(coin_vals) == 77)
+
+GRID = [F(j, 24) for j in range(1, 24)]
+col_ok = sum(1 for a in GRID for u in SAMPLE_DIRS
+             if L_A([("P", a, u)]) == (("P", a, u), ("P", 1 - a, u), ("P", F(1), neg(u))))
+check("C13e [exact] col3 sweeps the grid: %d/1840 over 23 scales j/24 x 80 directions"
+      % col_ok, col_ok == 1840)
+mix_ok = 0
+mix_vals = set()
+for c1 in GRID:
+    for c2 in GRID:
+        c = (c1 + c2) / 2
+        mix_vals.add(c)
+        u = SAMPLE_DIRS[(24 * int(c1 * 24) + int(c2 * 24)) % 80]
+        if L_A([("P", c1, u), ("P", c2, neg(u))]) == (("P", c, u), ("P", c, neg(u)), ("I", 1 - c)):
+            mix_ok += 1
+check("C13f [exact] mix3 at c = (c1+c2)/2: %d/529 grid pairs, %d distinct c"
+      % (mix_ok, len(mix_vals)), mix_ok == 529 and len(mix_vals) == 45)
+four_ok = 0
+four_n = 0
+for a in GRID:
+    for b in GRID:
+        if a + b < 1:
+            four_n += 1
+            u = SAMPLE_DIRS[(int(a * 24) * 7 + int(b * 24)) % 80]
+            if L_4([("P", a, u), ("P", b, u)]) == (("P", a, u), ("P", b, u),
+                                                   ("P", 1 - a - b, u), ("P", F(1), neg(u))):
+                four_ok += 1
+check("C13g [exact] col4 under L_4: %d/%d grid pairs with a+b<1" % (four_ok, four_n),
+      four_ok == four_n and four_n == 253)
+
+
+# --- the lattice-dipole fibres (b7_census.py:458-500) -------------------------
+def lam(slots):
+    v = (0, 0, 0)
+    for d in slots:
+        v = tuple(a + b for a, b in zip(v, d))
+    return v
+
+
+KP_OF = {"binary": 1, "collinear3": 1, "coin": 2, "mixed3": 2, "collinear4": 2, "balanced3": 3}
+fib_pad = {t: set() for t in KP_OF}
+fib_nopad = {t: set() for t in KP_OF}
+for r in range(7):
+    for sub in combinations(SLOTS, r):
+        d = lam(sub)
+        for t, kp in KP_OF.items():
+            if r == kp:
+                fib_nopad[t].add(d)
+            if r >= kp:
+                fib_pad[t].add(d)
+EX = (1, 0, 0)
+ZERO = (0, 0, 0)
+check("C14a [exact] parity: dipole sum = recorded slots mod 2; unpadded e_x reaches only the "
+      "odd-arity menus",
+      all(sum(d) % 2 == KP_OF[t] % 2 for t in KP_OF for d in fib_nopad[t])
+      and all((EX in fib_nopad[t]) == (KP_OF[t] % 2 == 1) for t in KP_OF))
+check("C14b [exact] with one I-record pad every menu type reaches fibre e_x and the invariant "
+      "fibre 0", all(EX in fib_pad[t] and ZERO in fib_pad[t] for t in KP_OF))
+w_ex = {SLOTS[0]: ("P", F(1, 3), m2), SLOTS[2]: ("P", F(1, 2), neg(m2)), SLOTS[3]: ("I", F(1))}
+w_ex4 = {SLOTS[0]: ("P", F(1, 3), m2), SLOTS[2]: ("P", F(1, 2), m2), SLOTS[3]: ("I", F(1))}
+w_ex1 = {SLOTS[0]: ("P", F(1, 3), m2)}
+w_0 = {SLOTS[0]: ("P", F(1, 3), m2), SLOTS[1]: ("I", F(1)), SLOTS[2]: ("I", F(1)),
+       SLOTS[3]: ("I", F(1)), SLOTS[4]: ("I", F(1)), SLOTS[5]: ("I", F(1))}
+check("C14c [exact] witnesses: mix3 and col4 at e_x with an I pad, col3 at e_x unpadded and "
+      "at fibre 0",
+      lam(w_ex) == EX and menu_type(L_A(list(w_ex.values()))) == "mixed3"
+      and lam(w_ex4) == EX and menu_type(L_4(list(w_ex4.values()))) == "collinear4"
+      and lam(w_ex1) == EX and menu_type(L_A(list(w_ex1.values()))) == "collinear3"
+      and lam(w_0) == ZERO and menu_type(L_A(list(w_0.values()))) == "collinear3")
+S_col = L_A([("P", F(1, 4), m2)])
+sc = [it for it in S_col if it[0] == "P" and it[2] == m2]
+check("C15 [exact] col3 outcomes %s and %s share the direction: the record registers a scale, "
+      "not a sign" % (sc[0][1], sc[1][1]),
+      len(sc) == 2 and sc[0][1] == F(1, 4) and sc[1][1] == F(3, 4))
+
+
+# ============================================================ T2, the rank certificates
+# --- exact elimination over Q and Chebyshev (b7_rank.py:44-104) ---------------
+def rref_nullspace(rows, ncols):
+    """Reduced row echelon form over `Q` with an explicit nullspace basis."""
+    piv_rows = []
+    piv_cols = []
+    for r in rows:
+        r = [F(x) for x in r]
+        for pr, pc in zip(piv_rows, piv_cols):
+            if r[pc] != 0:
+                f = r[pc]
+                r = [a - f * b for a, b in zip(r, pr)]
+        pc = next((j for j in range(ncols) if r[j] != 0), None)
+        if pc is None:
+            continue
+        f = r[pc]
+        r = [a / f for a in r]
+        for i in range(len(piv_rows)):
+            if piv_rows[i][pc] != 0:
+                g = piv_rows[i][pc]
+                piv_rows[i] = [a - g * b for a, b in zip(piv_rows[i], r)]
+        piv_rows.append(r)
+        piv_cols.append(pc)
+        if len(piv_rows) == ncols:
+            break
+    rank = len(piv_rows)
+    free = [j for j in range(ncols) if j not in piv_cols]
+    basis = []
+    for fcol in free:
+        v = [F(0)] * ncols
+        v[fcol] = F(1)
+        for pr, pc in zip(piv_rows, piv_cols):
+            v[pc] = -pr[fcol]
+        basis.append(v)
+    return rank, basis
+
+
+def in_span(vec, basis, n):
+    rk0, _ = rref_nullspace([list(b) for b in basis], n)
+    rk1, _ = rref_nullspace([list(b) for b in basis] + [list(vec)], n)
+    return rk0 == rk1
+
+
+def cheb_T(k, x):
+    a, b = F(1), x
+    if k == 0:
+        return a
+    for _ in range(k - 1):
+        a, b = b, 2 * x * b - a
+    return b
+
+
+def cheb_U(k, x):
+    a, b = F(1), 2 * x
+    if k == 0:
+        return a
+    for _ in range(k - 1):
+        a, b = b, 2 * x * b - a
+    return b
+
+
+# --- the angle-mode rows and the four families (b7_rank.py:107-232) -----------
+NG = 24
+RGRID = [F(j, NG) for j in range(1, NG + 1)]
+IDX = {c: i for i, c in enumerate(RGRID)}
+ONE = IDX[F(1)]
+INTERIOR = [c for c in RGRID if c < 1]
+
+TRI = []
+for s1, s2 in combinations_with_replacement(INTERIOR, 2):
+    s3 = 2 - s1 - s2
+    if s3 in IDX and 0 < s3 < 1 and s3 >= s2:
+        TRI.append((s1, s2, s3))
+check("R0 [exact] %d perimeter-2 triangles on the grid j/24 (PR #7950's 44 plus %d isosceles)"
+      % (len(TRI), len(TRI) - 44), len(TRI) == 48)
+
+
+def mode_rows(k, fam):
+    """Rows of the mode-k system: unknowns h_k(c) on the grid, plus utilde(c) at k = 0."""
+    n = 2 * NG if k == 0 else NG
+    rows = []
+    sgn = F(1) if k % 2 == 0 else F(-1)
+
+    def new():
+        return [F(0)] * n
+
+    for s1, s2, s3 in TRI:
+        if k == 0:
+            r = new()
+            r[IDX[s1]] += 1
+            r[IDX[s2]] += 1
+            r[IDX[s3]] += 1
+            rows.append(r)
+        else:
+            cA3 = (s1 * s1 + s2 * s2 - s3 * s3) / (2 * s1 * s2)
+            cA2 = (s1 * s1 + s3 * s3 - s2 * s2) / (2 * s1 * s3)
+            sA3, sA2 = 2 / (s1 * s2), 2 / (s1 * s3)
+            re = new()
+            im = new()
+            re[IDX[s1]] += 1
+            re[IDX[s2]] += sgn * cheb_T(k, cA3)
+            re[IDX[s3]] += sgn * cheb_T(k, cA2)
+            im[IDX[s2]] += -sA3 * cheb_U(k - 1, cA3)
+            im[IDX[s3]] += sA2 * cheb_U(k - 1, cA2)
+            rows.append(re)
+            rows.append(im)
+    if "binary" in fam and k % 2 == 0:
+        r = new()
+        r[ONE] += 2
+        rows.append(r)
+    if "coin" in fam and k == 0:
+        for a in INTERIOR:
+            if (1 - a) in IDX:
+                r = new()
+                r[NG + IDX[a]] += 1
+                r[NG + IDX[1 - a]] += 1
+                rows.append(r)
+        r = new()
+        r[NG + ONE] += 1
+        rows.append(r)
+    if "collinear" in fam:
+        for a in INTERIOR:
+            if (1 - a) in IDX:
+                r = new()
+                r[IDX[a]] += 1
+                r[IDX[1 - a]] += 1
+                r[ONE] += sgn
+                rows.append(r)
+    if "mixed" in fam and k % 2 == 0:
+        for c in INTERIOR:
+            r = new()
+            r[IDX[c]] += 2
+            if k == 0:
+                r[NG + IDX[1 - c]] += 1
+            rows.append(r)
+    if "four" in fam:
+        for a, b in combinations_with_replacement(INTERIOR, 2):
+            c3 = 1 - a - b
+            if c3 in IDX and 0 < c3 < 1:
+                r = new()
+                r[IDX[a]] += 1
+                r[IDX[b]] += 1
+                r[IDX[c3]] += 1
+                r[ONE] += sgn
+                rows.append(r)
+    if "terncoin" in fam and k == 0:
+        for a, b in combinations_with_replacement(INTERIOR, 2):
+            c3 = 1 - a - b
+            if c3 in IDX and 0 < c3 < 1:
+                r = new()
+                r[NG + IDX[a]] += 1
+                r[NG + IDX[b]] += 1
+                r[NG + IDX[c3]] += 1
+                rows.append(r)
+    return rows, n
+
+
+FAMS = {
+    "F_CONT": {"binary", "coin"},
+    "F_A": {"binary", "coin", "collinear", "mixed"},
+    "F_4": {"binary", "coin", "collinear", "mixed", "four"},
+    "M_all": {"binary", "coin", "collinear", "mixed", "terncoin"},
+}
+BORN1 = [c for c in RGRID]
+ROGUE0 = [(c - F(2, 3)) if c < 1 else F(0) for c in RGRID]
+KMAX = 12
+null = {}
+kern = {}
+for fam in FAMS:
+    for k in range(KMAX + 1):
+        rows, n = mode_rows(k, FAMS[fam])
+        rk, ker = rref_nullspace(rows, n)
+        null[(fam, k)] = len(ker)
+        kern[(fam, k)] = ker
+print("     mode nullity k=0..12: F_CONT %s | F_A = F_4 = M_all %s"
+      % (" ".join(str(null[("F_CONT", k)]) for k in range(KMAX + 1)),
+         " ".join(str(null[("F_A", k)]) for k in range(KMAX + 1))))
+
+ctrl = []
+for k in (0, 1, 3, 5, 7):
+    rows, n = mode_rows(k, set())
+    rows = [r[:NG] for r in rows]
+    rk, ker = rref_nullspace(rows, NG)
+    ctrl.append(len(ker))
+check("R1 [exact] control, triangle rows alone: nullities %s at k = 0, 1, 3, 5, 7" % ctrl, ctrl == [3, 3, 2, 2, 2])
+rog = [F(0)] * (2 * NG)
+for i in range(NG):
+    rog[i] = ROGUE0[i]
+check("R2 [exact] F_CONT k=0 nullity %d holds the counting rogue c - 2/3; 11 are free coin "
+      "values" % null[("F_CONT", 0)],
+      in_span(rog, kern[("F_CONT", 0)], 2 * NG) and null[("F_CONT", 0)] == 13
+      and [null[("F_CONT", k)] for k in range(1, 6)] == [3, 1, 2, 1, 2])
+check("R3 [exact] F_A: nullity 0 at every mode k <= 12 but k = 1, kernel exactly the Born "
+      "vector h_1(c) = c",
+      all(null[("F_A", k)] == 0 for k in range(KMAX + 1) if k != 1)
+      and null[("F_A", 1)] == 1 and in_span(BORN1, kern[("F_A", 1)], NG))
+check("R4 [exact] F_4: the same, nullity 0 at every mode but the Born vector at k = 1",
+      all(null[("F_4", k)] == 0 for k in range(KMAX + 1) if k != 1)
+      and null[("F_4", 1)] == 1 and in_span(BORN1, kern[("F_4", 1)], NG))
+check("R5 [exact] M_all agrees with F_A mode by mode: the ternary coin adds nothing",
+      all(null[("M_all", k)] == null[("F_A", k)] for k in range(KMAX + 1)))
+check("R6 [exact] the rogue is outside F_A's k=0 kernel; radius 1/24 is covered by the "
+      "collinear row",
+      not in_span(rog, kern[("F_A", 0)], 2 * NG) and null[("F_A", 0)] == 0)
+
+# --- the per-point ray certificate (b7_rank.py:296-330) -----------------------
+rows = []
+for a in INTERIOR:
+    if (1 - a) in IDX:
+        r = [F(0)] * NG
+        r[IDX[a]] += 1
+        r[IDX[1 - a]] += 1
+        r[ONE] -= 1
+        rows.append(r)
+ncol = len(rows)
+for a, b in combinations_with_replacement(INTERIOR, 2):
+    c3 = 1 - a - b
+    if c3 in IDX and 0 < c3 < 1:
+        r = [F(0)] * NG
+        r[IDX[a]] += 1
+        r[IDX[b]] += 1
+        r[IDX[c3]] += 1
+        r[ONE] -= 1
+        rows.append(r)
+rk, ker = rref_nullspace(rows, NG)
+hom = len(ker) == 1 and all(ker[0][i] * RGRID[ONE] == ker[0][ONE] * RGRID[i] for i in range(NG))
+check("R9 [exact] F_4 on one ray, no ansatz: %d + %d rows, 24 unknowns, rank %d, nullity %d, "
+      "kernel W(c) = cW(1)"
+      % (ncol, len(rows) - ncol, rk, len(ker)),
+      hom and rk == NG - 1 and ncol == 23 and len(rows) - ncol == 132)
+rk_c, ker_c = rref_nullspace(rows[:ncol], NG)
+check("R10 [exact] the collinear rows alone leave nullity %d: F_A's ray content fixes no "
+      "scale law" % len(ker_c), len(ker_c) == 12)
+
+
+# --- PR #7950's 52-direction stage (b7_rank.py:333-378) -----------------------
+def pyth_pairs(maxmn):
+    pts = set()
+    for mm in range(1, maxmn + 1):
+        for nn in range(0, mm):
+            d = mm * mm + nn * nn
+            c, s = F(mm * mm - nn * nn, d), F(2 * mm * nn, d)
+            for (a, b) in [(c, s), (s, c)]:
+                for sa in (1, -1):
+                    for sb in (1, -1):
+                        pts.add((sa * a, sb * b))
+    return sorted(pts)
+
+
+def cross2(u, v):
+    return u[0] * v[1] - u[1] * v[0]
+
+
+def balanced_weights2(n1, n2, n3):
+    p = [cross2(n2, n3), cross2(n3, n1), cross2(n1, n2)]
+    if all(x > 0 for x in p) or all(x < 0 for x in p):
+        s = sum(p)
+        return [x / s for x in p]
+    return None
+
+
+PTS5 = pyth_pairs(5)
+trips = []
+for n1, n2, n3 in combinations(PTS5, 3):
+    p = balanced_weights2(n1, n2, n3)
+    if p is not None:
+        trips.append(((n1, n2, n3), p))
+pidx = {p: i for i, p in enumerate(PTS5)}
+rows = []
+for ns, p in trips:
+    r = [F(0)] * len(PTS5)
+    for ni, x in zip(ns, p):
+        r[pidx[ni]] += 2 * x
+    rows.append(r)
+rk, ker = rref_nullspace(rows, len(PTS5))
+xs = [n[0] for n in PTS5]
+ys = [n[1] for n in PTS5]
+check("R12 [exact] 52 directions, %d balanced ternaries, rank %d, nullity %d, kernel "
+      "span{x, y}" % (len(trips), rk, len(ker)),
+      len(PTS5) == 52 and len(trips) == 5200 and rk == 50 and len(ker) == 2
+      and in_span(xs, ker, 52) and in_span(ys, ker, 52))
+
+
+# ================================================================== T3, the fair coin
+# --- the invariant fibre (b7_sign.py:103-160) ---------------------------------
+def born(r, it):
+    """tr(rho E) with rho = (I + r.sigma)/2."""
+    if it[0] == "I":
+        return it[1]
+    return it[1] * (1 + dot(r, it[2])) / 2
+
+
+def rank_exact(rws):
+    M = [list(r) for r in rws]
+    rk = 0
+    for c in range(len(M[0])):
+        p = next((i for i in range(rk, len(M)) if M[i][c] != 0), None)
+        if p is None:
+            continue
+        M[rk], M[p] = M[p], M[rk]
+        pv = M[rk][c]
+        M[rk] = [x / pv for x in M[rk]]
+        for i in range(len(M)):
+            if i != rk and M[i][c] != 0:
+                f = M[i][c]
+                M[i] = [x - f * y for x, y in zip(M[i], M[rk])]
+        rk += 1
+    return rk
+
+
+rows = []
+for R in ROTS:
+    for i in range(3):
+        rows.append([R[i][j] - (F(1) if i == j else F(0)) for j in range(3)])
+rk = rank_exact(rows)
+check("S1 [exact] every fully recorded condition has dipole %s; stacked R - 1 has rank %d, so "
+      "the bulk fibre is rho = I/2" % (lam(SLOTS), rk), lam(SLOTS) == (0, 0, 0) and rk == 3 and len(ROTS) == 24)
+
+# --- bulk odds of each new menu (b7_sign.py:163-205) --------------------------
+mB = m2
+R0 = (F(0), F(0), F(0))
+fair = True
+for c in (F(1, 4), F(1, 2), F(3, 4)):
+    S = L_A([("P", c, mB)] + [("I", F(1))] * 5)
+    odds = [born(R0, it) for it in S]
+    plus = sum(o for o, it in zip(odds, S) if it[0] == "P" and it[2] == mB)
+    minus = sum(o for o, it in zip(odds, S) if it[0] == "P" and it[2] == neg(mB))
+    fair &= plus == F(1, 2) and minus == F(1, 2) and odds == [c / 2, (1 - c) / 2, F(1, 2)]
+check("S2a [exact] L_A bulk {cP(m), five I}: col3 odds (c/2, (1-c)/2, 1/2); +m total 1/2, "
+      "-m 1/2", fair)
+S = L_A([("P", F(1, 4), mB), ("P", F(3, 4), neg(mB))] + [("I", F(1))] * 4)
+check("S2b [exact] L_A bulk {(1/4)P(m), (3/4)P(-m), four I}: mix3 odds %s"
+      % [str(born(R0, it)) for it in S],
+      [born(R0, it) for it in S] == [F(1, 4), F(1, 4), F(1, 2)])
+S = L_4([("P", F(1, 4), mB), ("P", F(1, 2), mB)] + [("I", F(1))] * 4)
+odds = [born(R0, it) for it in S]
+check("S2c [exact] L_4 bulk {(1/4)P(m), (1/2)P(m), four I}: odds %s, +m total %s"
+      % ([str(o) for o in odds], sum(odds[:3])),
+      odds == [F(1, 8), F(1, 4), F(1, 8), F(1, 2)] and sum(odds[:3]) == F(1, 2))
+S = L_A([("P", F(1), mB)] * 6)
+check("S2d [exact] six direction records give {I}: no direction and no sign is registered", S == ONE_I and L_4([("P", F(1), mB)] * 6) == ONE_I)
+
+# --- the sign lemma, every state (b7_sign.py:208-232) -------------------------
+GRIDC = [F(j, 8) for j in range(1, 8)]
+STATES = [R0, (F(2, 3), F(0), F(0)), (F(0), F(0), F(2, 3)), (F(1, 3), F(1, 5), F(2, 7)),
+          (F(3, 5), F(0), F(4, 5))]
+ok = True
+for r in STATES:
+    pb = born(r, ("P", F(1), mB))
+    for c in GRIDC:
+        S3 = L_A([("P", c, mB)])
+        plus = sum(born(r, it) for it in S3 if it[0] == "P" and it[2] == mB)
+        ok &= plus == pb and born(r, ("P", F(1), neg(mB))) == 1 - pb
+        for c2 in GRIDC:
+            if c + c2 < 1:
+                S4 = L_4([("P", c, mB), ("P", c2, mB)])
+                ok &= sum(born(r, it) for it in S4 if it[0] == "P" and it[2] == mB) == pb
+        S5 = L_A([("P", c, mB), ("P", c, neg(mB))])
+        ok &= born(r, S5[0]) + born(r, S5[1]) == c and born(r, S5[0]) / c == pb
+check("S3 [exact] sign lemma, 5 states x 7 scales: the +m members of every new menu total "
+      "tr(rho P(m))", ok)
+
+# --- re-registration and the tilt bound (b7_sign.py:235-258) ------------------
+pw = {N: N * N * math.log10(2) for N in (24, 32, 48)}
+check("S4 [exact odds, float log10] bulk sign 1/2, so 2^-N^2 = 10^-%.1f, 10^-%.1f, 10^-%.1f "
+      "at N = 24, 32, 48"
+      % (pw[24], pw[32], pw[48]),
+      abs(pw[24] - 173.4) < 0.1 and abs(pw[32] - 308.3) < 0.1 and abs(pw[48] - 693.6) < 0.1)
+okt = True
+for t in (F(0), F(2, 3), F(9, 10), F(99, 100)):
+    r = (t * mB[0], t * mB[1], t * mB[2])
+    wp = born(r, ("P", F(1), mB))
+    wm = born(r, ("P", F(1), neg(mB)))
+    okt &= wp == (1 + t) / 2 and wm == (1 - t) / 2 and wm > 0
+check("S5 [exact] tilt t: sign odds (1+t)/2, antipode (1-t)/2 > 0 at t = 0, 2/3, 9/10, 99/100, "
+      "so t < 1", okt)
+pt = {N: -N * N * math.log10(F(5) / 6) for N in (24, 32, 48)}
+check("S5a [float log10] at t = 2/3 the unflipped path costs (5/6)^N^2 = 10^-%.1f, 10^-%.1f, "
+      "10^-%.1f" % (pt[24], pt[32], pt[48]),
+      abs(pt[24] - 45.6) < 0.1 and abs(pt[32] - 81.1) < 0.1 and abs(pt[48] - 182.4) < 0.1)
+
+
+# --- the string modes: float64, model construction (h3_helpers.py, itself PR #7973's
+#     runner lines 261-537 verbatim: cell algebra :9-27, Plane :30-116, build_H :119-134,
+#     ingap_modes :137-142, relax_xy_fast :146-166, support_residual :169-181,
+#     M0/WGAP :196-197, analytic_field :209-217, relaxed_field :264-283 open branch) ---
+import numpy as np                                                       # noqa: E402
+import scipy.sparse as sp                                                # noqa: E402
+import scipy.sparse.linalg as spla                                       # noqa: E402
+
+I2 = np.eye(2)
+Xp = np.array([[0, 1], [1, 0]], complex)
+Yp = np.array([[0, -1j], [1j, 0]])
+Zp = np.diag([1.0, -1.0]).astype(complex)
+PAULI = {"I": I2, "X": Xp, "Y": Yp, "Z": Zp}
+
+
+def P3(s):
+    return np.kron(np.kron(PAULI[s[0]], PAULI[s[1]]), PAULI[s[2]])
+
+
+M2S = P3("XYX")
+M0 = 0.7
+WGAP = 0.98 * M0
+
+
+class Plane:
+    """Transverse (x, y) plane of coarse sites with the z cell bit b."""
+
+    def __init__(self, Nx, Ny, periodic=False):
+        assert Nx % 2 == 0 and Ny % 2 == 0
+        self.Nx, self.Ny, self.periodic = Nx, Ny, periodic
+        self.D = 2 * Nx * Ny
+        xs, ys, bs = np.meshgrid(np.arange(Nx), np.arange(Ny), np.arange(2), indexing="ij")
+        self.x = xs.ravel()
+        self.y = ys.ravel()
+        self.b = bs.ravel()
+        self.cells = [(X, Y) for X in range(Nx // 2) for Y in range(Ny // 2)]
+
+    def idx(self, x, y, b):
+        return (x * self.Ny + y) * 2 + b
+
+    def cell_sites(self, X, Y):
+        return [self.idx(2 * X + b1, 2 * Y + b2, b3)
+                for b1 in range(2) for b2 in range(2) for b3 in range(2)]
+
+    def hop_matrices(self):
+        Nx, Ny, idx = self.Nx, self.Ny, self.idx
+        rows, cols, vals = [], [], []
+        zr, zc, zv = [], [], []
+        for x in range(Nx):
+            for y in range(Ny):
+                for b in range(2):
+                    i = idx(x, y, b)
+                    if x + 1 < Nx or self.periodic:
+                        j = idx((x + 1) % Nx, y, b)
+                        rows += [j, i]
+                        cols += [i, j]
+                        vals += [1.0, 1.0]
+                    if y + 1 < Ny or self.periodic:
+                        amp = (-1.0) ** x
+                        j = idx(x, (y + 1) % Ny, b)
+                        rows += [j, i]
+                        cols += [i, j]
+                        vals += [amp, amp]
+                eta3 = (-1.0) ** (x + y)
+                i0, i1 = idx(x, y, 0), idx(x, y, 1)
+                rows += [i1, i0]
+                cols += [i0, i1]
+                vals += [eta3, eta3]
+                zr += [i0]
+                zc += [i1]
+                zv += [eta3]
+        H0 = sp.csr_matrix((vals, (rows, cols)), shape=(self.D, self.D), dtype=complex)
+        Zi = sp.csr_matrix((zv, (zr, zc)), shape=(self.D, self.D), dtype=complex)
+        return H0, Zi
+
+    def m2_hop_operator(self, m2_site):
+        """The body-diagonal hop M2, each amplitude the mean of the two endpoint records."""
+        rows, cols, vals = [], [], []
+        nz = np.argwhere(np.abs(M2S) > 0)
+        for (X, Y) in self.cells:
+            s = self.cell_sites(X, Y)
+            for i, j in nz:
+                rows.append(s[i])
+                cols.append(s[j])
+                vals.append(0.5 * (m2_site[s[i]] + m2_site[s[j]]) * M2S[i, j])
+        return sp.csr_matrix((vals, (rows, cols)), shape=(self.D, self.D), dtype=complex)
+
+    def neighbours_inplane(self, i):
+        x, y, b = self.x[i], self.y[i], self.b[i]
+        out = []
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            xx, yy = x + dx, y + dy
+            if self.periodic:
+                xx %= self.Nx
+                yy %= self.Ny
+            elif not (0 <= xx < self.Nx and 0 <= yy < self.Ny):
+                continue
+            out.append(self.idx(xx, yy, b))
+        return out
+
+
+def build_H(pl, rvec, M0, H0, Zi, e1=(1, 0, 0), e2=(0, 1, 0)):
+    """The dressed one-particle Hamiltonian read from the record Bloch vectors."""
+    e1 = np.asarray(e1, float)
+    e2 = np.asarray(e2, float)
+    m1v = M0 * (rvec @ e1)
+    m2v = M0 * (rvec @ e2)
+    eps = (-1.0) ** (pl.x + pl.y + pl.b)
+    Hstat = (H0 + sp.diags(eps * m1v) + pl.m2_hop_operator(m2v)).tocsr()
+
+    def H(q):
+        return (Hstat + Zi * np.exp(-1j * q) + Zi.conj().T * np.exp(1j * q)).tocsr()
+
+    def V(q):
+        return (-1j * Zi * np.exp(-1j * q) + 1j * Zi.conj().T * np.exp(1j * q)).tocsr()
+
+    return H, V
+
+
+def ingap_modes(Hq, k, window):
+    E, U = spla.eigsh(Hq, k=k, sigma=0.0, which="LM", tol=1e-12)
+    o = np.argsort(E)
+    E, U = E[o], U[:, o]
+    sel = np.abs(E) < window
+    return E[sel], U[:, sel]
+
+
+def relax_xy_fast(pl, n0, pinned, zterm=2.0, tol=1e-14, maxit=200000):
+    n = n0.copy()
+    nbl = np.array([pl.neighbours_inplane(i) + [i] * (4 - len(pl.neighbours_inplane(i)))
+                    for i in range(pl.D)])
+    cnt = np.array([len(pl.neighbours_inplane(i)) for i in range(pl.D)])
+    pad = 4 - cnt
+    free = ~pinned
+    for it in range(maxit):
+        s = n[nbl].sum(1) - pad[:, None] * n + zterm * n
+        norm = np.linalg.norm(s, axis=1)
+        new = n.copy()
+        mk = free & (norm > 0)
+        new[mk] = s[mk] / norm[mk, None]
+        delta = np.max(np.abs(new - n))
+        n = new
+        if delta < tol:
+            return n, it + 1
+    return n, maxit
+
+
+def support_residual(pl, n, zterm=2.0):
+    nbl = [pl.neighbours_inplane(i) for i in range(pl.D)]
+    res = np.zeros(pl.D)
+    dotp = np.zeros(pl.D)
+    for i in range(pl.D):
+        v = n[nbl[i]].sum(0) + zterm * n[i]
+        vn = np.linalg.norm(v)
+        if vn > 0:
+            res[i] = np.linalg.norm(np.cross(n[i], v)) / vn
+            dotp[i] = n[i] @ v / vn
+    return res, dotp
+
+
+def analytic_field(pl, cores):
+    r = np.zeros((pl.D, 3))
+    for i in range(pl.D):
+        ph = 0.0
+        for (xc, yc, n) in cores:
+            ph += n * np.arctan2(pl.y[i] - yc, pl.x[i] - xc)
+        r[i] = [np.cos(ph), np.sin(ph), 0.0]
+    return r
+
+
+def relaxed_field(pl, cores):
+    """The L_HYB fixed point on the open plane: XY relaxation from the analytic field with
+    the boundary ring and the four plaquette corners about each core pinned."""
+    n0 = analytic_field(pl, cores)
+    pinned = np.minimum.reduce([pl.x, pl.y, pl.Nx - 1 - pl.x, pl.Ny - 1 - pl.y]) < 0.5
+    for (xc, yc, _) in cores:
+        pinned |= (np.abs(pl.x - xc) < 0.75) & (np.abs(pl.y - yc) < 0.75)
+    n, _ = relax_xy_fast(pl, n0, pinned)
+    res, dotp = support_residual(pl, n)
+    free = ~pinned
+    return n, float(res[free].max()), float(dotp[free].min()), int(free.sum())
+
+
+Nf = 24
+plf = Plane(Nf, Nf)
+H0f, Zif = plf.hop_matrices()
+cf = ((Nf - 1) / 2, (Nf - 1) / 2)
+nf, res, mind, nfree = relaxed_field(plf, [(cf[0], cf[1], 1)])
+check("S6a [float64, model] the 24x24 relaxed vortex is an L_HYB fixed point: residual %.1e, "
+      "%d sites, min n.vhat %+.4f" % (res, nfree, mind),
+      res < 1e-13 and nfree == 960 and mind > 0.999999)
+golden = (1 + 5 ** 0.5) / 2
+qr = (plf.x * golden + plf.y * 2 ** 0.5) % 1.0
+FLIPS = [("none", np.ones(plf.D)),
+         ("1/9", np.where((plf.x % 3 == 0) & (plf.y % 3 == 0), -1.0, 1.0)),
+         ("1/2", np.where(qr < 0.5, -1.0, 1.0)),
+         ("1/6", np.where(qr < 1 / 6, -1.0, 1.0))]
+flipres = {}
+for nm, s in FLIPS:
+    Hf, Vf = build_H(plf, nf * s[:, None], M0, H0f, Zif)
+    Ef, Uf = ingap_modes(Hf(np.pi + 0.1), 60, WGAP)
+    core = np.hypot(plf.x - cf[0], plf.y - cf[1]) < 5
+    sel = [j for j in range(len(Ef)) if (np.abs(Uf[:, j]) ** 2)[core].sum() > 0.6]
+    flipres[nm] = (float(np.mean(s)), len(sel))
+check("S6b [float64, model] flip density 1/2 (mean %+.3f) leaves %d core modes; none, 1/9, "
+      "~1/6 keep %d, %d, %d"
+      % (flipres["1/2"][0], flipres["1/2"][1], flipres["none"][1], flipres["1/9"][1],
+         flipres["1/6"][1]),
+      flipres["1/2"][1] == 0 and flipres["none"][1] == 2 and flipres["1/9"][1] == 2
+      and flipres["1/6"][1] == 2)
+
+
+# ======================================================= T4, homogeneity as a clause
+# (b7_rank.py:381-430)
+TP = [F(0), F(1), F(-1), F(1, 2), F(-1, 2), F(2), F(-2), F(1, 3), F(3)]
+cpts = [circle_dir(t) for t in TP]
+cpts += [neg(p) for p in cpts]
+TERN = []
+for i, j, k in combinations(range(len(cpts)), 3):
+    n1, n2, n3 = cpts[i], cpts[j], cpts[k]
+    if len({n1, n2, n3}) < 3:
+        continue
+    q = balanced_weights2((n1[0], n1[1]), (n2[0], n2[1]), (n3[0], n3[1]))
+    if q is not None:
+        TERN.append(((2 * q[0], n1), (2 * q[1], n2), (2 * q[2], n3)))
+T_PARAM = F(2, 3)
+EXV = (F(1), F(0), F(0))
+
+
+def w_fib(c, n, l):
+    """L_FIB of PR #7926: rho_l = (I + t l.sigma)/2 on a unit lattice dipole l."""
+    return c * (1 + T_PARAM * dot(l, n)) / 2
+
+
+check("R13 [exact] L_CONT + L_FIB satisfies the clause in fibre e_x on all %d ternaries and "
+      "their binaries" % len(TERN),
+      len(TERN) == 126
+      and all(w_fib(c, n, EXV) / c == w_fib(F(1), n, EXV) for mn in TERN for c, n in mn)
+      and all(sum(w_fib(c, n, EXV) for c, n in mn) == 1 for mn in TERN))
+
+
+def rogue(c):
+    return F(1, 2) if c == 1 else F(1, 3)
+
+
+check("R14 [exact] the counting rogue violates it, %s against %s, while normalised on all %d "
+      "ternaries"
+      % (rogue(F(1, 2)) / F(1, 2), rogue(F(1)), len(TERN)),
+      rogue(F(1, 2)) / F(1, 2) != rogue(F(1))
+      and all(sum(rogue(c) for c, _ in mn) == 1 for mn in TERN))
+
+
+def w_cubic(c, n):
+    return c * (1 + n[2] ** 3) / 2
+
+
+u35 = (F(3, 5), F(0), F(4, 5))
+check("R15 [exact] L_BIN with c(1 + u_z^3)/2: homogeneous, normalised on every binary, not "
+      "Born (%s against 4/5)" % (u35[2] ** 3),
+      all(w_cubic(F(1), n) + w_cubic(F(1), neg(n)) == 1 for n in cpts + [u35])
+      and all(w_cubic(c, n) / c == w_cubic(F(1), n)
+              for c in (F(1, 2), F(1, 3), F(1, 7)) for n in cpts + [u35])
+      and u35[2] ** 3 != u35[2])
+check("R17 [exact] status: F_CONT a clause, F_A a theorem under direction-measurability, "
+      "F_4 a theorem",
+      null[("F_CONT", 0)] == 13 and in_span(rog, kern[("F_CONT", 0)], 2 * NG)
+      and null[("F_A", 1)] == 1 and all(null[("F_A", k)] == 0
+                                        for k in range(KMAX + 1) if k != 1)
+      and hom and rk_c == NG - 12)
+
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))


### PR DESCRIPTION
## Summary

Bounded theorem note + exact rational runner + cache pricing the two wordings of the Born price (PR #7950) as actual formation events on the continuum record alphabet of PR #7926. **The continuum law as it stands realises exactly the identity, binary, coin and balanced-ternary menus and no others**, by a complete census over all `21^6 = 85,766,121` neighbourhood conditions; the collinear ternary, the mixed coin ternary and the four-outcome collinear menu never occur, because the law is scale-blind (its support is unchanged when every recorded scale is set to one). The smallest covariant modification reads the record scales on the collinear conditions: one record gives the collinear ternary at its scale, an antipodal pair the mixed coin at the mean scale, an equal-direction pair the four-outcome menu; each keeps the echo lemma, the bulk identity record on all `18^6` fully recorded conditions, covariance (684,024 checks, no mismatch) and PR #7926's abundance, and two-record menus reach the fibre only with an identity-record pad. **Wording (B), fibred clause plus abundance plus homogeneity, is payable by the law unmodified**, its own binaries and balanced ternaries, at the exact cost of a supplied homogeneity clause (on the law's realised family the counting rogue survives, nullity `13, 3, 1, 2, 1, …` across the angle modes). **Wording (A), fibred clause plus abundance with the collinear menus, is payable only after the scale-reading modification**, and then closes up to direction-measurability (nullity 0 at every mode except `k = 1`, whose kernel is exactly the homogeneous Born vector, with `u(c) = c` obtained without the ternary coin). **The four-outcome menu pays with no clause at all**: per point on a ray, rank 23 and nullity 1 force `W(c) = c W(1)`, bounded additivity extends it to real scales, and the 52-direction stage (rank 50, kernel `span{x, y}`) closes the Born form. **None of them removes the fair-coin sign of PR #7973**: the bulk fibre stays `ρ = I/2`, and by the sign lemma the `+m` members of any collinear-type menu total `tr(ρ P(m))`, the binary's odds, so a collinear menu at a bulk site registers a scale, not a sign; the sign odds stay `1/2, 1/2`, the re-registration odds `2^{−N²}`, a tilted record-value map biases but never fixes the coin, and the flip-density-one-half row (0 core modes) is unchanged. Homogeneity is stated as a clause in the axioms' register: the fibred law satisfies it, the counting rogue violates it, and a binary law with a cubic term shows that homogeneity without abundance forces nothing.

- `docs/THE_BORN_PRICE_WORDINGS_HOMOGENEITY_IS_PAYABLE_ON_THE_CONTINUUM_LAW_AS_IT_STANDS_THE_COLLINEAR_MENUS_NEED_A_SCALE_READING_RULE_THE_FOUR_OUTCOME_MENU_PAYS_WITH_NO_CLAUSE_AND_NONE_REMOVES_THE_FAIR_COIN_BOUNDED_NOTE_2026-09-05.md` (329 lines)
- `scripts/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.py` (`TOTAL: PASS=49 FAIL=0`, 94 s; the full `21^6` census with no reduction; exact rational certificates; one float64 row labelled; no seeds; stdout 4,987 characters)
- `logs/runner-cache/born_price_wordings_homogeneity_collinear_four_outcome_fair_coin_check_2026_09_05.txt`

## Theorems

- **T1** the census and the scale-blindness; the three modifications and what they keep; the parity fact. **T2** the rank certificates on the three families without homogeneity. **T3** the fair coin (the invariant fibre, the sign lemma, the tilt). **T4** the homogeneity clause and its status on each family (a clause, a measurability-conditional theorem, an exact theorem).

## Boundary

- The continuum effect domain and the fibred odds of PR #7926 verbatim; the `j/24` angle grid and modes `k ≤ 12`; the 52-direction stage; the six-direction declared set (two of its directions have no antipode in the set, which the census counts reflect); the float64 string-mode row labelled; nothing derived from the axioms.

## Context

- Parents (open PRs): the menu-independence and abundance note (#7919), the continuum alphabet (#7926), the fibred clause (#7931), the Born-from-ternaries note (#7950), the one-frame tick note (#7969), the winding-phase note (#7973).
- Item 6 and last of the owner's third-campaign queue (2026-09-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
