### PR TITLE
feat(chirality): a time-directed formation sweep registers the direction of motion, not handedness; the screw sense registers nothing

### DIFF
--- a/docs/A_TIME_DIRECTED_FORMATION_SWEEP_REGISTERS_THE_DIRECTION_OF_MOTION_AT_ORDER_ONE_AND_ITS_SCREW_SENSE_REGISTERS_NOTHING_THE_RECORD_SIDE_IMAGE_OF_A_CURRENT_NOT_A_CHIRALITY_BOUNDED_NOTE_2026-09-05.md
+++ b/docs/A_TIME_DIRECTED_FORMATION_SWEEP_REGISTERS_THE_DIRECTION_OF_MOTION_AT_ORDER_ONE_AND_ITS_SCREW_SENSE_REGISTERS_NOTHING_THE_RECORD_SIDE_IMAGE_OF_A_CURRENT_NOT_A_CHIRALITY_BOUNDED_NOTE_2026-09-05.md
@@ -1,0 +1,246 @@
+---
+claim_id: directed_formation_sweep_registers_direction_of_motion_not_handedness_2026_09_05
+claim_type: bounded_theorem
+claim_scope: "One-particle and determinantal record numerics on declared finite geometries, with a complete many-body tree check on two small blocks and complete integer enumerations over the ternary nearest-neighbour profile alphabet. SUPPLIED, none of it read out of any axiom: the body-diagonal second mass M2 with its winding phase and the 12x12x24 string (PR #7949) as PR #7989 rebuilt it, the half-filled sea and the determinantal record law (PR #7883), the star tick with the rotated kernel K = G P G+ (PR #7986), the record-time vortex construction of PR #7935 in full, and this note's own tick model (site-set Model A with end-recorded hop deletion and tau), its formation sweeps with their quadrant construction and seam, its regions, columns, rules and order-pseudoscalar. (T1) Under the tick model a formation sweep directed along the string axis separates the string's core right-mover from its time-reversal partner, the anti-string's core left-mover, at order one: registration odds 0.1366 against 0.6048 at the core, Delta_core = -0.46825 at tau = 0.5 with the transfer to the ring Delta_ring = +0.54803, the T-partner identity exact at 0.0e+00 in the density and 0.0e+00 in total variation at the pattern level and many-body, growing with the string length (-0.4683, -0.5031, -0.5264 at L_z = 24, 48, 96), stable in the transverse size (-0.4352, -0.4683, -0.4507) and momentum (-0.5444, -0.5270, -0.4683), and superlinear at small tau (Delta/tau = -0.22, -0.53, -0.81 at tau = 0.05, 0.1, 0.25). (T2) The screw sense of the sweep contributes exactly nothing on the string: Delta(screw+) - Delta(screw-) <= 1.7e-16 at every pitch and direction with the densities pointwise mirror images to 3.6e-17, because the string is its own sigma_x image and sigma_x maps screw+ onto screw-; with the core off the mirror plane the screw difference is a boundary effect falling like the ring weight, -4.0e-03, -7.8e-04, +2.1e-04 at N_s = 8, 12, 16. (T3) C2(x) composed with complex conjugation is an exact anti-unitary symmetry of the string, giving Delta(S) = -Delta(C2(x) S) to 2.8e-16 and pointwise 6.9e-17, so every C2(x)-closed family of sweeps averages to exactly zero while reversal-closed screw families keep a seam of +0.002 to +0.006; and the rotated kernel is even under sigma_z times particle-hole times tau reversal, 6.6e-17 pointwise and 9.4e-15 in total variation. (T4) On the record-time vortex the registration is exactly time-even for every sweep, tau and momentum (<= 2.2e-15), certified by a site-diagonal conserved helicity and the transverse anti-unitary alpha_1 alpha_4 at 0.0e+00; the anti-vortex is C conj(H) C+ for a monomial site-independent C at residual 0.0e+00; and the spiral sense registers a parity-odd, time-even difference of a few percent (0.9196 against 0.9469 at pitch 2) because the Wilson vortex is not its own mirror image. (T5) On the cube and the slab no covariant nearest-neighbour rule selects a handed formation order: complete dynamic-programming counts over the 3^V ternary configurations give mean order-pseudoscalar exactly 0.000e+00 for every rule with or without empty menus, the readable class admits every order (1961990553600 = 12! x 2^12 complete paths, 0 dead ends), the rule that forbids one chiral shape admits screw+ and screw- with all 4096 value assignments, and the mechanism is identified on the slab. Interactions, wider windows, other geometries, other momenta and boundary conditions, and the uniform-order average are out of scope. No axiom is changed, no status is set, no hypothesis is adopted, and no registry entry is created."
+upstream_dependencies: []
+runner: scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py
+---
+
+# A time-directed formation sweep registers the direction of motion of the string's movers at order one and the screw sense of the sweep registers nothing: the mirror difference is an exact zero on the string, the record-time vortex's registration is exactly time-even, and no nearest-neighbour rule selects a handed order (bounded, one-particle with a many-body check, declared sweeps)
+
+**Date:** 2026-09-05
+**Type:** bounded_theorem
+**Audit:** unset; independent audit remains a separate lane
+**Status:** bounded - bounded or caveated result note
+**Status authority:** independent audit only. This source changes no axiom, primitive, framework rule, or audit verdict.
+**Primary runner:**
+[`scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py`](../scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py)
+**Runner cache:**
+[`logs/runner-cache/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.txt`](../logs/runner-cache/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.txt)
+**Parents:** none load-bearing. Every object used below is declared in this note and rebuilt from scratch by the runner; the notes named in "Imports and authority" are plain-text pointers carrying no grade and no dependency weight.
+
+The question this note answers is the owner's: *could chirality be obtained from a mirrored configuration of neighbourhood maps applied in record time?* The framework's time is the direction in which records accumulate, so the natural way to make a mirrored configuration act is to sweep the formation front along a screw. The arithmetic below separates two things that the question runs together. A **directed** sweep registers a great deal: it separates a mover from its time-reversal partner at order one. The **screw sense** of that sweep registers nothing at all on the object the handedness line cares about, and the reason is an exact mirror-image identity, not a small number. What a directed sweep sees is the sign of the mover's motion along the arrow of formation - a polar quantity of the `d.J` kind, the record-side image of a current - and not a pseudoscalar handedness.
+
+## Machine status
+
+```yaml
+actual_current_surface_status: bounded-support
+target_claim_type: bounded_theorem
+claim_type_reason: "T1's time-reversal identity, T2's mirror identity, T3's two anti-unitary identities, T4's helicity certificate and anti-vortex identity, and T5's integer path counts and mean order-pseudoscalar are exact or machine-precision statements on named finite objects; the registration odds, the scans in tau, size, length and momentum, the pattern-level correlators and the vortex spiral odds are floating-point statements on the declared geometries at the stated tolerance. The tick model, the sweeps, the regions and the rules are supplied by this note. No statement here is a proof about the infinite lattice, and none is read out of any axiom."
+trace_class: frontier_discovery
+target_claim_id: null
+target_blocker_text: null
+source_of_blocker_text: frontier_question
+reachability_to_target: unknown_frontier
+artifact_role: theorem
+next_trace_action: "Run independent audit on this self-contained finite-size result, and route to the record-time lane the one quantity this note prices but does not compute: whether any formation process whose order statistics are covariant under the proper rotations can register a nonzero time-odd bias at all, given that every C2(x)-closed family averages to exactly zero."
+conditional_surface_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+hypothetical_axiom_status: null
+admitted_observation_status: null
+```
+
+## Exact target
+
+The target is the conjunction of the five statements below, exactly the runner's check groups `A`-`G`. The zero-residual and integer items are exact; the items tagged `[numerical]` are floating-point statements on the named finite geometries at the stated tolerance.
+
+1. `T1` (`A`, `B`). A time-directed plane sweep along `+z` separates the string's core right-mover from the anti-string's core left-mover at order one.
+2. `T2` (`C`). The screw sense of the sweep contributes exactly nothing on the string, and off the mirror plane only a boundary effect.
+3. `T3` (`D`). Two exact anti-unitary identities organise the census: `C2(x)` with conjugation, and `sigma_z` with particle-hole and time reversal.
+4. `T4` (`E`, `F`). The tick model is certified many-body; on the record-time vortex the registration is exactly time-even and the spiral sense registers a parity-odd, time-even few-percent difference.
+5. `T5` (`G`). No covariant nearest-neighbour rule selects a handed formation order on the cube or the slab.
+
+## Imports and authority
+
+Imported scientific authority: none load-bearing. Kawamoto-Smit staggered signs, Jacobi-Anger Chebyshev propagation, determinantal point processes, Burnside's counting lemma and the Jackiw-Rossi vortex mode are standard methodology and appear below only as **plain-text pointers carrying no authority**; every object is redeclared here and the runner recomputes every statement from scratch. No observational value, no fitted number and no framework premise enters any proof. Non-load-bearing pointers, carrying no grade and no dependency weight: `A_MIRROR_ASYMMETRIC_ADMISSIBILITY_RULE_REGISTERS_ITS_OWN_PARITY_ODD_TEXTURE_AND_NOTHING_ELSE_..._BOUNDED_NOTE_2026-09-05.md` (PR #7989, the chiral-rule census and the T-blindness lemma); `THE_STAR_TICKS_RECORD_LAW_IS_EXACTLY_DETERMINANTAL_WITH_A_ROTATED_KERNEL_..._BOUNDED_NOTE_2026-09-05.md` (PR #7986, the rotated kernel); `NO_SITE_WISE_FORMATION_RULE_PRESERVES_THE_SEA_UNDER_TICK_EVOLUTION_..._NOTE_2026-09-03.md` (PR #7947, the set-wise formation unit); `THE_TASTE_SINGLET_SECOND_MASS_IS_A_BODY_DIAGONAL_IMAGINARY_HOP_AND_ITS_VORTEX_STRINGS_CARRY_2N_CO_MOVING_MODES_BOUNDED_THEOREM_NOTE_2026-09-03.md` (PR #7949, the second mass and the string); `A_VORTEX_IN_A_TWO_DIMENSIONAL_RECORD_TIME_CARRIES_A_SINGLE_WEYL_MODE_IN_THE_INTERIOR_AND_A_REAL_MASS_CARRIES_NONE_BOUNDED_THEOREM_NOTE_2026-09-04.md` (PR #7935, the record-time vortex); `A_READABLE_MATTER_LAW_EXISTS_ON_THE_5X5X5_WINDOW_..._BOUNDED_NOTE_2026-09-04.md` (PR #7982, the readable class); `RECORD_STATISTICS_OF_THE_HALF_FILLED_SEA_ARE_DETERMINANTAL_CONDITIONAL_BOUNDED_THEOREM_NOTE_2026-09-03.md` (PR #7883, the determinantal record statistics). None is linked and none is on the main line. [`MINIMAL_AXIOMS_2026-06-29.md`](MINIMAL_AXIOMS_2026-06-29.md) supplies the clauses quoted in "Setting"; no grade of it is cited and no hypothesis is adopted.
+
+## Setting
+
+The framework axioms are quoted, not amended. **Lattice / Physical Locality**, verbatim:
+
+> Physical sites are the points of the cubic lattice `Z^3`, with nearest-neighbor
+> adjacency, standard translations, and proper cubic rotations about each site.
+
+**Admissibility / Local Constraint**, first clause, verbatim:
+
+> There is one fixed nearest-neighbor admissibility rule, covariant under lattice
+> translations and proper cubic rotations.
+
+and its second reading note, verbatim:
+
+> (2) Read with Record, the
+> distribution concerns which possibility a forming record locks, conditional
+> on formation at that site; it does not supply the formation site, probability,
+> or rate.
+
+Covariance is demanded under the 24 **proper** rotations only, so a nearest-neighbour rule is allowed to differ from its mirror image; that is the room the owner's idea needs. The reading note is the other half of the setting: the rule does not supply the formation site or the rate, so a formation **order** - and in particular a screw-shaped one - is not axiom content. `T5` asks whether a covariant rule can nevertheless force one by admissibility alone, and finds that on the cube and the slab it cannot. Everything the sweeps do below therefore rests on a supplied directed order.
+
+Supplied by the open branches and taken as they stand: the body-diagonal second mass `M2` with its winding phase and the `12x12x24` string it binds (PR #7949), rebuilt exactly as PR #7989 rebuilt it; the half-filled sea and its determinantal record law (PR #7883); the star tick with the rotated kernel `K = G P G+` (PR #7986); the set-wise formation unit (PR #7947); the record-time vortex on the eight-component embedding (PR #7935). Supplied by this note and by no parent: the tick model in the form used here, the sweeps and their quadrant construction, the regions and columns, the rules and the order-pseudoscalar, and every tolerance.
+
+## Obligation graph
+
+The proof is acyclic and each node after `P0` is checked by the correspondingly lettered runner group. `P0`, declared here, is the string with its sea and movers, the tick model, the sweeps, the regions, the vortex and the profile alphabet (`A`, `F1`, `G1`). `P1` (`B`) is the directed registration and its scans, which uses `P0` and the time-reversal identity. `P2` (`C`) is the screw-sense zero, which uses `P0`'s point-group census. `P3` (`D`) is the two anti-unitary identities and the pattern-level laws, which uses `P0` and `P1`. `P4` (`E`, `F`) is the many-body certification of the tick model and the vortex battery, which uses `P0` and `P3`'s reading of the kernel. `P5` (`G`) is the rule census, which uses `P0`'s alphabet only. The strongest supported scope is precisely `P0`-`P5`.
+
+## Definitions
+
+```text
+string        h_KS + m1 eps_v + m2 M2 on a 12x12x24 coarse lattice, one mode per
+              site, Kawamoto-Smit signs eta_x = 1, eta_y = (-1)^x,
+              eta_z = (-1)^{x+y}; M2[sbar, s] = i(-1)^{b_2} on every 2x2x2 cell
+              with even corner; m1 + i m2 = M0 tanh(rho/xi) e^{i n phi} about a
+              core at (5.5, 5.5), M0 = 0.7, xi = 2, open plane, periodic
+              axis                                                    SUPPLIED
+anti-string   conj(h), the winding reversal n -> -n                   SUPPLIED
+sea           the 1728 modes of negative energy; the half filling sector
+core R        the E > 0 doublet at p = +pi/6 of maximal core weight, dE/dp > 0
+ring L        the E > 0 doublet at p = -pi/6 of maximal ring weight, dE/dp < 0
+hole          the E < 0 core doublet at p = -pi/6, which also moves +z
+tick model    site-set Model A at the coarse one-particle level: a formation
+              step records a declared SET of sites, locking their occupations
+              with Born odds; between steps the pre-record state runs by
+              exp(-i tau h_R), h_R = h with every hop touching a recorded site
+              deleted.  The record law of a schedule is determinantal with
+              K = G P G+, G = prod exp(-i tau h_{R_i})                THIS NOTE
+sweep         cells are (z-slice, quadrant about the core); a screw of pitch p
+              and sense s forms the cells of equal t = z - s p (q + 1/2)/4
+              together, in increasing t; p = 0 is the plane sweep; direction
+              -z is the reversed list                                 THIS NOTE
+regions       core rho < 3.5, ring within 2 of the plane edge, bulk the rest
+mu(v)         |G psi(v)|^2, the mover's registered excess density, traced over
+              the doublet, per mode
+Delta_reg     O_reg(+tau) - O_reg(-tau), the registration of the string's mover
+              against its time-reversal partner under one and the same sweep
+column        the 2x2x4 core column x, y in {5, 6}, z in {10..13}: 16 sites,
+              65536 patterns, carrying the sea plus the mover
+chi_k^sigma   the signed sum over sigma-mirror pairs of k-subsets of
+              det K_S - det K_{sigma S}, exactly odd under the relabelling
+A_x           TV(p, sigma_x p), the mirror asymmetry of a pattern law
+vortex        PR #7935's record-time vortex: Cl(7) on C^8, Gamma_i = s_i x B,
+              Gamma_{4..7} = I x alpha_{1..4}, open N = 16 record-time square
+              with hard ends, Wilson r_s(L_1 + L_2), constant-modulus complex
+              mass M e^{i theta} with M = 0.8, Bloch momentum p         SUPPLIED
+spiral        the same construction in the record-time plane, cells indexed by
+              (shell, quadrant), pitch in shells per turn, sense +-  THIS NOTE
+profile       ternary map from the six offsets to {open, 0, 1}: the
+              nearest-neighbour condition a corner reads
+orbit A       (+x:0, -x:1, +y:0, -y:open, +z:1, -z:open) and its 24 proper
+              rotations; orbit B its inversion image
+rule          a menu in {0, 1} per proper orbit; an empty menu means the site
+              cannot form under that condition                       THIS NOTE
+Xi            the order-pseudoscalar sum over formation events of
+              sum_{u,w recorded, d(u,v) < d(w,v)} det[r_u, r_w, r_v]: odd under
+              every mirror, invariant under the proper rotations     THIS NOTE
+```
+
+Sizes: the `12x12x24` string in its 12 cell-momentum sectors of dimension 288, with `8x8`, `16x16` and `20x20` planes and `L_z = 48, 96` for the scans; the `2x2x4` core column; the open `2x2x2` and `2x2x3` blocks for the many-body tree, in the 5- and 7-particle sectors of dimension 56 and 792; the record-time vortex at `N = 16` (dimension 2048) with the certificate at `N = 12`; the open `2x2x2` cube and `2x2x3` slab for the rule census. **There is no random number and no seed anywhere in the runner**: every enumeration is complete or a declared sub-family, every sweep is declared, and every eigenproblem is a deterministic LAPACK call. The largest dense matrix built anywhere is `2048 x 2048`; the `3456`-site string and its scans are carried sparse. Declared reductions, with the probe output lines that carry the rest, are listed in "Proof boundary".
+
+## Theorem 1 -- a time-directed sweep registers the direction of motion at order one
+
+**Conclusion.** Under the tick model with the rotated kernel, a plane sweep advancing along `+z` registers the string's core right-mover at the core with odds `0.1366` and its time-reversal partner - the anti-string's core left-mover - with `0.6048`, so `Delta_core = -0.46825` at `tau = 0.5`, with the transfer to the ring `Delta_ring = +0.54803`. The identification of the partner is **exact**: the anti-string carrying `conj(psi_R)` at `+tau` and the string carrying `psi_R` at `-tau` are registered identically site by site at `0.0e+00`, in total variation at `0.0e+00` on the `2x2x4` column with the sea, and at `0.0e+00` in the many-body tree on the `2x2x2` block, where the same sweep separates the pair by `TV = 0.393394`. The bias is the `tau`-odd part of the law: it is `-0.0109, -0.0529, -0.2021, -0.4683, -0.4982, -0.2307` at `tau = 0.05, 0.1, 0.25, 0.5, 1, 2`, saturating near `-0.5` and quasi-periodic beyond. It **grows with the string length** (`-0.4683, -0.5031, -0.5264` at `L_z = 24, 48, 96`) and is stable in the transverse size (`-0.4352, -0.4683, -0.4507` at `N_s = 8, 12, 16`) and in the momentum (`-0.5444, -0.5270, -0.4683` at `p = pi/24, pi/12, pi/6`). The pitch of a screw changes only the magnitude of the directed part (`-0.43744, -0.39396, -0.32929, -0.25016` at pitch 4, 8, 12, 24).
+
+**Reading.** The core right-mover runs away from the advancing front, reaches the seam of the recorded region, cannot reflect - the core branch is chiral - and transfers to the ring's left-moving branch, so it is registered mostly on the ring; the partner runs into the front and is registered at the core. The quantity is `d.J`: the sweep direction against the mover's current.
+
+## Theorem 2 -- the screw sense of the sweep registers exactly nothing on the string
+
+**Conclusion.** At fixed pitch and direction the mirror difference `Delta(screw+) - Delta(screw-)` is `<= 1.7e-16` in the core, the bulk and the ring at pitch 4, 8, 12 and 24, and the registered densities are pointwise mirror images, `max |mu(screw+) - sigma_x mu(screw-)| <= 3.6e-17`; at the pattern level `TV(law(screw+), sigma_x-relabelled law(screw-)) = 1.9e-15`. The reason is an exact identity, not a small number: of the 16 elements of the point group about the core, `sigma_x` sends the string to a gauge copy of itself at `1.1e-16`, the `sigma_x` image of the `+` screw is the `-` screw as a set identity, and the core doublet maps onto itself under `sigma_x` with the `2x2` matrix unitary to `5.3e-15` and eigenvalues `(-1, -1)`. Any `sigma_x`-covariant registered quantity is therefore identical for the two screws. With the core placed off the mirror plane, so that the finite plane breaks `sigma_x`, the screw difference becomes nonzero but falls with the plane size like the mode's ring weight: `-4.0e-03, -7.8e-04, +2.1e-04` at `N_s = 8, 12, 16` with ring weights `0.551, 0.181, 0.057`, while the directed bias on the same geometries stays at `-0.459, -0.478, -0.456`.
+
+**Reading.** The screw sense is a boundary effect; the directed bias is a bulk one. The string's handedness is time-odd and mirror-even, and a mirror-odd sweep cannot see it.
+
+## Theorem 3 -- the two exact anti-unitary identities
+
+**Conclusion.** `C2(x)` composed with complex conjugation is an **exact anti-unitary symmetry of the string**: `C2(x) h = D h_anti D+` at `0.0e+00` for a diagonal gauge, and conjugation returns `h_anti` to `h`. It gives `mu_R(S, +tau) = C2(x) mu_R(C2(x) S, -tau)` pointwise to `6.9e-17` and hence `Delta(S) = -Delta(C2(x) S)` to `2.8e-16` for the plane sweep and every screw, so **every `C2(x)`-closed family of sweeps averages to exactly zero**. For the plane, `C2(x)(plane+)` is `plane-` exactly and the reversal-closed average is `+0.00000`; for a finite screw the two differ by the seam of the quadrant construction, and the reversal-closed screw averages keep `+0.002, +0.003, +0.006, +0.006` at pitch 4, 8, 12, 24. Separately, the rotated kernel is even under `sigma_z` times particle-hole times `tau` reversal: `mu_R(S, +tau) = sigma_z mu_hole(sigma_z S, -tau)` pointwise to `6.6e-17` (plane) and `5.7e-17` (screw), and at the pattern level with the sea to `TV = 9.4e-15`. On the `2x2x4` column the mover's time-odd registration is `TV(R+, R-) = 0.01892` against the sea's own time-odd texture `0.00645`, and the screw's parity-odd record correlators flip sign exactly between the senses (`chi_2 = +0.02367` against `-0.02367`, `chi_3 = +0.05728` against `-0.05728`) with mirror asymmetry `A_x = 0.04437` for the screw and `0.00000` for the plane.
+
+**Reading.** The mirror partner of the right-moving core particle is the right-moving core hole with the arrow of record time reversed. There is no identity relating the string's right-mover law to any left-mover's law under the *same* sweep at the *same* `tau`, which is exactly why the directed bias is nonzero.
+
+## Theorem 4 -- the record-time vortex is the opposite case
+
+**Conclusion.** The tick model is certified many-body: on the open `2x2x2` block with `M2` on, the Lueders tree walked over all `2^V` leaves for the raster, screw+, screw- and slice-wise orders at `tau = 0.5` and `2.0` reproduces the one-particle rotated-kernel law to `3.2e-16` and the invisible-formation formula to `4.5e-17`, with `K^2 - K <= 1.0e-15` and `tr K = N` exactly, and the same on the `2x2x3` block to `8.1e-17`. On PR #7935's record-time vortex the anti-vortex is `C conj(H) C+` for the site-independent internal unitary `C = s_2 x alpha_2 alpha_3 alpha_4` at residual `0.0e+00`, and `C` is **monomial** in the component basis, so PR #7989's time-reversal lemma applies there unchanged - the open item that note left. The registration is then **exactly time-even** for both light modes, the plane sweep and the outward spirals of pitch 2, 4 and 8 in both senses, at `tau = 0.1, 0.5, 2.0`: `O(+tau) = O(-tau)` to `2.2e-15`. The mechanism is certified at `N = 12` at two momenta: the helicity is site-diagonal and commutes with `H` and with every restricted `H_R` (`5.6e-17`), in a helicity sector the even product `alpha_1 alpha_4` - which flips exactly the two generators with imaginary coefficients - satisfies `U conj(h_lam) U+ = h_lam` at `0.0e+00` full and restricted for both helicities, and each light mode has `|<phi|U conj phi>| = 1.0000`. What the spiral sense **does** register there is a parity-odd, time-even difference of a few percent - core odds `0.9196` against `0.9469` at pitch 2, `0.9473` against `0.9605` at pitch 4, `0.8979` against `0.9459` at pitch 8, with the edge mode untouched at `0.9909` - because the record-time mirror of the Wilson vortex is the vortex with `m1 -> -m1` up to `Gamma_2 Gamma_4` at `4.7e-16`, and neither the vortex nor the declared anti-vortex.
+
+**Reading.** Two faces of one coin with opposite discrete labels. The string's handedness is time-odd and mirror-even: a directed sweep separates its movers at order one, a screw does nothing. The record-time vortex's handedness is mirror-odd and time-even: a spiral registers it at the percent level, a directed sweep does nothing.
+
+## Theorem 5 -- no nearest-neighbour rule selects the sweep
+
+**Conclusion.** The 729 ternary nearest-neighbour profiles fall into 57 proper and 56 full orbits, so exactly one chiral orbit pair `(A, B)` exists, and Burnside counting gives `7140` chiral pairs on the 12-offset window, `7960311` on the 18-offset window and `52932198249` on the 26-offset shell - room that no rule here occupies, the Lattice axiom's adjacency clause being nearest-neighbour. Complete dynamic-programming counts over the `3^V` ternary configurations then give, on the **cube** (`2x2x2`, calibration `Xi(screw+) = +1`, `Xi(screw-) = -1`, `Xi(raster) = 0`): no corner has four recorded neighbours, so the all-permissive rule, the maximal chiral rule and the two rules with one chiral menu empty all give `10321920 = 8! x 2^8` complete `(order, value)` paths with 0 dead ends, mean `Xi` exactly `0.000e+00` and final-law mirror asymmetry `0.0e+00` over the 24 improper elements, while every rule empty above two records gives 0 complete paths and `1636608` dead-ended ones. On the **slab** (`2x2x3`, `Xi(screw+/-) = +6/-6`): the readable class admits every order, `1961990553600 = 12! x 2^12` complete paths with 0 dead ends; the maximal chiral rule and the rule forbidding `B` give `1771922718720` (a fraction `0.903`) with `39063306240` dead ends; the rule that forces the chiral shape gives `1405870080` with `19345547712` dead ends while its achiral control gives 0, so every complete path of it passes through an `A`-shaped formation; and **the mean `Xi` over complete paths is exactly `0.000e+00` for every one of them**, while the final-law mirror asymmetry is `0.0e+00`, `6.845e-02` and `5.154e-01`. Under the rule that forbids `B`, all `4096` value assignments complete screw+, screw- and the raster alike on the slab (all `256` on the cube); under the rules that force the chiral shape, none completes any of the three. The mechanism: the global value flip fixes both `A` and `B` (2 of 2 chiral orbits at nearest neighbour), so it does not relate a rule to its mirror; but on the slab every chiral-capable corner shares the full axis `z`, the 16 neighbour-value combinations at a middle corner split as `A: 2, B: 2, achiral: 12`, and reversing the `z`-pair - a flip of the two end slices - exchanges `A` and `B` at every middle corner at once with the **order unchanged**, so the admissible order multiset is mirror-symmetric. On the 12-offset window that argument fails (23355 orbits, 14280 chiral, 128 fixed by the value flip and 14144 sent elsewhere), but no such rule is constructed here.
+
+**Reading.** A chiral rule prunes orders, and can even force every complete path through the chiral shape, yet it writes its handedness into the **values** and never into the **order**. The sweep is a supplied directed order.
+
+## Corollary -- what a directed sweep buys, and what it does not
+
+A directed formation sweep separates a mover from its time-reversal partner at order one. The quantity it registers is `d.J`, the sweep direction against the mover's current: parity-odd under the reflection along the sweep, **time-odd**, and blind to the pseudoscalar sense. It is the record-side image of a current, not of a chirality. Three exact identities fix its character. The time-reversal identity (`0.0e+00`) says what the two registered objects are. The `sigma_x` identity (`3.6e-17`) says the screw sense cannot enter, because the string is its own mirror image. The `C2(x)`-with-conjugation identity (`2.8e-16`) says that the whole bias reverses under a proper rotation composed with time reversal, so **it vanishes exactly over any `C2(x)`-closed family of orders**.
+
+That last point is where the weak sector's requirement bites. A chiral coupling has to be parity-odd and **time-even**, and it has to survive an average over the formation orders a covariant process would actually produce. The bias found here is time-odd and averages to exactly zero over a closed family; the one parity-odd, time-even registration found anywhere in this note - the spiral on the record-time vortex, a few percent - is the registration of a chiral *background* by a chiral *sweep*, with both objects supplied, and it distinguishes a vortex from its mirror image rather than one mover from another in the same background. And the sweep itself is not law content: on the cube and the slab no covariant nearest-neighbour rule selects a handed order, the readable class admitting every order and the chiral rules pruning orders in a mirror-symmetric way. Toward Root B, then: a supplied *chiral* order buys nothing handed, and a supplied *directed* order buys an order-one registration of the direction of motion, which is not the parity-odd, time-even chiral coupling the weak sector needs. What does move is the diagnosis - the obstruction on the string is now a named symmetry (`C2(x)` with conjugation) rather than an absence of effect, and the record-time vortex is shown to sit on the opposite side of both discrete labels.
+
+**Reading, not theorem (this register).** Suppose the world's records are laid down in some order, and ask whether that order can make the world left-handed. Give the order a corkscrew shape and sweep it along a string of matter. Nothing happens: the string looks the same in a mirror, the corkscrew's mirror image is the other corkscrew, and the two give answers identical to the last digit a machine can carry. Now forget the corkscrew and just sweep the front steadily one way along the string. A great deal happens - a mode moving with the front is recorded quite differently from a mode moving against it - but what has been detected is which way the thing is going, not which way it is wound. Reverse the arrow of the sweep and the effect reverses; average over sweeps that come in mirror-and-reverse pairs and it cancels to nothing. So the sweep is a good detector of motion and a blind one for handedness, and the handedness the weak sector wants is still not anywhere in view.
+
+**Disagreements with the expectation, stated plainly.** (1) There is no "core left-mover of the same string": the core branch is chiral, so at `-p` it sits at negative energy and still moves `+z`, and the two movers of one string are the core right-mover and the ring left-mover, or the right-moving particle and the right-moving hole. The clean time-reversal pair is string-right against anti-string-left. (2) The separation of that pair is **order one** (`-0.468`, growing to `-0.526` at `L_z = 96`), not the small effect the question anticipated. (3) The screw contributes an **exact zero**, not a small number, and the reason is a mirror-image identity. (4) The reversal-closed average is **not** the right time-even control: a finite screw has a seam, so reversal-closed screw families leave `+0.002` to `+0.006`; the exact anti-unitary operation is `C2(x)` with conjugation, whose closed families vanish to `2.8e-16`. (5) The record-time vortex's registration is **exactly time-even**, opposite to the string, for a structural reason; the reading that its complex mass is time-violating does not survive at the level of the transverse operator's record law. (6) A chiral rule with empty menus does prune orders, and can force every complete path through the chiral shape, yet its admissible order multiset is exactly mirror-symmetric on the slab. (7) Against the probe write-up this note recomputes: the small-`tau` growth of `Delta_core` is **faster than linear**, not linear - `Delta/tau = -0.22, -0.53, -0.81` at `tau = 0.05, 0.1, 0.25` - and this note uses those values; the recomputed screw-sense bound over the declared sub-family is `1.7e-16` rather than `2.8e-16`, and the recomputed vortex time-evenness bound is `2.2e-15` rather than `1.1e-15`, both machine zero.
+
+## The framework reading -- supplied item by item
+
+**Supplied.** The string of PR #7949 with `M2`, the winding phase, the profile `M0 tanh(rho/xi)` and the core position; the sea and the half filling sector (PR #7883); the star tick and the rotated kernel (PR #7986); the set-wise formation unit (PR #7947); the record-time vortex construction of PR #7935 in full; and, from this note, the tick model with its end-recorded hop-deletion rule and `tau`, the sweeps with their quadrant construction and seam, the regions and columns, the rules, the order-pseudoscalar `Xi` and every tolerance. **Derived, given those:** the point-group census and the schedule set identities; the time-reversal identity and every registration number and scan; the `sigma_x` zero and its off-plane boundary behaviour; the `C2(x)`-with-conjugation and `sigma_z`-particle-hole identities; the pattern-level correlators; the many-body certification; the vortex's exact time-evenness with its certificate and the spiral odds; and the rule counts with the slab mechanism. Nothing here is read out of an axiom; the axiom text is quoted only to fix what covariance demands and that the formation order is not axiom content.
+
+## What is not changed
+
+- No axiom text is amended, extended, reworded, or reinterpreted, and no hypothesis is adopted. The Lattice and Admissibility axioms are quoted, not weakened.
+- No status value is set, predicted, or implied. No premise registry, citation manifest, or axiom-premise node is created or edited. The ledger is fully unaudited since 2026-08-07, and no status word here describes any current audit standing.
+- Nothing here is read out of the axioms: the tick model, the sweeps, the regions, the rules and the geometries are declared objects, and no coefficient is derived.
+- Nothing here is framed as foreclosing anything. `T5` bounds what a *nearest-neighbour* rule can force on two named clusters; it says nothing about wider windows, larger alphabets or constructions outside the declared setting, and `T1`-`T4` are statements about declared objects at declared sizes.
+
+## Interfaces named for other lanes, not taken up here
+
+- **PR #7989** (the chiral-rule census): its open item is answered - the winding reversal of the record-time vortex *is* a complex conjugation in a record basis up to a monomial site-independent relabelling, so its time-reversal lemma applies there unchanged. Its `T1` census is reproduced here at `57/56`.
+- **PR #7986** (the rotated kernel): the kernel is shown to be even under `sigma_z` times particle-hole times `tau` reversal, and its `tau`-odd part is exactly the quantity `T1` measures. Offered to that lane.
+- **PR #7947** (the set-wise formation unit): used as declared; the sweeps here are set-wise schedules of exactly that kind.
+- **PR #7949** (the second mass and its string): the string's core branch is chiral, so its two in-gap movers at `+-p` are not a mirror pair; and the handedness of that string is time-odd and mirror-even. Both belong to that lane.
+- **PR #7935** (the record-time vortex): rebuilt here. Its registration is exactly time-even for a structural reason, and the Wilson vortex is a chiral object whose record-time mirror is the vortex with `m1 -> -m1`. Offered to that lane.
+- **PR #7982 and PR #7883** (the readable class and the determinantal statistics): the readable class is shown to admit every formation order on the two clusters, and the determinantal law is the one every statement here is computed in.
+
+## Remaining live routes
+
+1. Whether any formation process with covariant order statistics can register a nonzero time-odd bias at all, given that every `C2(x)`-closed family averages to exactly zero. Nothing here computes the uniform-order average.
+2. Wider admissibility windows and larger alphabets, where the chiral orbit count is not one; the 12-offset counts are given but no rule there is constructed.
+3. The many-body statements beyond the two small blocks: no interaction, no dynamics for the phase, no anomaly matching, no transverse torus, and no string with its anti-string on one plane.
+
+## Executable claim block
+
+```text
+setting: PR #7949's 12x12x24 string with M0 = 0.7, xi = 2, open plane, periodic axis, in 12 sectors of dimension 288 (plus 8x8, 16x16, 20x20 planes and L_z = 48, 96); the 2x2x4 core column; open 2x2x2 and 2x2x3 blocks for the many-body tree; PR #7935's record-time vortex at N = 16 (certificate at N = 12); open 2x2x2 cube and 2x2x3 slab for the rule census; SUPPLIED: M2 and the string, the sea and half filling, the star tick and the rotated kernel, the record-time vortex, and this note's tick model, sweeps, regions, columns, rules and tolerances; axiom clauses quoted from MINIMAL_AXIOMS_2026-06-29.md
+T1 directed registration [exact / 1e-4]: V = 3456, Hermitian 0.0e+00, anti-string = conj(h) 0.0e+00, sea 1728, residual 4.8e-15; core R doublet E = +0.51019, dE/dp = +0.8809, core 0.619, ring 0.164; ring L dE/dp = -0.8809, ring 0.876; the core E<0 doublet also dE/dp = +0.8809; T-partner identity 0.0e+00 in density, 0.0e+00 in TV, 0.0e+00 many-body with TV(pair) = 0.393394; plane+ at tau = 0.5: core 0.1366 against 0.6048, Delta_core = -0.46825, Delta_ring = +0.54803, plane- exactly the negative; tau scan -0.0109, -0.0529, -0.2021, -0.4683, -0.4982, -0.2307 with Delta/tau = -0.22, -0.53, -0.81; pitch 4/8/12/24 -0.43744, -0.39396, -0.32929, -0.25016; N_s 8/12/16 -0.4352, -0.4683, -0.4507; L_z 24/48/96 -0.4683, -0.5031, -0.5264; p pi/24, pi/12, pi/6 -0.5444, -0.5270, -0.4683
+T2 screw sense [exact / 1e-5]: Delta(screw+) - Delta(screw-) <= 1.7e-16 in core, bulk and ring at every pitch and direction; densities pointwise mirror images 3.6e-17; pattern level 1.9e-15; sigma_x h = D h D+ 1.1e-16, sigma_x(screw+) = screw- exactly, doublet matrix unitary 5.3e-15 with eigenvalues (-1, -1); core off the mirror plane: -4.0e-03, -7.8e-04, +2.1e-04 at N_s = 8, 12, 16 with ring weights 0.551, 0.181, 0.057, directed bias -0.459, -0.478, -0.456
+T3 exact symmetries [exact / 1e-5]: C2(x) h = D h_anti D+ 0.0e+00; mu_R(S, +tau) = C2(x) mu_R(C2(x)S, -tau) 6.9e-17; Delta(S) + Delta(C2(x)S) 2.8e-16; plane reversal-closed average +0.00000, screw seams +0.002, +0.003, +0.006, +0.006; sigma_z x particle-hole x tau reversal 6.6e-17 and 5.7e-17 pointwise, TV 9.4e-15; column: static TV 0.01523, |Sigma_R| 32020, mass 0.48078, plane+ Delta -0.01548, TV(R+, R-) 0.01892 against sea 0.00645, chi_2 +0.02367/-0.02367, chi_3 +0.05728/-0.05728, A_x 0.04437 against plane 0.00000
+T4 vortex [exact / 1e-4]: many-body tree = one-particle kernel 3.2e-16, = invisible-formation formula 4.5e-17, K^2 - K 1.0e-15, tr K = N, 2x2x3 8.1e-17; anti-vortex = C conj(H) C+ 0.0e+00 with C monomial; light modes |E| = 0.309017, CHI +-1, core 0.965, edge 0.991, dE/dp1 = +0.9511 both; registration time-even to 2.2e-15 (core) and 4.4e-16 (edge) over the declared sweeps and tau, T-partner 5.6e-17; helicity commutators 5.6e-17, U conj(h_lam) U+ = h_lam 0.0e+00, overlap 1.0000; spiral+/spiral- core odds 0.9196/0.9469, 0.9473/0.9605, 0.8979/0.9459, edge 0.9909 both; record-time mirror = vortex with m1 -> -m1 up to Gamma_2 Gamma_4 at 4.7e-16
+T5 rule census [exact]: 729 profiles -> 57 proper, 56 full orbits, one chiral pair; Burnside 7140 / 7960311 / 52932198249 chiral pairs on the 12-, 18- and 26-offset windows; cube Xi(screw+/-/raster) +1/-1/0, four rules give 10321920 = 8! x 2^8 complete paths, 0 dead, mean Xi 0.000e+00, asymmetry 0.0e+00, three rules give 0 complete and 1636608 dead; slab Xi +-6, R0 1961990553600 = 12! x 2^12 with 0 dead, chiral rules 1771922718720 with 39063306240 dead, forced-shape rules 1405870080 with 19345547712 dead, achiral control 0, mean Xi 0.000e+00 for all, asymmetry 0.0e+00 / 6.845e-02 / 5.154e-01; 4096 and 256 value assignments complete screw+, screw- and raster under the chiral rule, 0 under the forced-shape rules; value flip fixes both chiral orbits, middle-corner split A 2, B 2, achiral 12, z-pair reversal exchanges A and B at every one; 12-offset window 23355 orbits, 14280 chiral, 128 flip-fixed, 14144 sent elsewhere
+supplied: the tick model, the sweeps and their seam, the regions and columns, the rules and Xi; PR #7949's string and M2; the sea and half filling; the star tick and the rotated kernel; PR #7935's vortex; all tolerances
+axioms_amended_status_values_set_registry_entries_created: 0, 0, 0
+runner_result: PASS=25 FAIL=0
+```
+
+## Proof boundary
+
+**Geometries.** The `12x12x24` string of PR #7949 as PR #7989 rebuilt it, with `8x8`, `16x16` and `20x20` transverse planes and `L_z = 48, 96` for the scans, open plane, periodic axis, `M0 = 0.7`, `xi = 2`, momenta `p` in `{pi/24, pi/12, pi/8, pi/6}`; the declared tick model with `tau` in `{0.05, 0.1, 0.25, 0.5, 1, 2}`; the declared sweeps (plane, screws of pitch 4, 8, 12, 24 with the quadrant construction and its seam, reversals) and regions (core `rho < 3.5`, ring within 2 of the edge); the `2x2x4` core column for the pattern-level laws; the open `2x2x2` and `2x2x3` blocks for the many-body tree; the record-time vortex at `N = 16` with `M = 0.8`, hard ends and `p = (0.1 pi, 0, 0)`, and the certificate at `N = 12` at that momentum and at `(0.1 pi, 0.06 pi, 0.03 pi)`; the open `2x2x2` cube and `2x2x3` slab with seven declared rules for the census. One particle plus the determinantal record law throughout, apart from the two blocks where the tree is walked in full. Nothing is claimed at other sizes, other profiles, other momenta or other boundary conditions.
+
+**Declared reductions this runner makes,** with the probe output lines that carry the rest. (1) The momentum scan recomputes `p = pi/24, pi/12, pi/6`; `p = pi/8` is **quoted** (`h5_string.py -> out_string.txt:93`: plane+ `Delta_core = -0.54469`). (2) The pitch scan recomputes both senses at pitch 4, 8, 12, 24 swept `+z` and pitch 4 swept `-z`; the `-z` sweeps at pitch 8, 12, 24 are quoted (`out_string.txt:20, 22, 26, 28, 30`). (3) The pattern-level laws are recomputed on the `2x2x4` column; the `2x2x2` column is quoted (`out_string.txt:55-67`: `TV(sea+R, sea) = 0.009634`, plane+ `Delta = -0.011679`, exact checks `0.0e+00 / 1.2e-15 / 6.4e-15`). (4) The off-mirror-plane scan recomputes `N_s = 8, 12, 16` and quotes `N_s = 20` (`h5_string_extra.py -> out_string_extra.txt:20`: mirror difference `-1.51e-04`, ring weight `0.019`). (5) The many-body tree is walked in full on the `2x2x2` block and for one order on the `2x2x3` block; the remaining `2x2x3` orders are quoted (`h5_manybody.py -> out_manybody.txt:10, 12-16`: tree against the one-particle law `1.2e-16`, T-pair `0.0e+00`). (6) The vortex recomputes `N = 16` for the plane sweep and the outward spirals of pitch 2, 4, 8 in both senses; the inward spirals, `plane-` and the whole generic-momentum battery are quoted (`out_vortex.txt:21-46`, `out_vortex2.txt:9-14`: every difference `<= 1.11e-15`), as is the complete 128-product scan for anti-unitary symmetries (`out_vortex2.txt:1, 8, 16`). (7) The slab rule census recomputes five rules and quotes the two mirror rules (`h5_rules.py -> out_rules.txt:21, 23`: identical counts, mean `Xi = 0.000e+00`).
+
+**Not claimed.** That any rule here is the framework's rule - none is landed, and the rules are this note's own supplied objects. Any derivation of `M2`, the winding phase, the core position, the formation order, the sweep, `tau`, or the tick model. The uniform average over all `3456!` formation orders, which is out of reach and about which nothing is said. Anything about the infinite lattice. Anything about wider admissibility windows beyond the orbit counts quoted. **Nothing here is read out of the axioms**; the axiom text is quoted only to fix what covariance demands and that the formation order is not axiom content.
+
+## Review record
+
+**Honest-auditor read.** An auditor should come away with four exact identities and one integer census, in that order. First, **the time-reversal identity**: the anti-string with the conjugated mover at `+tau` and the string with the mover at `-tau` are registered identically, `0.0e+00` in density, in total variation and in the many-body tree, which is what makes `Delta` the separation of a genuine time-reversal pair. Second, **the mirror identity**: the string is its own `sigma_x` image and `sigma_x` exchanges the two screws as sets, so the screw sense contributes `<= 1.7e-16` - an exact zero, not a small effect. Third, **`C2(x)` with conjugation**: `Delta(S) = -Delta(C2(x)S)` to `2.8e-16`, so the whole order-one bias averages to exactly zero over any closed family, which is the sharpest limit on what a directed sweep can be worth. Fourth, **the vortex certificate**: a conserved site-diagonal helicity plus the transverse anti-unitary `alpha_1 alpha_4` at `0.0e+00`, which forces exact time-evenness there. Then the census: mean order-pseudoscalar exactly `0.000e+00` for every declared rule on the cube and the slab, with the slab mechanism identified.
+
+The auditor should also come away with five caveats. The registration numbers are **floating-point statements on declared finite geometries** with a declared tick model, and the tick model, the sweeps and the rules are **supplied by this note**, so what is bounded is what the declared construction gives, not what the axioms give. The order-one separation is between a mover and its **time-reversed** partner, not between two mirror-partner movers in one background, and the note's Root B reading turns on that distinction. The exactly-time-even control is the `C2(x)`-closed family and **not** order reversal, because a finite screw has a seam worth `+0.002` to `+0.006`. `T5` is proved on two small clusters and its mechanism uses that every chiral-capable corner of the slab shares one full axis; larger clusters and wider windows are not enumerated. And three numbers here differ from the probe write-up they were recomputed against - the small-`tau` growth is superlinear rather than linear, and two machine-zero bounds move within the noise - with this note using its own values.
+
+This note is self-contained: `upstream_dependencies` is empty, every object is declared in "Definitions", no hypothesis is adopted, and the pointers in "Imports and authority" carry no grade and no weight. The ledger is fully unaudited since 2026-08-07, and no status word in this note describes any current audit standing. Hard landing conditions are a fresh runner and cache pair closing at `PASS=25 FAIL=0`, runtime under the declared `AUDIT_TIMEOUT_SEC = 200` seconds, and passing pipeline and strict-lint gates; independent audit remains a separate lane.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py
+```
+
+Expected terminal summary:
+
+```text
+TOTAL: PASS=25 FAIL=0
+```

--- a/logs/runner-cache/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.txt
+++ b/logs/runner-cache/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.txt
@@ -1,0 +1,38 @@
+===== runner cache v1 =====
+runner: scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py
+runner_sha256: caa98053dc7e514c49d08aa01b944848ab8d68091983432f5572c17753beb69a
+timeout_sec: 200
+exit_code: 0
+elapsed_sec: 62.86
+status: ok
+----- stdout -----
+PASS A1 [1e-14] string 12x12x24, open plane, periodic axis, M0 0.7, xi 2: V 3456, Herm 0e+00, anti = conj(h) 0e+00, sea 1728, resid 4.8e-15, bound 7.0353
+PASS A2 [1e-14] core R doublet p +pi/6: E +0.51019, v +0.8809, core 0.619, ring 0.164; ring L p -pi/6: v -0.8809, ring 0.876; the core hole at -pi/6 also has v +0.8809: no core left-mover on one string; conj(psi_R) on the anti-string 4.6e-15
+PASS A3 [1e-14] point group, 16 elements: s_x h = D h D+ 1e-16; inversion, C2(x) -> anti-string 1e-16, 0e+00; s_z h = -eps h eps 0e+00; s_y h = D(-eps h_a eps)D+ 0e+00, D real True; R doublet D s_x unitary 5e-15, eigs [-1.0, -1.0]
+PASS A4 [exact / 1e-15] sweeps by (z-slice, quadrant), steps 24/27/30/33/42: s_x(screw+) = screw- True, s_z(screw+, +z) = screw- swept -z True, s_x(plane+) = plane+, s_z(plane+) = plane- True; Chebyshev vs expm 3e-16
+PASS B1 [exact] under plane+, anti-string+conj(psi_R) at +tau and string+psi_R at -tau register identically site by site, 0.0e+00: D = O(+tau)-O(-tau) is core R vs its T-partner
+PASS B2 [1e-4] plane+ tau 0.5: core odds 0.1366 vs the T-partner's 0.6048, D_core -0.46825, D_ring +0.54803; plane- exactly the negative +0.46825; pitch 4/8/12/24 at +z: -0.43744, -0.39396, -0.32929, -0.25016
+PASS B3 [1e-4] D_core(plane+), tau 0.05/0.1/0.25/0.5/1/2: -0.0109, -0.0529, -0.2021, -0.4683, -0.4982, -0.2307; D/tau -0.22, -0.53, -0.81 at the first three, falling as tau -> 0: small-tau growth faster than linear, saturating near -0.5
+PASS B4 [1e-4] N_s 8/12/16: -0.4352, -0.4683, -0.4507; L_z 24/48/96 at p pi/6: -0.4683, -0.5031, -0.5264; p pi/24, pi/12, pi/6: -0.5444, -0.5270, -0.4683 (pi/8 quoted)
+PASS C1 [exact] screw sense registers nothing: D(screw+)-D(screw-) <= 1.7e-16 in core, bulk, ring at every pitch and direction; densities pointwise s_x images to 3.6e-17
+PASS C2 [1e-5] core off the mirror plane, screw difference at N_s 8/12/16: -4.0e-03 (0.551), -7.8e-04 (0.181), +2.1e-04 (0.057) (N_s 20 quoted); directed bias -0.459, -0.478, -0.456
+PASS D1 [exact] C2(x) o T: mu_R(S, +tau) = C2(x) mu_R(C2(x)S, -tau) 6.9e-17, D(S) = -D(C2(x)S) 2.8e-16, every C2(x)-closed family averages exactly zero; reversal-closed screw families keep the seam, +0.002, +0.003, +0.006, +0.006, plane +0.00000
+PASS D2 [exact] mu_R(S, +tau) = s_z mu_hole(s_z S, -tau) 6.6e-17 (plane), 5.7e-17 (screw): the kernel is even under s_z x particle-hole x tau reversal; under plane+ core R keeps 0.1366 of the core, ring L 0.8540 of the ring
+PASS D3 [1e-5] 2x2x4 column+sea, 65536 patterns: static TV 0.01523, |Sigma_R| 32020, mass 0.48078; plane+ tau 0.5: D -0.01548, TV(R+,R-) 0.01892 vs sea 0.00645; screw chi_2 +0.02367/-0.02367, chi_3 +0.05728/-0.05728, A_x 0.04437 vs plane 0.00000
+PASS D4 [1e-14] pattern level: (i) anti+conj(psi_R) at +0.5 vs string+psi_R at -0.5, TV 0.0e+00; (ii) screw+ vs s_x screw- 1.9e-15; (iii) R at (plane+,+0.5) vs hole at (plane-,-0.5), s_z-relabelled, complemented, 9.4e-15
+PASS E1 [1e-15] many-body: 2x2x2 (max|Im h| 0.133, dim 56), one order on 2x2x3 (dim 792); Lueders tree over all 2^V leaves, 4 orders, tau 0.5 and 2.0: vs one-particle kernel 3.2e-16, invisible-formation formula 4.5e-17, K^2-K 1.0e-15; 2x2x3 8.1e-17
+PASS E2 [exact] T-pair many-body, 2x2x2 screw+: tree law of conj(h)+conj(state) at +0.5 = tree law of h at -0.5, 0.0e+00; against h at +0.5 the laws differ by TV 0.393394
+PASS F1 [exact] PR #7935 vortex, N 16, Cl(7), M 0.8, p (0.1pi,0,0), dim 2048, sea 1024: anti-vortex = C conj(H) C+, site-indep C = s2 x a2a3a4, 0.0e+00, monomial True; light modes |E| 0.309017, CHI +1 core 0.965, -1 edge 0.991, both +x, v +0.9511
+PASS F2 [1e-14] vortex registration exactly time-even: both modes, plane sweep and outward spirals p 2/4/8, both senses, tau 0.1/0.5/2.0, O(+tau) = O(-tau) to 2.2e-15 core, 4.4e-16 edge; T-partner 5.6e-17
+PASS F3 [exact] mechanism at N 12, both momenta: helicity site-diagonal, [H, hel] 5.6e-17, [H_R, hel] 5.6e-17; U = a1a4 gives U conj(h_lam) U+ = h_lam at 0.0e+00 full and restricted, both lam; light modes have |<phi|U conj phi>| 1.0000
+PASS F4 [1e-4] record-time mirror of the Wilson vortex = m1 -> -m1 up to G2G4 (4.7e-16), not the vortex (1.6) or anti-vortex (1.6); spiral+/spiral- core odds 0.9196/0.9469, 0.9473/0.9605, 0.8979/0.9459 at pitch 2/4/8, edge 0.9909/0.9909
+PASS G1 [exact] 729 profiles give 57 proper and 56 full orbits, so one chiral pair; Burnside: 7140 chiral pairs on the 12-offset window, 7960311 on 18-offset, 52932198249 on the 26-shell, none constructed here
+PASS G2 [exact] cube 2x2x2, 6561 cfgs, Xi(screw+/-/raster) +1.0/-1.0/+0.0: R0/R1/R2/R2m each give 10321920 complete paths = 8! x 2^8, 0 dead, mean Xi +0.000e+00, asymmetry 0e+00; R3/R3m/R4 give 0 complete, 1636608 dead
+PASS G3 [exact] slab 2x2x3, 531441 cfgs, Xi(screw+/-) +6.0/-6.0: R0 1961990553600 = 12! x 2^12, 0 dead; R1, R2 1771922718720; R3 1405870080 with 19345547712 dead; R4 0; mean Xi +0.000e+00 for all; mirror asymmetry 0e+00, 6.845e-02, 5.154e-01
+PASS G4 [exact] under R2 all 4096 value assignments complete screw+, screw- and raster alike on the slab, all 256 on the cube; under R3/R3m none completes any, 0/0/0 and 0/0/0
+PASS G5 [exact] value flip fixes A and B (2 of 2 chiral orbits at NN); slab middle-corner combinations split A 2, B 2, achiral 12, z-pair reversal maps A to B at every one (True); 12-offset: 23355 orbits, 14280 chiral, 128 F-fixed, 14144 moved
+SUMMARY: a directed sweep separates a mover from its T-partner at order one and is blind to screw sense.  [62.3 s]
+TOTAL: PASS=25 FAIL=0
+
+----- stderr -----
+

--- a/scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py
+++ b/scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py
@@ -1,0 +1,1356 @@
+#!/usr/bin/env python3
+"""A time-directed formation sweep registers the direction of motion at order one and its screw
+sense registers nothing: the record-side image of a current, not a chirality.
+
+Self-contained class-A runner: no seed, no random number, no external input file, no import of any
+repository module.  Every enumeration below is complete or a declared sub-family, and every
+eigenproblem is a deterministic LAPACK call.  Largest dense matrix built anywhere: 2048 x 2048
+(the record-time vortex at N = 16); the 3456-site string and its scans are carried sparse.
+
+Copied source blocks (the probe scripts of 2026-09-05; each copy names the block it reproduces):
+  make_geom / build_string / cell_displacement_matrix / sector_basis / diagonalise_sectors /
+  restrict / cheb_coeffs / expm_apply / sweep_forward / sweep_backward / screw_schedule /
+  schedule_key / map_schedule / rot_mats / plane_syms / sym_name / permute_sp / gauge_between /
+  all_patterns / det_law / tv / region_perm / mirror_law / chi_pseudoscalars   <- h5_common.py
+  pick / mover_density / odds / kernels / column / scan_case      <- h5_string.py A, B, C, D
+  delta / the C2(x) control family / the off-plane core geometry  <- h5_string_extra.py E1, E2, E5
+  build_block / fock_sector / hop_matrix / slater / restrict1 / det_law_full / run_case /
+  orders_for                                                      <- h5_manybody.py
+  chain_ops / H8 / prof_vortex / schedule / restrict_modes / site_density / the C identity /
+  the Gamma-product scan                                          <- h5_vortex.py, h5_vortex2.py
+  the helicity + alpha_1 alpha_4 certificate                      <- h5_vortex3.py X1
+  group / dir_perm / orbits / burnside / cluster / step_pseudoscalar_table / dp_count /
+  final_law_asym / screw_orders / xi_of_order / the seven rules   <- h5_rules.py
+  the F-fixed chiral orbit census and the slab middle-corner split  <- h5_rules2.py
+The dynamic programme of h5_rules.py::dp_count is reproduced here in a vectorised form over the
+same 3^V ternary configurations; its integer outputs are the probe's, checked against them below.
+
+Groups: A the string, its movers and its point group; B the directed sweep (T1); C the screw sense
+        (T2); D the exact symmetries (T3); E the many-body certification; F the record-time vortex
+        (T4); G the rule census on the cube and the slab (T5).
+
+Declared reductions (everything else is recomputed from scratch), with the probe output lines that
+carry the rest:
+  * The string's transverse-size scan recomputes N_s = 8, 12, 16 and the length scan L_z = 24, 48,
+    96 at p = pi/6; the momentum scan recomputes p = pi/24, pi/12, pi/6 and quotes p = pi/8
+    (h5_string.py -> out_string.txt:93, plane+ Delta_core = -0.54469).
+  * The pitch scan recomputes both screw senses at pitch 4, 8, 12, 24 swept +z and pitch 4 swept
+    -z; the -z sweeps at pitch 8, 12, 24 are quoted (out_string.txt:20, 22, 26, 28, 30).
+  * The pattern-level laws are recomputed on the 2x2x4 core column; the 2x2x2 column is quoted
+    (out_string.txt:55-67: TV(sea+R, sea) = 0.009634, plane+ Delta = -0.011679, exact checks
+    0.0e+00 / 1.2e-15 / 6.4e-15).
+  * The off-mirror-plane core scan recomputes N_s = 8, 12, 16 and quotes N_s = 20
+    (h5_string_extra.py -> out_string_extra.txt:20: mirror difference -1.51e-04, ring weight 0.019).
+  * The many-body Lueders tree is walked in full on the open 2x2x2 block and for one order on the
+    2x2x3 block; the remaining 2x2x3 orders are quoted (h5_manybody.py -> out_manybody.txt:10,
+    12-16: tree = p_K to 1.2e-16, T-pair 0.0e+00).
+  * The record-time vortex recomputes N = 16 at p = (0.1 pi, 0, 0) for the plane sweep and the
+    outward spirals of pitch 2, 4, 8 in both senses, and the N = 12 certificate at both momenta;
+    the inward spirals, plane-, and the whole generic-momentum registration battery are quoted
+    (out_vortex.txt:21-46, out_vortex2.txt:9-14: every Delta <= 1.11e-15).
+  * The slab rule census recomputes R0, R1, R2, R3 and R4 and quotes the two mirror rules R2m and
+    R3m (h5_rules.py -> out_rules.txt:21, 23: identical counts, mean Xi 0.000e+00).
+
+Output: one PASS/FAIL line per check, and a final `TOTAL: PASS=N FAIL=M`.
+"""
+import itertools
+import math
+import sys
+import time
+
+import numpy as np
+import scipy.linalg as sla
+import scipy.sparse as sp
+from scipy.special import jv
+
+AUDIT_TIMEOUT_SEC = 200
+
+T0 = time.time()
+PASS = 0
+FAIL = 0
+
+
+def check(msg, ok):
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+    else:
+        FAIL += 1
+    print("%s %s" % ("PASS" if ok else "FAIL", msg))
+
+
+# ==================================================================== h5_common.py: the string
+M0, XI, EMAX = 0.7, 2.0, 0.686
+
+
+def make_geom(NS, LZ, core=None):                                  # h5_common.py::make_geom
+    core = ((NS - 1) / 2.0, (NS - 1) / 2.0) if core is None else core
+    sidx = {(x, y, z): (x * NS + y) * LZ + z for x in range(NS) for y in range(NS) for z in range(LZ)}
+    V = len(sidx)
+    xs = np.zeros(V); ys = np.zeros(V); zs = np.zeros(V)
+    for (x, y, z), i in sidx.items():
+        xs[i], ys[i], zs[i] = x, y, z
+    rho = np.hypot(xs - core[0], ys - core[1])
+    phi = np.mod(np.arctan2(xs - core[0], ys - core[1]), 2 * np.pi)
+    quad = np.floor(4 * phi / (2 * np.pi)).astype(int)
+    core_mask = rho < 3.5
+    ring_mask = np.minimum.reduce([xs, ys, NS - 1 - xs, NS - 1 - ys]) < 2
+    return dict(NS=NS, LZ=LZ, NC=LZ // 2, core=core, sidx=sidx, V=V, xs=xs, ys=ys, zs=zs,
+                rho=rho, quad=quad, core_mask=core_mask, ring_mask=ring_mask,
+                bulk_mask=~core_mask & ~ring_mask, eps=(-1.0) ** (xs + ys + zs))
+
+
+def build_string(g, n_wind):                                       # h5_common.py::build_string
+    NS, LZ, sidx, core = g["NS"], g["LZ"], g["sidx"], g["core"]
+    rows, cols, vals = [], [], []
+
+    def add(i, j, val):
+        rows.append(i); cols.append(j); vals.append(val)
+    for (x, y, z), i in sidx.items():
+        if x + 1 < NS:
+            j = sidx[(x + 1, y, z)]; add(i, j, 1.0); add(j, i, 1.0)
+        if y + 1 < NS:
+            j = sidx[(x, y + 1, z)]; add(i, j, float((-1) ** x)); add(j, i, float((-1) ** x))
+        j = sidx[(x, y, (z + 1) % LZ)]; add(i, j, float((-1) ** (x + y))); add(j, i, float((-1) ** (x + y)))
+
+    def mass(px, py):
+        r = np.hypot(px - core[0], py - core[1])
+        return M0 * np.tanh(r / XI), n_wind * np.arctan2(py - core[1], px - core[0])
+    for (x, y, z), i in sidx.items():
+        mag, ph = mass(x, y)
+        add(i, i, mag * np.cos(ph) * (-1) ** (x + y + z))
+    for X in range(NS // 2):
+        for Y in range(NS // 2):
+            mag, ph = mass(2 * X + 0.5, 2 * Y + 0.5)
+            m2c = mag * np.sin(ph)
+            for Z in range(LZ // 2):
+                for b in itertools.product((0, 1), repeat=3):
+                    s = sidx[(2 * X + b[0], 2 * Y + b[1], 2 * Z + b[2])]
+                    sb = sidx[(2 * X + 1 - b[0], 2 * Y + 1 - b[1], 2 * Z + 1 - b[2])]
+                    add(sb, s, m2c * 1j * (-1) ** b[1])
+    H = sp.csr_matrix((np.array(vals, dtype=complex), (rows, cols)), shape=(g["V"], g["V"]))
+    H.sum_duplicates()
+    return H
+
+
+def cell_displacement_matrix(g, H):                    # h5_common.py::cell_displacement_matrix
+    NC = g["NC"]
+    Hc = H.tocoo()
+    d = ((g["zs"][Hc.row] // 2).astype(int) - (g["zs"][Hc.col] // 2).astype(int)) % NC
+    d = np.where(d > NC // 2, d - NC, d)
+    return sp.csr_matrix((-1j * d * Hc.data, (Hc.row, Hc.col)), shape=H.shape)
+
+
+def sector_basis(g, q):                                            # h5_common.py::sector_basis
+    NS, NC, sidx = g["NS"], g["NC"], g["sidx"]
+    B = np.zeros((g["V"], 2 * NS * NS), dtype=complex)
+    col = 0
+    for x in range(NS):
+        for y in range(NS):
+            for b in range(2):
+                for Z in range(NC):
+                    B[sidx[(x, y, 2 * Z + b)], col] = np.exp(1j * q * Z) / np.sqrt(NC)
+                col += 1
+    return B
+
+
+def diagonalise_sectors(g, H, want_W=True):               # h5_common.py::diagonalise_sectors
+    NC = g["NC"]
+    Hv = cell_displacement_matrix(g, H)
+    Wcols, modes = [], []
+    resid = 0.0
+    for jq in range(NC):
+        q = 2 * np.pi * jq / NC
+        p = (q % (2 * np.pi)) - np.pi
+        B = sector_basis(g, q)
+        Hq = B.conj().T @ (H @ B)
+        Hq = (Hq + Hq.conj().T) / 2
+        w, U = np.linalg.eigh(Hq)
+        Vq = B.conj().T @ (Hv @ B)
+        if want_W:
+            Wcols.append(B @ U[:, w < 0])
+        for k in np.flatnonzero(np.abs(w) < EMAX):
+            psi = B @ U[:, k]
+            resid = max(resid, float(np.linalg.norm(H @ psi - w[k] * psi)))
+            dens = np.abs(psi) ** 2
+            modes.append(dict(E=float(w[k]), p=float(p), psi=psi,
+                              core=float(dens[g["core_mask"]].sum()),
+                              ring=float(dens[g["ring_mask"]].sum()),
+                              v=float(np.real(np.vdot(U[:, k], Vq @ U[:, k])))))
+    W = np.concatenate(Wcols, axis=1) if want_W else None
+    return W, modes, resid
+
+
+def restrict(H, recorded):                                             # h5_common.py::restrict
+    D = sp.diags((~recorded).astype(float))
+    return (D @ H @ D).tocsr()
+
+
+def cheb_coeffs(tau_a, tol=1e-17):                                  # h5_common.py::cheb_coeffs
+    k, coeffs = 0, []
+    while True:
+        b = jv(k, tau_a)
+        coeffs.append(b)
+        if k > abs(tau_a) + 5 and abs(b) < tol:
+            break
+        k += 1
+        if k > 4000:
+            break
+    c = np.array(coeffs, dtype=complex)
+    c[1:] *= 2 * (-1j) ** np.arange(1, len(c))
+    return c
+
+
+def expm_apply(H, tau, X, a=None):                                   # h5_common.py::expm_apply
+    if a is None:
+        a = float(np.abs(H).sum(axis=1).max())
+    if a == 0.0 or tau == 0.0:
+        return X.copy()
+    c = cheb_coeffs(tau * a)
+    Hs = H / a
+    T0_, T1 = X, Hs @ X
+    Y = c[0] * T0_ + c[1] * T1
+    for k in range(2, len(c)):
+        T2 = 2 * (Hs @ T1) - T0_
+        Y += c[k] * T2
+        T0_, T1 = T1, T2
+    return Y
+
+
+def sweep_forward(H, schedule, tau, X, a=None):                   # h5_common.py::sweep_forward
+    rec = np.zeros(H.shape[0], dtype=bool)
+    Y = X.copy()
+    for i, S in enumerate(schedule):
+        rec[S] = True
+        if i == len(schedule) - 1:
+            break
+        Y = expm_apply(restrict(H, rec), tau, Y, a)
+    return Y
+
+
+def sweep_backward(H, schedule, tau, X, a=None):                 # h5_common.py::sweep_backward
+    recs, rec = [], np.zeros(H.shape[0], dtype=bool)
+    for S in schedule[:-1]:
+        rec = rec.copy(); rec[S] = True
+        recs.append(rec)
+    Y = X.copy()
+    for rec in reversed(recs):
+        Y = expm_apply(restrict(H, rec), -tau, Y, a)
+    return Y
+
+
+def screw_schedule(g, s, pitch, direction=+1):                   # h5_common.py::screw_schedule
+    t = g["zs"].astype(int) - s * pitch * (g["quad"] + 0.5) / 4.0
+    t = np.round(t * 4) / 4.0
+    sched = [np.flatnonzero(t == tv) for tv in np.unique(t)]
+    return sched[::-1] if direction < 0 else sched
+
+
+def schedule_key(sched):                                          # h5_common.py::schedule_key
+    return tuple(tuple(sorted(int(v) for v in S)) for S in sched)
+
+
+def map_schedule(sched, perm):                                     # h5_common.py::map_schedule
+    return [np.sort(perm[S]) for S in sched]
+
+
+def rot_mats():                                                       # h5_common.py::rot_mats
+    mats, dets = [], []
+    for P in itertools.permutations(range(3)):
+        for sg in itertools.product((1, -1), repeat=3):
+            M = np.zeros((3, 3))
+            for i in range(3):
+                M[i, P[i]] = sg[i]
+            mats.append(M); dets.append(int(round(np.linalg.det(M))))
+    return mats, dets
+
+
+def plane_syms(g):                                                  # h5_common.py::plane_syms
+    out = []
+    cz = (g["LZ"] - 1) / 2.0
+    core, sidx, LZ = g["core"], g["sidx"], g["LZ"]
+    for M, d in zip(*rot_mats()):
+        perm = np.zeros(g["V"], dtype=int)
+        ok = True
+        for (x, y, z), v in sidx.items():
+            gc = M @ np.array([x - core[0], y - core[1], z - cz])
+            s_ = (gc[0] + core[0], gc[1] + core[1], gc[2] + cz)
+            si = tuple(int(round(t)) for t in s_)
+            if any(abs(si[a] - s_[a]) > 1e-9 for a in range(3)):
+                ok = False; break
+            si = (si[0], si[1], si[2] % LZ)
+            if si not in sidx:
+                ok = False; break
+            perm[v] = sidx[si]
+        if ok:
+            out.append((M, d, perm))
+    return out
+
+
+def sym_name(M):                                                      # h5_common.py::sym_name
+    names = {(1, 1, 1): "identity", (-1, 1, 1): "sigma_x", (1, -1, 1): "sigma_y",
+             (1, 1, -1): "sigma_z", (-1, -1, 1): "C2(z)", (-1, 1, -1): "C2(y)",
+             (1, -1, -1): "C2(x)", (-1, -1, -1): "inversion"}
+    if np.allclose(np.abs(M), np.eye(3)):
+        return names[tuple(int(M[i, i]) for i in range(3))]
+    return "other"
+
+
+def permute_sp(A, perm):                                            # h5_common.py::permute_sp
+    P = sp.csr_matrix((np.ones(len(perm)), (perm, np.arange(len(perm)))), shape=A.shape)
+    return (P @ A @ P.T).tocsr()
+
+
+def gauge_between(H, Hp):                                        # h5_common.py::gauge_between
+    H, Hp = H.tocsr().copy(), Hp.tocsr().copy()
+    for A in (H, Hp):
+        A.data[np.abs(A.data) < 1e-12] = 0.0
+        A.eliminate_zeros(); A.sort_indices()
+    V = H.shape[0]
+    if not (np.array_equal(H.indptr, Hp.indptr) and np.array_equal(H.indices, Hp.indices)):
+        return None, float("inf")
+    D = np.zeros(V, dtype=complex)
+    D[0] = 1.0
+    stack, seen = [0], {0}
+    while stack:
+        u = stack.pop()
+        for t in range(H.indptr[u], H.indptr[u + 1]):
+            v = H.indices[t]
+            if v not in seen and abs(H.data[t]) > 1e-12:
+                seen.add(v)
+                D[v] = np.conj(Hp.data[t] / (D[u] * H.data[t]))
+                D[v] /= abs(D[v])
+                stack.append(v)
+    rowsi = np.repeat(np.arange(V), np.diff(H.indptr))
+    return D, float(np.max(np.abs(Hp.data - D[rowsi] * np.conj(D[H.indices]) * H.data)))
+
+
+def all_patterns(n):                                              # h5_common.py::all_patterns
+    return ((np.arange(1 << n)[:, None] >> np.arange(n)[None, :]) & 1).astype(float)
+
+
+def det_law(K, bits, chunk=1 << 13):                                   # h5_common.py::det_law
+    n = K.shape[0]
+    out = np.empty(len(bits))
+    I = np.eye(n)
+    for s in range(0, len(bits), chunk):
+        b = bits[s:s + chunk]
+        M = b[:, :, None] * K[None, :, :] + (1 - b)[:, :, None] * (I - K)[None, :, :]
+        out[s:s + chunk] = np.real(np.linalg.det(M))
+    return out
+
+
+def tv(p, q):                                                                # h5_common.py::tv
+    return 0.5 * float(np.abs(p - q).sum())
+
+
+def region_perm(region, perm):                                    # h5_common.py::region_perm
+    pos = {v: i for i, v in enumerate(region)}
+    return np.array([pos[int(perm[v])] for v in region])
+
+
+def mirror_law(law, bits, rp):                                      # h5_common.py::mirror_law
+    return law[(bits[:, rp] * (1 << np.arange(bits.shape[1]))).sum(axis=1).astype(int)]
+
+
+def chi_pseudoscalars(K, rp, kmax=3):                        # h5_common.py::chi_pseudoscalars
+    n = K.shape[0]
+    out = {}
+    for k in range(2, kmax + 1):
+        tot = 0.0
+        for S in itertools.combinations(range(n), k):
+            Sm = tuple(sorted(int(rp[i]) for i in S))
+            if Sm <= S:
+                continue
+            tot += float(np.real(np.linalg.det(K[np.ix_(S, S)]) - np.linalg.det(K[np.ix_(Sm, Sm)])))
+        out[k] = tot
+    return out
+
+
+# ============================================ A. the string, its movers and its point group
+NS, LZ = 12, 24
+g = make_geom(NS, LZ)
+Hs = build_string(g, +1)
+Ha = build_string(g, -1)
+A_BOUND = float(np.abs(Hs).sum(axis=1).max())
+W, MODES, resid = diagonalise_sectors(g, Hs)
+check("A1 [1e-14] string 12x12x24, open plane, periodic axis, M0 0.7, xi 2: V %d, Herm %.0e, anti ="
+      " conj(h) %.0e, sea %d, resid %.1e, bound %.4f"
+      % (g["V"], abs(Hs - Hs.getH()).max(), abs(Ha - Hs.conjugate()).max(), W.shape[1], resid, A_BOUND),
+      g["V"] == 3456 and W.shape[1] == 1728 and abs(Hs - Hs.getH()).max() == 0.0
+      and abs(Ha - Hs.conjugate()).max() == 0.0 and resid < 1e-14 and abs(A_BOUND - 7.0353) < 1e-4)
+
+
+def pick(modes, p, esign, region, n=2):                                  # h5_string.py::pick
+    cand = [m for m in modes if abs(m["p"] - p) < 1e-9 and np.sign(m["E"]) == esign]
+    cand.sort(key=lambda m: -m[region])
+    return cand[:n]
+
+
+P0 = np.pi / 6
+R_, L_, H_ = pick(MODES, +P0, +1, "core"), pick(MODES, -P0, +1, "ring"), pick(MODES, -P0, -1, "core")
+PsiR = np.stack([m["psi"] for m in R_], axis=1)
+PsiL = np.stack([m["psi"] for m in L_], axis=1)
+PsiH = np.stack([m["psi"] for m in H_], axis=1)
+anti_res = max(float(np.linalg.norm(Ha @ np.conj(PsiR[:, k]) - R_[k]["E"] * np.conj(PsiR[:, k]))) for k in range(2))
+check("A2 [1e-14] core R doublet p +pi/6: E %+.5f, v %+.4f, core %.3f, ring %.3f; ring L p -pi/6: v"
+      " %+.4f, ring %.3f; the core hole at -pi/6 also has v %+.4f: no core left-mover on one "
+      "string; conj(psi_R) on the anti-string %.1e"
+      % (R_[0]["E"], R_[0]["v"], R_[0]["core"], R_[0]["ring"], L_[0]["v"], L_[0]["ring"], H_[0]["v"], anti_res),
+      abs(R_[0]["E"] - 0.51019) < 1e-5 and abs(R_[0]["v"] - 0.8809) < 1e-4 and abs(L_[0]["v"] + 0.8809) < 1e-4
+      and abs(H_[0]["v"] - 0.8809) < 1e-4 and abs(R_[0]["core"] - 0.619) < 1e-3
+      and abs(L_[0]["ring"] - 0.876) < 1e-3 and anti_res < 1e-14)
+
+SYMS = plane_syms(g)
+PERM = {sym_name(M): pm for M, d, pm in SYMS}
+eps = sp.diags(g["eps"])
+Dx, rx = gauge_between(Hs, permute_sp(Hs, PERM["sigma_x"]))
+_, r_inv = gauge_between(Ha, permute_sp(Hs, PERM["inversion"]))
+_, r_c2x = gauge_between(Ha, permute_sp(Hs, PERM["C2(x)"]))
+Dy, r_y = gauge_between(-(eps @ Ha @ eps), permute_sp(Hs, PERM["sigma_y"]))
+r_z = abs(permute_sp(Hs, PERM["sigma_z"]) + eps @ Hs @ eps).max()
+Ux = PsiR.conj().T @ (np.conj(Dx)[:, None] * PsiR[PERM["sigma_x"], :])
+evx = np.linalg.eigvals(Ux)
+check("A3 [1e-14] point group, %d elements: s_x h = D h D+ %.0e; inversion, C2(x) -> anti-string "
+      "%.0e, %.0e; s_z h = -eps h eps %.0e; s_y h = D(-eps h_a eps)D+ %.0e, D real %s; R doublet D "
+      "s_x unitary %.0e, eigs %s"
+      % (len(SYMS), rx, r_inv, r_c2x, r_z, r_y, bool(np.max(np.abs(Dy.imag)) < 1e-12),
+         np.abs(Ux.conj().T @ Ux - np.eye(2)).max(), np.round(evx.real, 6).tolist()),
+      len(SYMS) == 16 and rx < 1e-14 and r_inv < 1e-14 and r_c2x == 0.0 and r_z == 0.0 and r_y == 0.0
+      and np.max(np.abs(Dy.imag)) < 1e-12 and np.abs(Ux.conj().T @ Ux - np.eye(2)).max() < 1e-13
+      and np.allclose(np.sort(evx.real), [-1.0, -1.0], atol=1e-9))
+
+SW = {"plane+": screw_schedule(g, +1, 0, +1), "plane-": screw_schedule(g, +1, 0, -1)}
+for pitch in (4, 8, 12, 24):
+    for s, sn in ((+1, "+"), (-1, "-")):
+        for d, dn in ((+1, "+z"), (-1, "-z")):
+            SW["screw%s p%d %s" % (sn, pitch, dn)] = screw_schedule(g, s, pitch, d)
+okx = all(schedule_key(map_schedule(SW["screw+ p%d +z" % p], PERM["sigma_x"])) == schedule_key(SW["screw- p%d +z" % p]) for p in (4, 8, 12, 24))
+okz = all(schedule_key(map_schedule(SW["screw+ p%d +z" % p], PERM["sigma_z"])) == schedule_key(SW["screw- p%d -z" % p]) for p in (4, 8, 12, 24))
+okp = (schedule_key(map_schedule(SW["plane+"], PERM["sigma_x"])) == schedule_key(SW["plane+"])
+       and schedule_key(map_schedule(SW["plane+"], PERM["sigma_z"])) == schedule_key(SW["plane-"]))
+g2 = make_geom(4, 8)
+H2 = build_string(g2, +1)
+rec2 = np.zeros(g2["V"], bool); rec2[:20] = True
+HR2 = restrict(H2, rec2)
+X2 = np.exp(1j * np.arange(g2["V"]) * 0.37)[:, None] * np.ones((1, 3)); X2 = X2 / np.linalg.norm(X2, axis=0)
+cheb_err = max(np.abs(expm_apply(HR2, t, X2) - sla.expm(-1j * t * HR2.toarray()) @ X2).max() for t in (0.1, 0.5, 2.0))
+check("A4 [exact / 1e-15] sweeps by (z-slice, quadrant), steps 24/27/30/33/42: s_x(screw+) = screw-"
+      " %s, s_z(screw+, +z) = screw- swept -z %s, s_x(plane+) = plane+, s_z(plane+) = plane- %s; "
+      "Chebyshev vs expm %.0e"
+      % (okx, okz, okp, cheb_err),
+      okx and okz and okp and cheb_err < 1e-15
+      and [len(SW[k]) for k in ("plane+", "screw+ p4 +z", "screw+ p8 +z", "screw+ p12 +z", "screw+ p24 +z")] == [24, 27, 30, 33, 42])
+
+
+# ================================ B. T1: a directed sweep registers the direction of motion
+REGS = {"core": g["core_mask"], "bulk": g["bulk_mask"], "ring": g["ring_mask"]}
+
+
+def mover_density(H, sched, tau, Psi, a=A_BOUND):                # h5_string.py::mover_density
+    return (np.abs(sweep_forward(H, sched, tau, Psi, a)) ** 2).sum(axis=1) / Psi.shape[1]
+
+
+def odds(mu, regs=REGS):                                                 # h5_string.py::odds
+    return {r: float(mu[m].sum()) for r, m in regs.items()}
+
+
+def delta(H, sched, tau, Psi, regs=REGS, a=A_BOUND):            # h5_string_extra.py::delta
+    op = odds(mover_density(H, sched, tau, Psi, a), regs)
+    om = odds(mover_density(H, sched, -tau, Psi, a), regs)
+    return {r: op[r] - om[r] for r in regs}
+
+
+MU = {}
+for name in SW:
+    for sgn in (+1, -1):
+        MU[(name, 0.5, sgn)] = mover_density(Hs, SW[name], sgn * 0.5, PsiR)
+DEL = {name: {r: float(MU[(name, 0.5, +1)][m].sum() - MU[(name, 0.5, -1)][m].sum()) for r, m in REGS.items()} for name in SW}
+muA = mover_density(Ha, SW["plane+"], 0.5, np.conj(PsiR))
+check("B1 [exact] under plane+, anti-string+conj(psi_R) at +tau and string+psi_R at -tau register "
+      "identically site by site, %.1e: D = O(+tau)-O(-tau) is core R vs its T-partner"
+      % (np.abs(muA - MU[("plane+", 0.5, -1)]).max(),),
+      np.abs(muA - MU[("plane+", 0.5, -1)]).max() == 0.0)
+
+op, om = odds(MU[("plane+", 0.5, +1)]), odds(MU[("plane+", 0.5, -1)])
+check("B2 [1e-4] plane+ tau 0.5: core odds %.4f vs the T-partner's %.4f, D_core %+.5f, D_ring "
+      "%+.5f; plane- exactly the negative %+.5f; pitch 4/8/12/24 at +z: %+.5f, %+.5f, %+.5f, %+.5f"
+      % (op["core"], om["core"], DEL["plane+"]["core"], DEL["plane+"]["ring"], DEL["plane-"]["core"],
+         DEL["screw+ p4 +z"]["core"], DEL["screw+ p8 +z"]["core"], DEL["screw+ p12 +z"]["core"],
+         DEL["screw+ p24 +z"]["core"]),
+      abs(op["core"] - 0.1366) < 1e-4 and abs(om["core"] - 0.6048) < 1e-4
+      and abs(DEL["plane+"]["core"] + 0.46825) < 1e-5 and abs(DEL["plane+"]["ring"] - 0.54803) < 1e-5
+      and abs(DEL["plane+"]["core"] + DEL["plane-"]["core"]) < 1e-14
+      and abs(DEL["screw+ p4 +z"]["core"] + 0.43744) < 1e-5 and abs(DEL["screw+ p8 +z"]["core"] + 0.39396) < 1e-5
+      and abs(DEL["screw+ p12 +z"]["core"] + 0.32929) < 1e-5 and abs(DEL["screw+ p24 +z"]["core"] + 0.25016) < 1e-5)
+
+TAUS = (0.05, 0.1, 0.25, 0.5, 1.0, 2.0)
+dtau = [delta(Hs, SW["plane+"], t, PsiR)["core"] for t in TAUS]
+check("B3 [1e-4] D_core(plane+), tau 0.05/0.1/0.25/0.5/1/2: %s; D/tau %s at the first three, "
+      "falling as tau -> 0: small-tau growth faster than linear, saturating near -0.5"
+      % (", ".join("%+.4f" % v for v in dtau), ", ".join("%.2f" % (v / t) for v, t in zip(dtau[:3], TAUS))),
+      all(abs(a - b) < 1e-4 for a, b in zip(dtau, (-0.01092, -0.05289, -0.20208, -0.46825, -0.49816, -0.23069)))
+      and dtau[0] / 0.05 > dtau[1] / 0.1 > dtau[2] / 0.25 > dtau[3] / 0.5)
+
+
+def scan_case(NS_, LZ_, p_target, names, tau=0.5, core=None):        # h5_string.py::scan_case
+    gg = make_geom(NS_, LZ_, core=core)
+    H = build_string(gg, +1)
+    a = float(np.abs(H).sum(axis=1).max())
+    _, ms, _ = diagonalise_sectors(gg, H, want_W=False)
+    Rm = pick(ms, +p_target, +1, "core")
+    Psi = np.stack([m["psi"] for m in Rm], axis=1)
+    regs = {"core": gg["core_mask"], "bulk": gg["bulk_mask"], "ring": gg["ring_mask"]}
+    SWg = {"plane+": screw_schedule(gg, +1, 0, +1), "screw+ p4 +z": screw_schedule(gg, +1, 4, +1),
+           "screw- p4 +z": screw_schedule(gg, -1, 4, +1)}
+    out = {"core_w": Rm[0]["core"], "ring_w": Rm[0]["ring"], "E": Rm[0]["E"]}
+    for nm in names:
+        out[nm] = delta(H, SWg[nm], tau, Psi, regs, a)
+    return out
+
+sz = [scan_case(n_, 24, P0, ("plane+",))["plane+"]["core"] for n_ in (8, 16)]
+lz48 = scan_case(12, 48, P0, ("plane+",))
+g96 = make_geom(12, 96)
+H96 = build_string(g96, +1)
+a96 = float(np.abs(H96).sum(axis=1).max())
+_, m96, _ = diagonalise_sectors(g96, H96, want_W=False)
+r96 = {}
+for pt in (np.pi / 24, np.pi / 6):
+    Rm = pick(m96, +pt, +1, "core")
+    Psi = np.stack([m["psi"] for m in Rm], axis=1)
+    regs96 = {"core": g96["core_mask"], "bulk": g96["bulk_mask"], "ring": g96["ring_mask"]}
+    r96[pt] = delta(H96, screw_schedule(g96, +1, 0, +1), 0.5, Psi, regs96, a96)["core"]
+del H96, m96
+p12 = scan_case(12, 48, np.pi / 12, ("plane+",))["plane+"]["core"]
+check("B4 [1e-4] N_s 8/12/16: %+.4f, %+.4f, %+.4f; L_z 24/48/96 at p pi/6: %+.4f, %+.4f, %+.4f; p "
+      "pi/24, pi/12, pi/6: %+.4f, %+.4f, %+.4f (pi/8 quoted)"
+      % (sz[0], DEL["plane+"]["core"], sz[1], DEL["plane+"]["core"], lz48["plane+"]["core"],
+         r96[np.pi / 6], r96[np.pi / 24], p12, DEL["plane+"]["core"]),
+      abs(sz[0] + 0.43525) < 1e-4 and abs(sz[1] + 0.45069) < 1e-4
+      and abs(lz48["plane+"]["core"] + 0.50312) < 1e-4 and abs(r96[np.pi / 6] + 0.52641) < 1e-4
+      and abs(r96[np.pi / 24] + 0.54437) < 1e-4 and abs(p12 + 0.52697) < 1e-4)
+
+
+# ============================================= C. T2: the screw sense registers exactly nothing
+mir = []
+for pitch in (4, 8, 12, 24):
+    dirs = ("+z", "-z") if pitch == 4 else ("+z",)
+    for dn in dirs:
+        a_, b_ = DEL["screw+ p%d %s" % (pitch, dn)], DEL["screw- p%d %s" % (pitch, dn)]
+        mp, mm = MU[("screw+ p%d %s" % (pitch, dn), 0.5, +1)], MU[("screw- p%d %s" % (pitch, dn), 0.5, +1)]
+        mir.append((max(abs(a_[r] - b_[r]) for r in REGS), float(np.abs(mp - mm[PERM["sigma_x"]]).max())))
+check("C1 [exact] screw sense registers nothing: D(screw+)-D(screw-) <= %.1e in core, bulk, ring at"
+      " every pitch and direction; densities pointwise s_x images to %.1e"
+      % (max(m[0] for m in mir), max(m[1] for m in mir)),
+      max(m[0] for m in mir) < 1e-15 and max(m[1] for m in mir) < 1e-16)
+
+off = []
+for NS_ in (8, 12, 16):
+    r = scan_case(NS_, 24, P0, ("plane+", "screw+ p4 +z", "screw- p4 +z"), core=(NS_ / 2 - 1.5, NS_ / 2 - 0.5))
+    off.append((r["ring_w"], r["screw+ p4 +z"]["core"] - r["screw- p4 +z"]["core"], r["plane+"]["core"]))
+check("C2 [1e-5] core off the mirror plane, screw difference at N_s 8/12/16: %s (N_s 20 quoted); "
+      "directed bias %+.3f, %+.3f, %+.3f"
+      % (", ".join("%+.1e (%.3f)" % (o[1], o[0]) for o in off), off[0][2], off[1][2], off[2][2]),
+      abs(off[0][1] + 3.97e-3) < 1e-5 and abs(off[1][1] + 7.82e-4) < 1e-6 and abs(off[2][1] - 2.09e-4) < 1e-6
+      and abs(off[0][0] - 0.551) < 1e-3 and abs(off[2][0] - 0.057) < 1e-3
+      and all(abs(o[2] + 0.46) < 0.03 for o in off))
+
+
+# ================================================================ D. T3: the exact symmetries
+c2t = []
+for name in ("plane+", "screw+ p4 +z", "screw+ p8 +z", "screw+ p12 +z", "screw+ p24 +z", "screw- p4 +z"):
+    S = SW[name]
+    Sc = map_schedule(S, PERM["C2(x)"])
+    dS, dSc = DEL[name]["core"], delta(Hs, Sc, 0.5, PsiR)["core"]
+    pw = float(np.abs(MU[(name, 0.5, +1)] - mover_density(Hs, Sc, -0.5, PsiR)[PERM["C2(x)"]]).max())
+    c2t.append((dS + dSc, pw))
+rev = [0.25 * sum(DEL["screw%s p%d %s" % (s_, p_, d_)]["core"] for s_ in "+-" for d_ in ("+z", "-z")) for p_ in (4, 8, 12, 24)]
+check("D1 [exact] C2(x) o T: mu_R(S, +tau) = C2(x) mu_R(C2(x)S, -tau) %.1e, D(S) = -D(C2(x)S) %.1e,"
+      " every C2(x)-closed family averages exactly zero; reversal-closed screw families keep the "
+      "seam, %s, plane %+.5f"
+      % (max(c[1] for c in c2t), max(abs(c[0]) for c in c2t),
+         ", ".join("%+.3f" % v for v in rev), 0.5 * (DEL["plane+"]["core"] + DEL["plane-"]["core"])),
+      max(c[1] for c in c2t) < 1e-16 and max(abs(c[0]) for c in c2t) < 1e-15
+      and abs(0.5 * (DEL["plane+"]["core"] + DEL["plane-"]["core"])) < 1e-15
+      and all(abs(a - b) < 1e-4 for a, b in zip(rev, (0.00236, 0.00314, 0.00640, 0.00605))))
+
+MUH = {}
+for name in ("plane+", "plane-", "screw+ p4 +z", "screw- p4 -z"):
+    MUH[name] = mover_density(Hs, SW[name], -0.5, PsiH)
+pairs = {}
+for name in ("plane+", "screw+ p4 +z"):
+    tw = {"plane+": "plane-", "screw+ p4 +z": "screw- p4 -z"}[name]
+    pairs[name] = float(np.abs(MU[(name, 0.5, +1)] - MUH[tw][PERM["sigma_z"]]).max())
+oL = odds(mover_density(Hs, SW["plane+"], 0.5, PsiL))["ring"]
+check("D2 [exact] mu_R(S, +tau) = s_z mu_hole(s_z S, -tau) %.1e (plane), %.1e (screw): the kernel "
+      "is even under s_z x particle-hole x tau reversal; under plane+ core R keeps %.4f of the "
+      "core, ring L %.4f of the ring"
+      % (pairs["plane+"], pairs["screw+ p4 +z"], odds(MU[("plane+", 0.5, +1)])["core"], oL),
+      pairs["plane+"] < 1e-16 and pairs["screw+ p4 +z"] < 1e-16 and abs(oL - 0.8540) < 1e-4)
+
+
+def column(zlist):                                                     # h5_string.py::column
+    return [g["sidx"][(x, y, z)] for z in zlist for x in (5, 6) for y in (5, 6)]
+
+
+def kernels(H, Wsea, sched, tau, reg, Psi=None):                      # h5_string.py::kernels
+    E = np.zeros((g["V"], len(reg)), dtype=complex)
+    E[reg, np.arange(len(reg))] = 1.0
+    B = sweep_backward(H, sched, tau, E, A_BOUND) if (sched is not None and tau != 0.0) else E
+    X = Wsea.conj().T @ B
+    K0 = X.conj().T @ X
+    if Psi is None:
+        return K0
+    Y = Psi.conj().T @ B
+    return K0 + Y.conj().T @ Y
+
+
+REG4 = column([10, 11, 12, 13])
+BITS = all_patterns(16)
+rpx, rpz = region_perm(REG4, PERM["sigma_x"]), region_perm(REG4, PERM["sigma_z"])
+p0s = det_law(kernels(Hs, W, None, 0.0, REG4), BITS)
+pRs = det_law(kernels(Hs, W, None, 0.0, REG4, PsiR), BITS)
+SigR = pRs > p0s
+LAW = {}
+for cnm, sc in (("plane+", SW["plane+"]), ("screw+ p4 +z", SW["screw+ p4 +z"]), ("screw- p4 +z", SW["screw- p4 +z"])):
+    LAW[cnm] = (det_law(kernels(Hs, W, sc, 0.5, REG4, PsiR), BITS),
+                det_law(kernels(Hs, W, sc, -0.5, REG4, PsiR), BITS))
+p0p = det_law(kernels(Hs, W, SW["plane+"], 0.5, REG4), BITS)
+p0m = det_law(kernels(Hs, W, SW["plane+"], -0.5, REG4), BITS)
+cxp = chi_pseudoscalars(kernels(Hs, W, SW["screw+ p4 +z"], 0.5, REG4, PsiR), rpx)
+cxm = chi_pseudoscalars(kernels(Hs, W, SW["screw- p4 +z"], 0.5, REG4, PsiR), rpx)
+dpl = LAW["plane+"][0][SigR].sum() - LAW["plane+"][1][SigR].sum()
+Ax_s = tv(LAW["screw+ p4 +z"][0], mirror_law(LAW["screw+ p4 +z"][0], BITS, rpx))
+Ax_p = tv(LAW["plane+"][0], mirror_law(LAW["plane+"][0], BITS, rpx))
+check("D3 [1e-5] 2x2x4 column+sea, 65536 patterns: static TV %.5f, |Sigma_R| %d, mass %.5f; plane+ "
+      "tau 0.5: D %+.5f, TV(R+,R-) %.5f vs sea %.5f; screw chi_2 %+.5f/%+.5f, chi_3 %+.5f/%+.5f, "
+      "A_x %.5f vs plane %.5f"
+      % (tv(p0s, pRs), int(SigR.sum()), float(pRs[SigR].sum()), dpl, tv(*LAW["plane+"]), tv(p0p, p0m),
+         cxp[2], cxm[2], cxp[3], cxm[3], Ax_s, Ax_p),
+      abs(tv(p0s, pRs) - 0.015232) < 1e-6 and int(SigR.sum()) == 32020
+      and abs(float(pRs[SigR].sum()) - 0.480775) < 1e-6 and abs(dpl + 0.015482) < 1e-6
+      and abs(tv(*LAW["plane+"]) - 0.018923) < 1e-6 and abs(tv(p0p, p0m) - 0.006452) < 1e-6
+      and abs(cxp[2] - 0.023666) < 1e-6 and abs(cxp[2] + cxm[2]) < 1e-13
+      and abs(cxp[3] - 0.057275) < 1e-6 and abs(cxp[3] + cxm[3]) < 1e-13
+      and abs(Ax_s - 0.044366) < 1e-6 and Ax_p < 1e-14)
+
+pR_a = det_law(kernels(Ha, np.conj(W), SW["plane+"], 0.5, REG4, np.conj(PsiR)), BITS)
+e1 = tv(pR_a, LAW["plane+"][1])
+e2 = tv(LAW["screw+ p4 +z"][0], mirror_law(LAW["screw- p4 +z"][0], BITS, rpx))
+hole_cols = [int(np.argmax(np.abs(W.conj().T @ PsiH[:, k]))) for k in range(2)]
+W_hole = np.delete(W, hole_cols, axis=1)
+flip = ((1 << 16) - 1) - (BITS @ (1 << np.arange(16))).astype(int)
+e3 = tv(LAW["plane+"][0], mirror_law(det_law(kernels(Hs, W_hole, SW["plane-"], -0.5, REG4), BITS), BITS, rpz)[flip])
+check("D4 [1e-14] pattern level: (i) anti+conj(psi_R) at +0.5 vs string+psi_R at -0.5, TV %.1e; "
+      "(ii) screw+ vs s_x screw- %.1e; (iii) R at (plane+,+0.5) vs hole at (plane-,-0.5), s_z-"
+      "relabelled, complemented, %.1e"
+      % (e1, e2, e3),
+      e1 == 0.0 and e2 < 1e-14 and e3 < 1e-13)
+
+
+# ============================================== E. the many-body certification of the tick model
+def build_block(Lx, Ly, Lz, n_wind=+1):                          # h5_manybody.py::build_block
+    sidx = {(x, y, z): (x * Ly + y) * Lz + z for x in range(Lx) for y in range(Ly) for z in range(Lz)}
+    V = len(sidx)
+    h = np.zeros((V, V), dtype=complex)
+    core = ((Lx - 1) / 2 + 0.7, (Ly - 1) / 2 - 0.4)
+    for (x, y, z), i in sidx.items():
+        if (x + 1, y, z) in sidx:
+            j = sidx[(x + 1, y, z)]; h[i, j] += 1; h[j, i] += 1
+        if (x, y + 1, z) in sidx:
+            j = sidx[(x, y + 1, z)]; h[i, j] += (-1) ** x; h[j, i] += (-1) ** x
+        if (x, y, z + 1) in sidx:
+            j = sidx[(x, y, z + 1)]; h[i, j] += (-1) ** (x + y); h[j, i] += (-1) ** (x + y)
+        r = np.hypot(x - core[0], y - core[1]); ph = n_wind * np.arctan2(y - core[1], x - core[0])
+        h[i, i] += M0 * np.tanh(r / XI) * np.cos(ph) * (-1) ** (x + y + z)
+    for X in range(Lx // 2):
+        for Y in range(Ly // 2):
+            r = np.hypot(2 * X + 0.5 - core[0], 2 * Y + 0.5 - core[1])
+            ph = n_wind * np.arctan2(2 * Y + 0.5 - core[1], 2 * X + 0.5 - core[0])
+            m2c = M0 * np.tanh(r / XI) * np.sin(ph)
+            for Z in range(Lz // 2):
+                for b in itertools.product((0, 1), repeat=3):
+                    s_ = sidx[(2 * X + b[0], 2 * Y + b[1], 2 * Z + b[2])]
+                    sb = sidx[(2 * X + 1 - b[0], 2 * Y + 1 - b[1], 2 * Z + 1 - b[2])]
+                    h[sb, s_] += m2c * 1j * (-1) ** b[1]
+    return h, sidx
+
+
+def fock_sector(n, N):                                            # h5_manybody.py::fock_sector
+    states = [s for s in range(1 << n) if bin(s).count("1") == N]
+    return states, {s: i for i, s in enumerate(states)}
+
+
+def hop_matrix(h, states, pos, n):                                # h5_manybody.py::hop_matrix
+    H = np.zeros((len(states), len(states)), dtype=complex)
+    for i, s in enumerate(states):
+        for v in range(n):
+            if not (s >> v) & 1:
+                continue
+            s1 = s ^ (1 << v); sign_v = (-1) ** bin(s & ((1 << v) - 1)).count("1")
+            for u in range(n):
+                if h[u, v] == 0 or (s1 >> u) & 1:
+                    continue
+                s2 = s1 | (1 << u); sign_u = (-1) ** bin(s1 & ((1 << u) - 1)).count("1")
+                H[pos[s2], i] += h[u, v] * sign_u * sign_v
+    return H
+
+
+def slater(Wm, states):                                                # h5_manybody.py::slater
+    amp = np.zeros(len(states), dtype=complex)
+    for i, s in enumerate(states):
+        amp[i] = np.linalg.det(Wm[[v for v in range(Wm.shape[0]) if (s >> v) & 1], :])
+    return amp
+
+
+def restrict1(h, rec):                                              # h5_manybody.py::restrict1
+    keep = np.where(rec, 0.0, 1.0)
+    return keep[:, None] * h * keep[None, :]
+
+
+def run_case(Lx, Ly, Lz, order, tau, conj=False):                    # h5_manybody.py::run_case
+    h, _ = build_block(Lx, Ly, Lz)
+    if conj:
+        h = np.conj(h)
+    n = h.shape[0]; N = n // 2 + 1
+    w, U = np.linalg.eigh(h)
+    Wm = U[:, :N]
+    states, pos = fock_sector(n, N)
+    amp = slater(Wm, states)
+    rec = np.zeros(n, bool); G = np.eye(n, dtype=complex)
+    for i, S in enumerate(order):
+        rec[list(S)] = True
+        if i == len(order) - 1:
+            break
+        G = sla.expm(-1j * tau * restrict1(h, rec)) @ G
+    Wg = G @ Wm; K = Wg @ Wg.conj().T
+    law1 = det_law(K, all_patterns(n))
+    occ = np.array([[(s >> v) & 1 for v in range(n)] for s in states], dtype=float)
+    Br = amp[:, None].copy(); leaf_bits = np.zeros((1, n)); rec = np.zeros(n, bool)
+    for i, S in enumerate(order):
+        S = list(S)
+        newB, newbits = [], []
+        for pat in itertools.product((0, 1), repeat=len(S)):
+            mask = np.ones(len(states))
+            for v, b in zip(S, pat):
+                mask *= (occ[:, v] == b)
+            newB.append(Br * mask[:, None])
+            nb = leaf_bits.copy(); nb[:, S] = pat
+            newbits.append(nb)
+        Br = np.concatenate(newB, axis=1); leaf_bits = np.concatenate(newbits, axis=0)
+        rec[S] = True
+        if i == len(order) - 1:
+            break
+        Br = sla.expm(-1j * tau * hop_matrix(restrict1(h, rec), states, pos, n)) @ Br
+    prob = (np.abs(Br) ** 2).sum(0)
+    idx = (leaf_bits * (1 << np.arange(n))).sum(1).astype(int)
+    law_mb = np.zeros(1 << n); np.add.at(law_mb, idx, prob)
+    vec = amp.copy(); rec = np.zeros(n, bool)
+    for i, S in enumerate(order):
+        rec[list(S)] = True
+        if i == len(order) - 1:
+            break
+        vec = sla.expm(-1j * tau * hop_matrix(restrict1(h, rec), states, pos, n)) @ vec
+    law_inv = np.zeros(1 << n); np.add.at(law_inv, np.array(states), np.abs(vec) ** 2)
+    return dict(law1=law1, law_mb=law_mb, law_inv=law_inv, leaves=Br.shape[1],
+                sum_mb=float(law_mb.sum()), K2=float(np.abs(K @ K - K).max()),
+                trK=float(np.real(np.trace(K))))
+
+
+def orders_for(Lx, Ly, Lz, sidx):                                  # h5_manybody.py::orders_for
+    ring_p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    ring_m = [(0, 0), (0, 1), (1, 1), (1, 0)]
+    return {"raster": [(sidx[(x, y, z)],) for x in range(Lx) for y in range(Ly) for z in range(Lz)],
+            "screw+": [(sidx[(x, y, z)],) for z in range(Lz) for (x, y) in ring_p],
+            "screw-": [(sidx[(x, y, z)],) for z in range(Lz) for (x, y) in ring_m],
+            "slices": [tuple(sidx[(x, y, z)] for x in range(Lx) for y in range(Ly)) for z in range(Lz)]}
+
+
+hb, sidxb = build_block(2, 2, 2)
+ORDB = orders_for(2, 2, 2, sidxb)
+mb = {}
+for onm in ("raster", "screw+", "screw-", "slices"):
+    mb[(onm, 0.5)] = run_case(2, 2, 2, ORDB[onm], 0.5)
+mb[("screw+", 2.0)] = run_case(2, 2, 2, ORDB["screw+"], 2.0)
+mb_a = run_case(2, 2, 2, ORDB["screw+"], +0.5, conj=True)
+mb_b = run_case(2, 2, 2, ORDB["screw+"], -0.5)
+h3, sidx3 = build_block(2, 2, 3)
+ORD3 = orders_for(2, 2, 3, sidx3)
+mb3 = run_case(2, 2, 3, ORD3["screw+"], 0.5)
+check("E1 [1e-15] many-body: 2x2x2 (max|Im h| %.3f, dim 56), one order on 2x2x3 (dim 792); Lueders "
+      "tree over all 2^V leaves, 4 orders, tau 0.5 and 2.0: vs one-particle kernel %.1e, invisible-"
+      "formation formula %.1e, K^2-K %.1e; 2x2x3 %.1e"
+      % (np.abs(hb.imag).max(), max(np.abs(r["law_mb"] - r["law1"]).max() for r in mb.values()),
+         max(np.abs(r["law_mb"] - r["law_inv"]).max() for r in mb.values()),
+         max(r["K2"] for r in mb.values()), np.abs(mb3["law_mb"] - mb3["law1"]).max()),
+      max(np.abs(r["law_mb"] - r["law1"]).max() for r in mb.values()) < 1e-15
+      and max(np.abs(r["law_mb"] - r["law_inv"]).max() for r in mb.values()) < 1e-15
+      and max(r["K2"] for r in mb.values()) < 1e-14
+      and all(abs(r["trK"] - 5.0) < 1e-12 and abs(r["sum_mb"] - 1.0) < 1e-12 for r in mb.values())
+      and np.abs(mb3["law_mb"] - mb3["law1"]).max() < 1e-15 and abs(mb3["trK"] - 7.0) < 1e-12)
+check("E2 [exact] T-pair many-body, 2x2x2 screw+: tree law of conj(h)+conj(state) at +0.5 = tree "
+      "law of h at -0.5, %.1e; against h at +0.5 the laws differ by TV %.6f"
+      % (np.abs(mb_a["law_mb"] - mb_b["law_mb"]).max(),
+         0.5 * np.abs(mb[("screw+", 0.5)]["law_mb"] - mb_b["law_mb"]).sum()),
+      np.abs(mb_a["law_mb"] - mb_b["law_mb"]).max() == 0.0
+      and abs(0.5 * np.abs(mb[("screw+", 0.5)]["law_mb"] - mb_b["law_mb"]).sum() - 0.393394) < 1e-6)
+
+
+# ==================================================== F. T4: the record-time vortex of PR #7935
+I2 = np.eye(2, dtype=complex)
+S1 = np.array([[0, 1], [1, 0]], dtype=complex)
+S2 = np.array([[0, -1j], [1j, 0]], dtype=complex)
+S3 = np.array([[1, 0], [0, -1]], dtype=complex)
+A1, A2, A3, A4 = np.kron(S1, S1), np.kron(S1, S2), np.kron(S1, S3), np.kron(S2, I2)
+B4 = A1 @ A2 @ A3 @ A4
+GAM = [np.kron(s, B4) for s in (S1, S2, S3)] + [np.kron(I2, a) for a in (A1, A2, A3, A4)]
+CHI8 = np.kron(I2, B4)
+M_DEF, R_S, R_SPACE = 0.8, 1.0, 1.0
+
+
+def chain_ops(n):                                                    # h5_vortex.py::chain_ops
+    k = np.zeros((n, n), dtype=complex); lap = np.zeros((n, n), dtype=complex)
+    for s_ in range(n - 1):
+        k[s_, s_ + 1] += -0.5j; k[s_ + 1, s_] += 0.5j
+        lap[s_, s_] += 0.5; lap[s_ + 1, s_ + 1] += 0.5; lap[s_, s_ + 1] += -0.5; lap[s_ + 1, s_] += -0.5
+    lap[0, 0] += 0.5; lap[n - 1, n - 1] += 0.5
+    return k, lap
+
+
+def H8(n, m1, m2, p):                                                      # h5_vortex.py::H8
+    k1, l1 = chain_ops(n); e = np.eye(n, dtype=complex)
+    K1, K2, L = np.kron(k1, e), np.kron(e, k1), np.kron(l1, e) + np.kron(e, l1)
+    w_ = R_SPACE * sum(1.0 - math.cos(x) for x in p)
+    d1 = np.diag(np.asarray(m1).ravel() + w_) + R_S * L
+    d2 = np.diag(np.asarray(m2).ravel())
+    h = np.kron(K1, GAM[3]) + np.kron(K2, GAM[4]) + np.kron(d1, GAM[5]) + np.kron(d2, GAM[6])
+    for i, pi_ in enumerate(p):
+        if math.sin(pi_) != 0.0:
+            h += np.kron(np.eye(n * n, dtype=complex), math.sin(pi_) * GAM[i])
+    return h
+
+
+def prof_vortex(n, wnd=1, mag=M_DEF):                              # h5_vortex.py::prof_vortex
+    u = np.arange(n)[:, None] - (n - 1) / 2.0
+    v = np.arange(n)[None, :] - (n - 1) / 2.0
+    th = np.arctan2(v, u)
+    return mag * np.cos(wnd * th) + 0 * u, mag * np.sin(wnd * th) + 0 * u
+
+
+def internal_conj(Mx, Uu, nn):
+    """U conj(M) U+ for U = I_(nn x nn) kron Uu, without building the full kron."""
+    M4 = np.conj(Mx).reshape(nn, 8, nn, 8)
+    X = np.tensordot(Uu, M4, axes=([1], [1]))
+    return np.tensordot(X, np.conj(Uu), axes=([3], [1])).transpose(1, 0, 2, 3).reshape(8 * nn, 8 * nn)
+
+
+NV = 16
+PV = (0.1 * math.pi, 0.0, 0.0)
+mv1, mv2 = prof_vortex(NV, +1)
+HV = H8(NV, mv1, mv2, PV)
+HVa = H8(NV, mv1, -mv2, PV)
+NS2 = NV * NV
+Cint = np.kron(S2, A2 @ A3 @ A4)
+rT = float(np.abs(internal_conj(HV, Cint, NS2) - HVa).max())
+monomial = all((np.abs(Cint[i]) > 1e-12).sum() == 1 for i in range(8))
+wv, Uv = np.linalg.eigh(HV)
+u_ = np.arange(NV)[:, None] - (NV - 1) / 2.0
+v_ = np.arange(NV)[None, :] - (NV - 1) / 2.0
+rr = np.hypot(u_, v_).ravel()
+s1v = np.repeat(np.arange(NV), NV); s2v = np.tile(np.arange(NV), NV)
+core_v = rr < 3.0
+interior = (s1v >= 2) & (s1v < NV - 2) & (s2v >= 2) & (s2v < NV - 2)
+edge_v = ~interior
+phiv = np.mod(np.arctan2(u_, v_).ravel(), 2 * np.pi)
+quadv = np.floor(4 * phiv / (2 * np.pi)).astype(int)
+shell = np.maximum(np.abs(u_), np.abs(v_)).ravel()
+Vint = math.cos(PV[0]) * GAM[0] + R_SPACE * math.sin(PV[0]) * GAM[5]
+
+
+def site_density(vec):                                          # h5_vortex.py::site_density
+    return (np.abs(vec.reshape(NS2, 8)) ** 2).sum(1)
+
+
+def internal_exp(vec, Op):
+    r = vec.reshape(NS2, 8)
+    return float(np.real(np.einsum("ai,ij,aj->", np.conj(r), Op, r)))
+
+
+light = [k for k in range(HV.shape[0]) if abs(abs(wv[k]) - math.sin(PV[0])) < 0.05]
+vm = []
+for k in light:
+    psi = Uv[:, k]; d = site_density(psi)
+    vm.append(dict(E=float(wv[k]), chi=internal_exp(psi, CHI8), core=float(d[core_v].sum()),
+                   edge=float(d[edge_v].sum()), v=internal_exp(psi, Vint), psi=psi))
+INT = [m for m in vm if m["E"] > 0 and m["chi"] > 0][0]
+EDG = [m for m in vm if m["E"] > 0 and m["chi"] < 0][0]
+check("F1 [exact] PR #7935 vortex, N 16, Cl(7), M 0.8, p (0.1pi,0,0), dim 2048, sea 1024: anti-"
+      "vortex = C conj(H) C+, site-indep C = s2 x a2a3a4, %.1e, monomial %s; light modes |E| %.6f, "
+      "CHI %+.0f core %.3f, %+.0f edge %.3f, both +x, v %+.4f"
+      % (rT, monomial, math.sin(PV[0]), INT["chi"], INT["core"], EDG["chi"], EDG["edge"], INT["v"]),
+      rT == 0.0 and monomial and int((wv < 0).sum()) == 1024 and abs(INT["chi"] - 1) < 1e-5
+      and abs(EDG["chi"] + 1) < 1e-5 and abs(INT["core"] - 0.965) < 1e-3 and abs(EDG["edge"] - 0.991) < 1e-3
+      and abs(INT["v"] - 0.9511) < 1e-4 and abs(EDG["v"] - 0.9511) < 1e-4)
+
+HVsp = sp.csr_matrix(HV)
+HVasp = sp.csr_matrix(HVa)
+AV = float(np.abs(HVsp).sum(axis=1).max())
+
+
+def restrict_modes(Hs_, rec_sites):                            # h5_vortex.py::restrict_modes
+    keep = np.ones(Hs_.shape[0]); keep.reshape(NS2, 8)[rec_sites, :] = 0.0
+    D = sp.diags(keep)
+    return (D @ Hs_ @ D).tocsr()
+
+
+def vsweep(Hs_, sched, tau, X):                                 # h5_vortex.py::sweep_forward
+    rec = np.zeros(NS2, bool); Y = X.copy()
+    for i, S in enumerate(sched):
+        rec[S] = True
+        if i == len(sched) - 1:
+            break
+        Y = expm_apply(restrict_modes(Hs_, rec), tau, Y, AV)
+    return Y
+
+
+def vschedule(kind, s=+1, pitch=0, direction=+1):                  # h5_vortex.py::schedule
+    t = s1v.astype(float) if kind == "plane" else shell - s * pitch * (quadv + 0.5) / 4.0
+    t = np.round(t * 4) / 4
+    sched = [np.flatnonzero(t == tv_) for tv_ in np.unique(t)]
+    return sched[::-1] if direction < 0 else sched
+
+
+permS = np.zeros(NS2, int)
+for a_ in range(NV):
+    for b_ in range(NV):
+        permS[a_ * NV + b_] = (NV - 1 - a_) * NV + b_
+VSW = {"plane+": vschedule("plane")}
+for pitch in (2, 4, 8):
+    for s_, sn in ((+1, "+"), (-1, "-")):
+        VSW["spiral%s p%d out" % (sn, pitch)] = vschedule("spiral", s_, pitch)
+mir_ok = all(schedule_key([np.sort(permS[S]) for S in VSW["spiral+ p%d out" % pp]])
+             == schedule_key(VSW["spiral- p%d out" % pp]) for pp in (2, 4, 8))
+VR = {}
+for name in VSW:
+    for mn, m in (("interior", INT), ("edge", EDG)):
+        taus = (0.5, 0.1, 2.0) if name == "plane+" else (0.5,)
+        for t_ in taus:
+            VR[(name, t_, mn)] = (site_density(vsweep(HVsp, VSW[name], t_, m["psi"][:, None])[:, 0]),
+                                  site_density(vsweep(HVsp, VSW[name], -t_, m["psi"][:, None])[:, 0]))
+dmax = max(abs(float(a[core_v].sum() - b[core_v].sum())) for a, b in VR.values())
+dmaxe = max(abs(float(a[edge_v].sum() - b[edge_v].sum())) for a, b in VR.values())
+psiT = (Cint @ np.conj(INT["psi"]).reshape(NS2, 8).T).T.reshape(8 * NS2)
+eT = float(np.abs(site_density(vsweep(HVasp, VSW["plane+"], 0.5, psiT[:, None])[:, 0]) - VR[("plane+", 0.5, "interior")][1]).max())
+check("F2 [1e-14] vortex registration exactly time-even: both modes, plane sweep and outward "
+      "spirals p 2/4/8, both senses, tau 0.1/0.5/2.0, O(+tau) = O(-tau) to %.1e core, %.1e edge; "
+      "T-partner %.1e"
+      % (dmax, dmaxe, eT),
+      dmax < 1e-14 and dmaxe < 1e-14 and eT < 1e-16 and mir_ok)
+
+NC12 = 12
+mc1, mc2 = prof_vortex(NC12, +1)
+cert = []
+for pc in ((0.1 * math.pi, 0.0, 0.0), (0.1 * math.pi, 0.06 * math.pi, 0.03 * math.pi)):
+    Hc = H8(NC12, mc1, mc2, pc)
+    ps = np.array([math.sin(x) for x in pc]); ps = ps / np.linalg.norm(ps)
+    helint = np.kron(ps[0] * S1 + ps[1] * S2 + ps[2] * S3, np.eye(4))
+    nn = NC12 * NC12
+    rec = np.zeros(nn, bool); rec[: nn // 3] = True
+    keep = np.ones(8 * nn); keep.reshape(nn, 8)[rec, :] = 0.0
+    HcR = keep[:, None] * Hc * keep[None, :]
+    hel = np.kron(np.eye(nn), helint)
+    c1 = float(np.abs(Hc @ hel - hel @ Hc).max()); c2 = float(np.abs(HcR @ hel - hel @ HcR).max())
+    k1, l1 = chain_ops(NC12); e = np.eye(NC12, dtype=complex)
+    K1, K2, L = np.kron(k1, e), np.kron(e, k1), np.kron(l1, e) + np.kron(e, l1)
+    w_ = R_SPACE * sum(1.0 - math.cos(x) for x in pc)
+    D4 = (np.kron(K1, A1) + np.kron(K2, A2) + np.kron(np.diag(mc1.ravel() + w_) + R_S * L, A3)
+          + np.kron(np.diag(mc2.ravel()), A4))
+    spn = math.sqrt(sum(math.sin(x) ** 2 for x in pc))
+    keep4 = np.ones(4 * nn); keep4.reshape(nn, 4)[rec, :] = 0.0
+    res = []
+    for lam in (+1, -1):
+        hl = lam * spn * np.kron(np.eye(nn), B4) + D4
+        hlR = keep4[:, None] * hl * keep4[None, :]
+        M4a = np.conj(hl).reshape(nn, 4, nn, 4)
+        M4b = np.conj(hlR).reshape(nn, 4, nn, 4)
+        UU = A1 @ A4
+        for M4x, tgt in ((M4a, hl), (M4b, hlR)):
+            X = np.tensordot(UU, M4x, axes=([1], [1]))
+            Y = np.tensordot(X, np.conj(UU), axes=([3], [1])).transpose(1, 0, 2, 3).reshape(4 * nn, 4 * nn)
+            res.append(float(np.abs(Y - tgt).max()))
+    wD, VD = np.linalg.eigh(D4)
+    UU = A1 @ A4
+    ovs = []
+    for k in np.argsort(np.abs(wD))[:2]:
+        ph = VD[:, k]
+        uph = (UU @ np.conj(ph).reshape(nn, 4).T).T.reshape(4 * nn)
+        ovs.append(abs(complex(np.vdot(ph, uph))))
+    cert.append((c1, c2, max(res), min(ovs)))
+check("F3 [exact] mechanism at N 12, both momenta: helicity site-diagonal, [H, hel] %.1e, [H_R, "
+      "hel] %.1e; U = a1a4 gives U conj(h_lam) U+ = h_lam at %.1e full and restricted, both lam; "
+      "light modes have |<phi|U conj phi>| %.4f"
+      % (max(c[0] for c in cert), max(c[1] for c in cert), max(c[2] for c in cert), min(c[3] for c in cert)),
+      max(c[0] for c in cert) < 1e-16 and max(c[1] for c in cert) < 1e-16
+      and max(c[2] for c in cert) == 0.0 and min(c[3] for c in cert) > 1 - 1e-9)
+
+spir = {pp: (float(VR[("spiral+ p%d out" % pp, 0.5, "interior")][0][core_v].sum()),
+             float(VR[("spiral- p%d out" % pp, 0.5, "interior")][0][core_v].sum())) for pp in (2, 4, 8)}
+edge_sp = (float(VR[("spiral+ p2 out", 0.5, "edge")][0][edge_v].sum()),
+           float(VR[("spiral- p2 out", 0.5, "edge")][0][edge_v].sum()))
+Pi = np.zeros((NS2, NS2)); Pi[permS, np.arange(NS2)] = 1.0
+Hmir = np.kron(Pi, np.eye(8)) @ HV @ np.kron(Pi, np.eye(8)).T
+Hm1 = H8(NV, -mv1, mv2, PV)
+Uu = GAM[1] @ GAM[3]
+M4 = Hmir.reshape(NS2, 8, NS2, 8)
+Xc = np.tensordot(Uu, M4, axes=([1], [1]))
+Hmc = np.tensordot(Xc, np.conj(Uu), axes=([3], [1])).transpose(1, 0, 2, 3).reshape(8 * NS2, 8 * NS2)
+rm1 = float(np.abs(Hmc - Hm1).max()); rmv = float(np.abs(Hmc - HV).max()); rma = float(np.abs(Hmc - HVa).max())
+check("F4 [1e-4] record-time mirror of the Wilson vortex = m1 -> -m1 up to G2G4 (%.1e), not the "
+      "vortex (%.1f) or anti-vortex (%.1f); spiral+/spiral- core odds %.4f/%.4f, %.4f/%.4f, "
+      "%.4f/%.4f at pitch 2/4/8, edge %.4f/%.4f"
+      % (rm1, rmv, rma, spir[2][0], spir[2][1], spir[4][0], spir[4][1], spir[8][0], spir[8][1],
+         edge_sp[0], edge_sp[1]),
+      rm1 < 1e-14 and rmv > 1.0 and rma > 1.0 and abs(spir[2][0] - 0.9196) < 1e-4
+      and abs(spir[2][1] - 0.9469) < 1e-4 and abs(spir[4][0] - 0.9473) < 1e-4
+      and abs(spir[4][1] - 0.9605) < 1e-4 and abs(spir[8][0] - 0.8979) < 1e-4
+      and abs(spir[8][1] - 0.9459) < 1e-4 and abs(edge_sp[0] - 0.9909) < 1e-4
+      and abs(edge_sp[0] - edge_sp[1]) < 1e-4)
+del HV, HVa, Hmir, Hmc, Hm1, Uv
+
+
+# ============================================ G. T5: can a covariant rule select the sweep?
+DIRS = [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)]
+OPEN = 2
+
+
+def group(proper_only):                                                  # h5_rules.py::group
+    out = []
+    for Pm in itertools.permutations(range(3)):
+        for sg in itertools.product((1, -1), repeat=3):
+            M = np.zeros((3, 3), int)
+            for i in range(3):
+                M[i, Pm[i]] = sg[i]
+            d = int(round(np.linalg.det(M)))
+            if proper_only and d != 1:
+                continue
+            out.append((M, d))
+    return out
+
+
+G24, G48 = group(True), group(False)
+
+
+def dir_perm(M, offs=DIRS):                                           # h5_rules.py::dir_perm
+    return [offs.index(tuple(int(x) for x in (M @ np.array(d)))) for d in offs]
+
+
+PROFS = list(itertools.product((OPEN, 0, 1), repeat=6))
+
+
+def act(M, prof):                                                          # h5_rules.py::act
+    pp = dir_perm(M)
+    out = [None] * 6
+    for i in range(6):
+        out[pp[i]] = prof[i]
+    return tuple(out)
+
+
+def orbits(Gr):                                                        # h5_rules.py::orbits
+    seen, orbs = {}, []
+    for pr in PROFS:
+        if pr in seen:
+            continue
+        orb = set(act(M, pr) for M, d in Gr)
+        for q in orb:
+            seen[q] = len(orbs)
+        orbs.append(orb)
+    return orbs, seen
+
+
+ORB24, OID24 = orbits(G24)
+ORB48, OID48 = orbits(G48)
+chiral = [i for i, o in enumerate(ORB24) if len(o) != len(ORB48[OID48[next(iter(o))]])]
+A_prof = (0, 1, 0, OPEN, 1, OPEN)
+A_id = OID24[A_prof]
+B_id = [i for i in chiral if i != A_id][0]
+PW6 = 3 ** np.arange(6)
+OID_ARR = np.zeros(729, dtype=int)
+for pr, oi in OID24.items():
+    OID_ARR[int(sum(pr[i] * PW6[i] for i in range(6)))] = oi
+
+
+def burnside(offs):                                                 # h5_rules.py::burnside
+    res = {}
+    for nm, Gr in (("proper", G24), ("full", G48)):
+        tot = 0
+        for M, d in Gr:
+            img = dir_perm(M, offs)
+            seen = [False] * len(offs); cyc = 0
+            for i in range(len(offs)):
+                if seen[i]:
+                    continue
+                cyc += 1; j = i
+                while not seen[j]:
+                    seen[j] = True; j = img[j]
+            tot += 3 ** cyc
+        res[nm] = tot // len(Gr)
+    return res
+
+
+WIN = [("NN", DIRS),
+       ("NN+2e", DIRS + [(2 * a_, 2 * b_, 2 * c_) for (a_, b_, c_) in DIRS]),
+       ("NN+fd", DIRS + [t for t in itertools.product((-1, 0, 1), repeat=3) if sum(abs(x) for x in t) == 2]),
+       ("shell", [t for t in itertools.product((-1, 0, 1), repeat=3) if any(t)])]
+BW = [burnside(o) for nm, o in WIN]
+check("G1 [exact] 729 profiles give %d proper and %d full orbits, so one chiral pair; Burnside: %d "
+      "chiral pairs on the 12-offset window, %d on 18-offset, %d on the 26-shell, none constructed "
+      "here"
+      % (len(ORB24), len(ORB48), BW[1]["proper"] - BW[1]["full"], BW[2]["proper"] - BW[2]["full"],
+         BW[3]["proper"] - BW[3]["full"]),
+      len(ORB24) == 57 and len(ORB48) == 56 and len(chiral) == 2
+      and BW[0] == {"proper": 57, "full": 56} and BW[1]["proper"] - BW[1]["full"] == 7140
+      and BW[2]["proper"] - BW[2]["full"] == 7960311 and BW[3]["proper"] - BW[3]["full"] == 52932198249)
+
+
+def cluster(L):                                                       # h5_rules.py::cluster
+    sites = [(x, y, z) for x in range(L[0]) for y in range(L[1]) for z in range(L[2])]
+    idx = {s: i for i, s in enumerate(sites)}
+    nbr = [[idx.get((s[0] + d[0], s[1] + d[1], s[2] + d[2]), -1) for d in DIRS] for s in sites]
+    centre = np.array([(l - 1) / 2 for l in L])
+    return dict(L=L, sites=sites, idx=idx, nbr=np.array(nbr), V=len(sites),
+                R=np.array(sites, float) - centre, centre=centre)
+
+
+def step_pseudoscalar_table(C):                      # h5_rules.py::step_pseudoscalar_table
+    V = C["V"]; Rr = C["R"]
+    D = np.linalg.norm(Rr[:, None, :] - Rr[None, :, :], axis=2)
+    det3 = np.zeros((V, V, V))
+    for v in range(V):
+        det3[:, :, v] = np.einsum("ui,wj,ijk,k->uw", Rr, Rr,
+                                  np.array([[[int((i - j) * (j - k) * (k - i) / 2) for k in range(3)]
+                                             for j in range(3)] for i in range(3)], float), Rr[v])
+    E = all_patterns(V)
+    tab = np.zeros((1 << V, V))
+    for v in range(V):
+        Av = det3[:, :, v] * (D[:, v][:, None] < D[:, v][None, :])
+        tab[:, v] = ((E @ Av) * E).sum(1)
+    return tab
+
+
+def dp_count(C, allow0, allow1, ftab):                               # h5_rules.py::dp_count
+    V = C["V"]
+    pw3 = (3 ** np.arange(V)).astype(np.int64)
+    cnt = np.zeros(int(3 ** V), dtype=np.int64)
+    xis = np.zeros(int(3 ** V))
+    cnt[0] = 1
+    cur = np.zeros(1, dtype=np.int64)
+    dead = 0
+    pw2 = (1 << np.arange(V)).astype(np.int64)
+    for lev in range(V):
+        digits = (cur[:, None] // pw3[None, :]) % 3
+        ext = np.concatenate([digits, np.zeros((len(cur), 1), dtype=np.int64)], axis=1)
+        mint = ((digits > 0) * pw2).sum(1)
+        c0, x0 = cnt[cur], xis[cur]
+        moved = np.zeros(len(cur), dtype=bool)
+        nxt = []
+        for v in range(V):
+            free = digits[:, v] == 0
+            if not free.any():
+                continue
+            nb = ext[:, C["nbr"][v]]
+            code = (np.where(nb == 0, 2, nb - 1) * PW6).sum(1)
+            orb = OID_ARR[code]
+            f = ftab[mint, v]
+            for a_, allow in ((0, allow0), (1, allow1)):
+                sel = free & allow[orb]
+                if not sel.any():
+                    continue
+                moved |= sel
+                tgt = cur[sel] + (a_ + 1) * pw3[v]
+                cnt[tgt] += c0[sel]
+                xis[tgt] += x0[sel] + c0[sel] * f[sel]
+                nxt.append(tgt)
+        dead += int(c0[~moved].sum())
+        cur = np.unique(np.concatenate(nxt)) if nxt else np.zeros(0, dtype=np.int64)
+        if len(cur) == 0:
+            break
+    total = int(cnt[cur].sum()) if len(cur) else 0
+    xi = float(xis[cur].sum()) if len(cur) else float("nan")
+    return total, dead, (xi / total if total else float("nan")), cnt, cur
+
+
+def final_law_asym(C, cnt, fin):                              # h5_rules.py::final_law_asym
+    V = C["V"]
+    pw3 = (3 ** np.arange(V)).astype(np.int64)
+    total = int(cnt[fin].sum())
+    digits = (fin[:, None] // pw3[None, :]) % 3
+    out = []
+    for M, d in G48:
+        if d != -1:
+            continue
+        perm, ok = [], True
+        for s_ in C["sites"]:
+            img = M @ (np.array(s_) - C["centre"]) + C["centre"]
+            t = tuple(int(round(x)) for x in img)
+            if t not in C["idx"] or np.abs(img - np.array(t)).max() > 1e-9:
+                ok = False; break
+            perm.append(C["idx"][t])
+        if not ok:
+            continue
+        pm = np.array(perm)
+        img_cfg = (digits * pw3[pm]).sum(1)
+        out.append(0.5 * float(np.abs(cnt[fin].astype(float) - cnt[img_cfg].astype(float)).sum()) / total)
+    return out
+
+
+def screw_orders(C):                                            # h5_rules.py::screw_orders
+    L = C["L"]
+    rp = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    rm = [(0, 0), (0, 1), (1, 1), (1, 0)]
+    return ([C["idx"][(x, y, z)] for z in range(L[2]) for (x, y) in rp],
+            [C["idx"][(x, y, z)] for z in range(L[2]) for (x, y) in rm])
+
+
+def xi_of_order(order, ftab):                                    # h5_rules.py::xi_of_order
+    m, tot = 0, 0.0
+    for v in order:
+        tot += ftab[m, v]; m |= 1 << v
+    return tot
+
+
+def menus_of(assign):                                          # h5_rules.py::rule_menus
+    a0 = np.ones(len(ORB24), dtype=bool)
+    a1 = np.ones(len(ORB24), dtype=bool)
+    for i, menu in assign.items():
+        a0[i] = 0 in menu
+        a1[i] = 1 in menu
+    return a0, a1
+
+
+def r3(nrec_max):                                                           # h5_rules.py::r3
+    d = {}
+    for i, o in enumerate(ORB24):
+        pr = next(iter(o))
+        if sum(1 for x in pr if x != OPEN) > nrec_max and i != A_id:
+            d[i] = ()
+    return d
+
+
+RULES = [("R0", {}), ("R1", {A_id: (0,), B_id: (1,)}), ("R2", {B_id: ()}), ("R2m", {A_id: ()}),
+         ("R3", r3(2)), ("R3m", {**{k: v for k, v in r3(2).items() if k != B_id}, A_id: ()}),
+         ("R4", {**r3(2), A_id: ()})]
+
+
+def order_completions(C, a0, a1, order):                       # h5_rules.py::admissible_count
+    V = C["V"]
+    vals = ((np.arange(1 << V)[:, None] >> np.arange(V)[None, :]) & 1)
+    cfg = np.zeros((1 << V, V), dtype=np.int64)
+    alive = np.ones(1 << V, dtype=bool)
+    for j, v in enumerate(order):
+        ext = np.concatenate([cfg, np.zeros((1 << V, 1), dtype=np.int64)], axis=1)
+        nb = ext[:, C["nbr"][v]]
+        orb = OID_ARR[(np.where(nb == 0, 2, nb - 1) * PW6).sum(1)]
+        a = vals[:, j]
+        alive &= np.where(a == 0, a0[orb], a1[orb])
+        cfg[:, v] = a + 1
+    return int(alive.sum())
+
+
+RES = {}
+for L in ((2, 2, 2), (2, 2, 3)):
+    C = cluster(L)
+    ftab = step_pseudoscalar_table(C)
+    sp_, sm_ = screw_orders(C)
+    RES[L] = dict(xi=(xi_of_order(sp_, ftab), xi_of_order(sm_, ftab),
+                      xi_of_order(list(range(C["V"])), ftab)), rules={}, C=C, ftab=ftab,
+                  orders=(sp_, sm_, list(range(C["V"]))))
+    for rname, assign in RULES:
+        if L == (2, 2, 3) and rname in ("R2m", "R3m"):
+            continue
+        a0, a1 = menus_of(assign)
+        total, dead, xim, cnt, fin = dp_count(C, a0, a1, ftab)
+        asym = max(final_law_asym(C, cnt, fin)) if total else float("nan")
+        RES[L]["rules"][rname] = (total, dead, xim, asym)
+    RES[L]["r5"] = {rn: tuple(order_completions(C, *menus_of(dict(RULES)[rn]), o) for o in RES[L]["orders"])
+                    for rn in ("R2", "R3", "R3m")}
+
+cu, sl = RES[(2, 2, 2)], RES[(2, 2, 3)]
+check("G2 [exact] cube 2x2x2, 6561 cfgs, Xi(screw+/-/raster) %+.1f/%+.1f/%+.1f: R0/R1/R2/R2m each "
+      "give %d complete paths = 8! x 2^8, 0 dead, mean Xi %+.3e, asymmetry %.0e; R3/R3m/R4 give 0 "
+      "complete, %d dead"
+      % (cu["xi"][0], cu["xi"][1], cu["xi"][2], cu["rules"]["R0"][0], cu["rules"]["R1"][2],
+         cu["rules"]["R1"][3], cu["rules"]["R3"][1]),
+      abs(cu["xi"][0] - 1.0) < 1e-12 and abs(cu["xi"][1] + 1.0) < 1e-12 and abs(cu["xi"][2]) < 1e-12
+      and all(cu["rules"][r][0] == 10321920 and cu["rules"][r][1] == 0 and abs(cu["rules"][r][2]) < 1e-12
+              and cu["rules"][r][3] < 1e-12 for r in ("R0", "R1", "R2", "R2m"))
+      and all(cu["rules"][r][0] == 0 and cu["rules"][r][1] == 1636608 for r in ("R3", "R3m", "R4")))
+
+check("G3 [exact] slab 2x2x3, 531441 cfgs, Xi(screw+/-) %+.1f/%+.1f: R0 %d = 12! x 2^12, 0 dead; "
+      "R1, R2 %d; R3 %d with %d dead; R4 0; mean Xi %+.3e for all; mirror asymmetry %.0e, %.3e, "
+      "%.3e"
+      % (sl["xi"][0], sl["xi"][1], sl["rules"]["R0"][0], sl["rules"]["R1"][0], sl["rules"]["R3"][0],
+         sl["rules"]["R3"][1], max(abs(sl["rules"][r][2]) for r in ("R0", "R1", "R2", "R3")),
+         sl["rules"]["R0"][3], sl["rules"]["R1"][3], sl["rules"]["R3"][3]),
+      abs(sl["xi"][0] - 6.0) < 1e-12 and abs(sl["xi"][1] + 6.0) < 1e-12
+      and sl["rules"]["R0"][0] == 1961990553600 and sl["rules"]["R0"][1] == 0
+      and sl["rules"]["R1"][0] == 1771922718720 and sl["rules"]["R2"][0] == 1771922718720
+      and sl["rules"]["R2"][1] == 39063306240 and sl["rules"]["R3"][0] == 1405870080
+      and sl["rules"]["R3"][1] == 19345547712 and sl["rules"]["R4"][0] == 0
+      and max(abs(sl["rules"][r][2]) for r in ("R0", "R1", "R2", "R3")) < 1e-12
+      and sl["rules"]["R0"][3] < 1e-12 and abs(sl["rules"]["R1"][3] - 6.845e-2) < 1e-5
+      and abs(sl["rules"]["R3"][3] - 5.154e-1) < 1e-4)
+
+check("G4 [exact] under R2 all %d value assignments complete screw+, screw- and raster alike on the"
+      " slab, all %d on the cube; under R3/R3m none completes any, %s"
+      % (sl["r5"]["R2"][0], cu["r5"]["R2"][0],
+         "%d/%d/%d and %d/%d/%d" % (sl["r5"]["R3"] + sl["r5"]["R3m"])),
+      sl["r5"]["R2"] == (4096, 4096, 4096) and cu["r5"]["R2"] == (256, 256, 256)
+      and sl["r5"]["R3"] == (0, 0, 0) and sl["r5"]["R3m"] == (0, 0, 0))
+
+
+def census(offs):                                                      # h5_rules2.py::census
+    n = len(offs)
+    perms = [dir_perm(M, offs) for M, d in G24]
+    pinv = dir_perm(-np.eye(3, dtype=int), offs)
+    pw = 3 ** np.arange(n)
+    allp = ((np.arange(3 ** n)[:, None] // pw[None, :]) % 3).astype(np.int8)
+
+    def canon(arr):
+        best = None
+        for pp in perms:
+            img = np.empty_like(arr); img[:, pp] = arr
+            code = (img.astype(np.int64) * pw).sum(1)
+            best = code if best is None else np.minimum(best, code)
+        return best
+    reps = np.unique(canon(allp))
+    rep_arr = ((reps[:, None] // pw[None, :]) % 3).astype(np.int8)
+    img = np.empty_like(rep_arr); img[:, pinv] = rep_arr
+    can_sigma = canon(img)
+    F = rep_arr.copy(); F[F == 0] = 9; F[F == 1] = 0; F[F == 9] = 1
+    can_F = canon(F)
+    ch = can_sigma != reps
+    return len(reps), int(ch.sum()), int((ch & (can_F == reps)).sum()), int((ch & (can_F != reps) & (can_F != can_sigma)).sum())
+
+
+cen6 = census(DIRS)
+cen12 = census(DIRS + [(2 * a_, 2 * b_, 2 * c_) for (a_, b_, c_) in DIRS])
+counts = {"A": 0, "B": 0, "achiral": 0}
+pair_ok = True
+for ax, ay, ap, am in itertools.product((0, 1), repeat=4):
+    o = OID24[(ax, OPEN, ay, OPEN, ap, am)]
+    oz = OID24[(ax, OPEN, ay, OPEN, am, ap)]
+    counts["A" if o == A_id else ("B" if o == B_id else "achiral")] += 1
+    if (o == A_id and oz != B_id) or (o == B_id and oz != A_id):
+        pair_ok = False
+check("G5 [exact] value flip fixes A and B (%d of %d chiral orbits at NN); slab middle-corner "
+      "combinations split %s, z-pair reversal maps A to B at every one (%s); 12-offset: %d orbits, "
+      "%d chiral, %d F-fixed, %d moved"
+      % (cen6[2], cen6[1], "A %d, B %d, achiral %d" % (counts["A"], counts["B"], counts["achiral"]),
+         pair_ok, cen12[0], cen12[1], cen12[2], cen12[3]),
+      cen6 == (57, 2, 2, 0) and cen12[0] == 23355 and cen12[1] == 14280 and cen12[2] == 128
+      and cen12[3] == 14144 and counts == {"A": 2, "B": 2, "achiral": 12} and pair_ok)
+
+print("SUMMARY: a directed sweep separates a mover from its T-partner at order one and is blind to "
+      "screw sense.  [%.1f s]" % (time.time() - T0))
+print("TOTAL: PASS=%d FAIL=%d" % (PASS, FAIL))
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Bounded theorem note + exact runner + cache on the dynamical form of the owner's question: could chirality come from a mirrored configuration of neighbourhood maps applied in record time, a screw-like sweep of formation? PR #7989 had shown that every static rule, chiral or not, gives a mover and its time-reversal partner identical record laws; a time-directed sweep is the one construction that escapes that argument, because the framework's time is the accumulation of records. **A time-directed sweep separates a mover from its time-reversal partner at order one, and its screw sense registers nothing: what the records register is the direction of motion, the record-side image of a current, not a chirality.** Under Model A with the rotated kernel of PR #7986, a plane sweep along `+z` on the string plane of PR #7949 registers the string's core right-mover at the core with odds `0.137` and the anti-string's core left-mover, its time-reversal partner, with odds `0.605` under the same sweep: `Δ_core = −0.468` at `τ = 0.5`, with the transfer to the ring `Δ_ring = +0.548` (the mover runs from the front, cannot reflect on the chiral core branch, and hands its weight to the boundary). It is exactly the `τ`-odd part of the law (the string at `+τ` equals the anti-string at `−τ`, `TV = 0.0`, confirmed by a complete many-body tree on two small blocks), grows faster than linearly at small `τ` (`Δ/τ = −0.22, −0.53, −0.81` at `τ = 0.05, 0.1, 0.25`), and grows with string length (`−0.468 → −0.526` for `L_z = 24 → 96`). **The screw sense contributes exactly nothing on the string**: `Δ(screw+) − Δ(screw−) ≤ 2e-16` at every pitch, the densities pointwise mirror images to `4e-17`, because the string is its own mirror image and the mirror maps one screw onto the other; off the mirror plane the screw difference is a boundary effect falling like the ring weight. Three exact identities fix the character of the bias: `C₂(x)∘T` is an anti-unitary symmetry of the string with `Δ(S) = −Δ(C₂(x) S)`, so the bias averages to exactly zero over any closed family of orders; the rotated kernel is even under `σ_z × particle-hole × (τ → −τ)`, so the mirror partner of the right-moving particle is the right-moving hole with the arrow of record time reversed; and on the record-time vortex of PR #7935 registration is exactly time-even for every sweep (helicity site-diagonal and conserved; the anti-vortex is `C·conj(H)·C†` with a monomial site-independent `C`, answering PR #7989's open item), with the spiral sense registering only a few-percent parity-odd, time-even difference (`0.9196` vs `0.9469`). **No chiral nearest-neighbour rule can select the sweep**: exact dynamic-programming counts over all `3^V` configurations on the cube and slab give every chiral rule, with or without empty menus, a mean order-pseudoscalar of exactly zero; the readable class admits every order; the rule's handedness goes into record values, never into the order. Toward the weak sector: the bias is parity-odd along the sweep and time-odd, where a chiral coupling must be parity-odd and time-even; it is a supplied directed order, not law content.

- `docs/A_TIME_DIRECTED_FORMATION_SWEEP_REGISTERS_THE_DIRECTION_OF_MOTION_AT_ORDER_ONE_AND_ITS_SCREW_SENSE_REGISTERS_NOTHING_THE_RECORD_SIDE_IMAGE_OF_A_CURRENT_NOT_A_CHIRALITY_BOUNDED_NOTE_2026-09-05.md` (246 lines)
- `scripts/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.py` (`TOTAL: PASS=25 FAIL=0`, 63 s; the string sparse, the many-body tree complete on two small blocks, the rule census exact; no seeds; stdout 5,498 characters)
- `logs/runner-cache/directed_formation_sweep_direction_of_motion_not_handedness_check_2026_09_05.txt`

## Theorems

- **T1** the directed sweep and the order-one separation, its `τ`- and length-dependence, the many-body check; **T2** the exact zero of the screw sense; **T3** the three exact identities; **T4** the record-time vortex (time-even registration, the anti-vortex identity, the spiral difference); **T5** the rule census (no chiral nearest-neighbour rule selects an order).

## Boundary

- The string plane at the declared sizes, `τ` values and pitches; the record-time vortex geometry; the cube and slab for the rule census; seven declared reductions with the probe's output lines. Disagreements with the expectation stated plainly: there is no core left-mover of the same string (the core branch is chiral); the separation is order one, not small, and faster than linear at small `τ`; the screw is an exact zero; the reversal-closed average is not the right time-even control because of the seam; the vortex is exactly time-even, opposite to the string. Nothing derived from the axioms.

## Context

- Parents (open PRs): the mirror-asymmetric rule (#7989), the rotated-kernel record law (#7986), the tick (#7947), the string (#7949), the record-time vortex (#7935), the readable law (#7982), the determinantal statistics (#7883).
- The owner's idea, run as a follow-up to the third-campaign queue (2026-09-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjipjAKhSt5sjD6MM9M95k
