### PR TITLE
[physics-loop] Exact Regge reduction and positive tensor transfer bounded_theorem conditional-support

### DIFF
--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/CLAIM_STATUS_CERTIFICATE.md
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/CLAIM_STATUS_CERTIFICATE.md
@@ -1,0 +1,15 @@
+# Claim status certificate
+
+claim_id: regge_exact_reduction_positive_tensor_transfer_bounded_theorem_note_2026-09-13
+claim_type: bounded_theorem
+actual_current_surface_status: conditional-support
+conditional_surface_status: conditional-support
+source_enum: proposed_retained
+independent_review: pending
+formal_audit: deferred
+
+The source enum is an author proposal. No audited retention or landing is
+claimed. Supplied lattice, action, action orientation, time coordinate,
+source lift and tensor-section choices remain supplied. The local Hessian
+and transfer are independently formulated within one author's calculation;
+there is no external reviewer receipt. No physical axiom was changed.

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/HANDOFF.md
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/HANDOFF.md
@@ -1,0 +1,26 @@
+# Exact Regge and positive reduced transfer author handoff
+
+Base cda8b1445e21b3908a0a520710e0dae57b7bc3a3. Source campaign
+4889a58373, branch physics-loop/toe-local-formation-20260912, personally
+executed without subagents. Both main context notes are present at that base;
+the actual local geometry and transfer proofs are self-contained here.
+
+Scope: supplied unit 4D path complex and Euclidean length Regge action;
+exact Hessian/body/metric reduction, source lift and static scalar readouts;
+finite odd spatial torus with zero spatial mode removed, chosen -S_R sign,
+integer time coordinate and hyperdiagonal section for the positive tensor model.
+No nonlinear hyperdiagonal exclusion is imported as a proof premise.
+No physical matter source, clock, finite-qubit realization, nonlinear closure,
+axiom or independently audited retention is supplied.
+
+Author checks, mutation results, focused conformance and exact PR head will
+be recorded after source is frozen. Independent review is pending; no author
+landing or audit verdict is authorized by these checks.
+
+Final author package:92 checks pass in25.06s, source/input-bound cache fresh.
+Six actual mutants rejected, including a corrected exact-rational phase mutant;
+first source/failure preserved. One new graph node with two main context edges
+and three attached helpers. Manifest delta inspected. Focused vocabulary,
+compile,relative-link,whitespace,graph-row readiness and cache checks complete.
+Full pipeline,strict lint,ledger changed-evidence and independent review remain
+pending integration gates. No main merge, axiom edit or audit verdict.

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/NO_GO_DISCIPLINE_CHECKLIST.md
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/NO_GO_DISCIPLINE_CHECKLIST.md
@@ -1,0 +1,14 @@
+# Scope stress test
+
+This is a positive bounded conditional theorem, not a no-go packet.
+N1: exact geometry, source transport and Gaussian transfer are the proof routes.
+N2: supplied action, lattice, orientation and time are distinct premises.
+N3: hidden physical identifications are excluded: no Record clock or matter selector.
+N4: the exact linear source residual closes; nonlinear source compatibility remains.
+N5: no physical graviton, axiom necessity, universal action selection or priority claim.
+N6: reduced positive quantization is partial closure; it does not define the full conformal integral.
+N7: nonconstant curved tangents and other actions remain live; a chosen section is not a nonlinear solution.
+N8: the older disproved metric/readout claims remain disproved; the new coordinate map is stated explicitly.
+
+No formal negative-route quota or independent audit PASS is asserted. Exact
+coefficient checks and actual mutations are author evidence only.

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/REVIEW_HISTORY.md
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/REVIEW_HISTORY.md
@@ -1,0 +1,77 @@
+# Cold author proof pass: exact Regge reduction and reduced tensor transfer
+
+2026-09-13, completed by 03:42 UTC. The complete Block7 and Block9 derivations and their
+three exact checkers were reread. This is the same campaign author, not an
+independent source review or retention decision.
+
+The local Schlaefli sign and second-variation normalization were recomputed:
+-dA dtheta gives the displayed +tr(P h)W/4 local form. The reduced Q is
+-F/4, so the Taylor term for chosen -S_R is +F/8. With h=2X the tensor
+Gaussian is precisely I=sum[(dX)^2+r^2X^2]/2. Source lifts use Frobenius
+pairing, including twice each off-diagonal source. Null-rank dimensions were
+checked with a complex null dual vector, preserving the origin exception.
+The static readouts annihilate the full gauge plus hyperdiagonal kernel;
+this does not rehabilitate the older line-average metric map.
+
+The scalar/vector constraint proof works at t=0 and on complex shell without
+dividing by t. The positive heat-sandwich transfer uses width sinh(E), not r;
+its trace is 1/r and its Hermite spectrum is exp[-E(m+1/2)]. Finite-volume,
+nonzero spatial modes, opposite-phase reality, action sign and supplied time
+are necessary conditions. Reflection positivity applies only to the reduced
+model. Hyperdiagonal section fixing is explicitly not a vertex gauge choice
+or proof of nonlinear constraint satisfaction.
+
+Two presentation/checker cleanups were made: the coordinate order is now
+(1,2,3,0), with time last; the trace predicate checks the signed identity on
+0<z<1 instead of a redundant squared identity. An empty-product matrix-copy
+expression in the Laurent checker was simplified. No claim or coefficient
+changed. The final rerun has 12 Laurent, 32 consequence and 48 transfer named
+checks, with all 225 Laurent residual entries zero. The named counts do not
+mean independent proofs. The finite ranks and polynomial fragments support
+the analytical all-mode argument, not a global numerical certificate.
+
+Block8 was also reread: the projected uniform-shear equation has zero linear
+part and positive sum(v_x^2)/4 for the restricted real flat-metric plus hyper
+family. General nonconstant curved tangents remain outside it. The N1-N8
+scope record does not claim the formal five-failed-family quota was met.
+Keep that nonlinear result separate from the positive linear milestone.
+
+Disposition: prepare one self-contained source unit for the exact geometry,
+source/readouts, complete linear constraints and reduced tensor transfer.
+Independent review, full shared integration gates and physical matter/clock/
+nonlinear completion remain pending. No editable prompts or axioms changed.
+
+## Final packaged author checks
+
+Canonical source packaging uses callable helpers with no import-time writes.
+The complete canonical note and proof-bearing helper changes were inspected.
+Final cache:92 named checks,zero failures,25.06 seconds under180 seconds;
+all225 Laurent coefficient differences vanish. Declared source/helper/checklist/
+mutation inputs and the primary runner are bound and fresh. Six actual mutants
+were rejected. The first phase mutant also introduced Python floats; its exact
+source/failure is preserved, and the final mutant keeps rational arithmetic
+while omitting only the metric phase. No scientific finding was discarded.
+
+Vocabulary fix and report-only returned zero findings; .claude is skipped by
+that tool, so it does not certify those artifacts. All four Python sources
+compile. The fresh serialized graph has5042nodes12521edges. Its manifest
+adds exactly this one node and its two intended current-main context edges;
+all three static helper imports are attached. Graph-row forensic readiness
+and bound cache freshness passed. These are not the ledger changed-evidence
+gate or an independent scientific judgment.
+
+Conformance sections1–12: supplied object and main context identified; all
+runners declare180seconds; bounded conditional scope; positive N1–N8 scope
+checklist and actual mutation evidence; trace/proof/domain explicit; local
+geometry, direct tensor algebra and Gaussian-moment checks distinguish their
+construction paths without asserting independent authors; all helpers in the
+restricted graph; relative links and manifest checked; complete metadata and
+reproduction source; no author landing or audit; no empirical calibration or
+constant derived. Full pipeline,strict audit lint,ledger changed-evidence and
+independent source review remain shared integration gates under current
+SCIENCE_WORKFLOW and PR_CONFORMANCE section12.
+
+The final link check initially identified a displayed operator expression as a
+Markdown link to x. Replacing its square brackets with braces preserves the
+formula and fixes rendering; all nine actual relative links now resolve to
+tracked files. The source-bound cache is regenerated after this edit.

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/SOURCE_MANIFEST.json
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/SOURCE_MANIFEST.json
@@ -1,0 +1,41 @@
+{
+  "main_revision": "cda8b1445e21b3908a0a520710e0dae57b7bc3a3",
+  "sources": [
+    {
+      "path": "docs/THE_REGGE_SECOND_VARIATION_ON_THE_4D_CUBIC_COXETER_COMPLEX_CARRIES_A_NATIVE_LINEARISED_GRAVITON_BOUNDED_THEOREM_NOTE_2026-09-03.md",
+      "sha256": "aad9fa7b70fe00a18ea627248270c4d47250ff214e98d2ae2466760ad2084bf8",
+      "role": "main context or independently constructed geometry comparator; historical broad status not inherited",
+      "coverage": "notes fully read; geometry callable closure through box_action read, main not called"
+    },
+    {
+      "path": "docs/THE_FORMATION_RATE_DEFINES_THE_STATIC_REGGE_EDGE_LENGTHS_EXACTLY_REGGE_IS_THE_LATTICE_POISSON_EQUATION_AND_FORCES_NU_R_EQUAL_ONE_BOUNDED_THEOREM_NOTE_2026-09-03.md",
+      "sha256": "45105f11c6691355252339d7886f842cf2d49288cff0dfd39d0f1beb7b042fd6",
+      "role": "main context or independently constructed geometry comparator; historical broad status not inherited",
+      "coverage": "notes fully read; geometry callable closure through box_action read, main not called"
+    },
+    {
+      "path": "docs/THE_SPATIAL_HALF_OF_THE_METRIC_IS_ONE_DECLARED_WEIGHT_ON_THE_HOP_TERM_FREE_FALL_AND_LIGHT_BENDING_AT_FACTOR_TWO_BOUNDED_THEOREM_NOTE_2026-09-03.md",
+      "sha256": "c27e83f4d8f3fe21113a4f09d2f816591679854a31ba93d8d8c5ad8e23f81324",
+      "role": "main context or independently constructed geometry comparator; historical broad status not inherited",
+      "coverage": "notes fully read; geometry callable closure through box_action read, main not called"
+    },
+    {
+      "path": "scripts/frontier_cubic_coxeter_regge_second_variation_3plus1_2026_06_09.py",
+      "sha256": "537371554e1a5244875645ca600f5f01e0ccfae64530572630d934e8ea0a85ce",
+      "role": "main context or independently constructed geometry comparator; historical broad status not inherited",
+      "coverage": "notes fully read; geometry callable closure through box_action read, main not called"
+    }
+  ],
+  "primary_literature": [
+    {
+      "url": "https://arxiv.org/html/1011.3667v2",
+      "coverage": "section 6.1 through 6.11 and Appendix A through A.12 read; not full paper",
+      "role": "prior art for discrete metric and Regge reduction"
+    },
+    {
+      "url": "https://arxiv.org/pdf/2105.10808",
+      "coverage": "section IV.B.5 read, PDF pp9-10; not full paper",
+      "role": "prior art for hyperdiagonal/body elimination; action convention rederived locally"
+    }
+  ]
+}

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/TRACE_GATE.md
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/TRACE_GATE.md
@@ -1,0 +1,13 @@
+# Trace gate
+
+trace_class: upstream_support
+target_claim_id: the_regge_second_variation_on_the_4d_cubic_coxeter_complex_carries_a_native_linearised_graviton_bounded_theorem_note_2026-09-03
+target_blocker_text: Supply an all-momentum tensor reduction and a positive reduced state construction, with source and clock assumptions explicit.
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: Independent review of the self-contained linear unit, then physical source and nonlinear compatibility derivations.
+
+The nonlinear hyperdiagonal exclusion and native-matter campaign results are
+not dependencies of this milestone. Main's earlier metric/readout corrections
+are preserved. No claim of historical priority for linearized Regge gravity.

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/RESULTS.json
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/RESULTS.json
@@ -1,0 +1,73 @@
+{
+  "status": "six_actual_mutants_rejected",
+  "scope": "same-author proof discriminators; not a negative-route theorem",
+  "mutations": [
+    {
+      "name": "area_normalization",
+      "source": "scripts/regge_local_hessian_check_2026_09_13.py",
+      "old": "local+=s.trace(P*H)*W/4",
+      "new": "local+=s.trace(P*H)*W/8",
+      "original_sha256": "1e172437fca41640f4dc0e90ef4cbee8ce3ca57219327fdedecbe4f588f91188",
+      "mutated_sha256": "03453454a9fb776c4ede43d154ce2563f3310116fe987f02ee376d5f158cc546",
+      "exit_code": 1,
+      "failure": "AssertionError: [(0, 0, '3/4'), (0, 1, 'w0**2*w3**2/8 + w1**2*w3**2/8 + 1/(8*w1**2*w2**2) + 1/(8*w0**2*w2**2)'), (0, 2, '-1/4 - 1/(4*w2**2)')]",
+      "elapsed_sec": 0.8824623749824241
+    },
+    {
+      "name": "body_sign",
+      "source": "scripts/regge_local_hessian_check_2026_09_13.py",
+      "old": "C[i,idx[frozenset((a,b))]]-=(1+z[c])/2",
+      "new": "C[i,idx[frozenset((a,b))]]+=(1+z[c])/2",
+      "original_sha256": "1e172437fca41640f4dc0e90ef4cbee8ce3ca57219327fdedecbe4f588f91188",
+      "mutated_sha256": "59f47c9485d18d8bdd2463413c516e997c03a25a16bbefc86360ae97dbbf020e",
+      "exit_code": 1,
+      "failure": "AssertionError: [(0, 2, 'w0**2/(4*w2**2) + w1**2/(4*w2**2) + 1/2 + 1/(2*w2**2) + 1/(4*w1**2) + 1/(4*w0**2)'), (0, 4, 'w0**2/(4*w1**2) + 1/2 + 1/(4*w2**2) + w2**2/(4*w1**2) + 1/(2*w1**2) + 1/(4*w0**2)'), (0, 5, 'w3**2/(4*w2**2) + 1/(4*w2**2) + w3**2/(4*w1**2) + 1/(4*w1**2)')]",
+      "elapsed_sec": 0.659030792012345
+    },
+    {
+      "name": "metric_phase_removed",
+      "source": "scripts/regge_local_hessian_check_2026_09_13.py",
+      "old": "/(2*w[a]*w[b])",
+      "new": "/s.Integer(2)",
+      "original_sha256": "1e172437fca41640f4dc0e90ef4cbee8ce3ca57219327fdedecbe4f588f91188",
+      "mutated_sha256": "87d7e91214185a9bb00b82e2da4c60a81572a8ebf5563204a42e98800344c21b",
+      "exit_code": 1,
+      "failure": "AssertionError: [(0, 0, '-w0**2/4 + w0**2/(8*w2**2) + w0**2/(8*w1**2) + w0*w1/4 + w0*w2/4 - w0/(4*w2) - w0/(4*w1) - w1**2/4 + w1**2/(8*w2**2) + w1*w2/4 - w1/(4*w2) - w2**2/4 + 3/4 - 1/(4*w2**2) - w2/(4*w1) + 1/(4*w1*w2) + w2**2/(8*w1**2) - 1/(4*w1**2) - w1/(4*w0) - w2/(4*w0) + 1/(4*w0*w2) + 1/(4*w0*w1) + w1**2/(8*w0**2) + w2**2/(8*w0**2) - 1/(4*w0**2)'), (0, 1, '-w0**2*w3**2/4 + w0**2/8 + w0**2/(8*w2**2) + 3*w0*w2/8 + 3*w0*w3/8 - 3*w0/(8*w3) - 3*w0/(8*w2) - w1**2*w3**2/4 + w1**2/8 + w1**2/(8*w2**2) + 3*w1*w2/8 + 3*w1*w3/8 - 3*w1/(8*w3) - 3*w1/(8*w2) + w2*w3/4 - w2/(4*w3) - 1/4 - w3/(4*w2) + 1/(4*w2*w3) + w3**2/(4*w2**2) - 3*w2/(8*w1) - 3*w3/(8*w1) + 3/(8*w1*w3) + 3/(8*w1*w2) + w3**2/(8*w1**2) + 1/(8*w1**2) - 1/(4*w1**2*w2**2) - 3*w2/(8*w0) - 3*w3/(8*w0) + 3/(8*w0*w3) + 3/(8*w0*w2) + w3**2/(8*w0**2) + 1/(8*w0**2) - 1/(4*w0**2*w2**2)'), (0, 2, 'w0**2/8 - w0**2/(8*w2**2) - w0*w2/8 + w0/(8*w2) + w1**2/8 - w1**2/(8*w2**2) - w1*w2/8 + w1/(8*w2) - 1/4 + 1/(4*w2**2) + w2/(8*w1) - 1/(8*w1*w2) + w2/(8*w0) - 1/(8*w0*w2)')]",
+      "elapsed_sec": 0.8393732919939794,
+      "first_attempt": "Preserved in metric_phase_removed_first: plain /2 also introduced Python floats; final mutation removes only the phase while preserving exact rational arithmetic."
+    },
+    {
+      "name": "source_offdiagonal_halved",
+      "source": "scripts/regge_source_rank_check_2026_09_13.py",
+      "old": "J=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in Es])",
+      "new": "T=s.Matrix(4,4,lambda i,j:T[i,j] if i==j else T[i,j]/2)\n    J=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in Es])",
+      "original_sha256": "ab08cd53644936b9d5169e3db4da170d02b03a1f7df222c7ec3776129071d51f",
+      "mutated_sha256": "cace626c75e550361131d49b6c287c4ad737506d4d161fa0896a9bc5bd7f8e43",
+      "exit_code": 1,
+      "failure": "AssertionError: geometric_all_phase_exponent_source",
+      "elapsed_sec": 0.7587209580233321
+    },
+    {
+      "name": "scalar_cross_removed",
+      "source": "scripts/regge_tensor_transfer_check_2026_09_13.py",
+      "old": "Fs=-D*tau*tau/2-2*tau*(r*r*a+t*t*sigma-2*r*t*b3)",
+      "new": "Fs=-D*tau*tau/2-2*tau*(r*r*a+t*t*sigma)",
+      "original_sha256": "7a94cd98ea09453a5f9fe3b43cd05e8b935284e33b353391f83529f30e9ff278",
+      "mutated_sha256": "38f1125ca4ef0b844b2ab29925417ba7283d0ba82227c0cc65bf9971f7058043",
+      "exit_code": 1,
+      "failure": "AssertionError: full_mixed_decomposition",
+      "elapsed_sec": 0.18986625003162771
+    },
+    {
+      "name": "transfer_width_halved",
+      "source": "scripts/regge_tensor_transfer_check_2026_09_13.py",
+      "old": "alpha=(1/z-z)/2",
+      "new": "alpha=(1/z-z)/4",
+      "original_sha256": "7a94cd98ea09453a5f9fe3b43cd05e8b935284e33b353391f83529f30e9ff278",
+      "mutated_sha256": "a7c6a2573051624522ef1c6c3166e8abbd2d9191c1fffe0d7185ebab279952ff",
+      "exit_code": 1,
+      "failure": "AssertionError: transfer_width_equation",
+      "elapsed_sec": 0.30470924999099225
+    }
+  ]
+}

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/area_normalization/regge_local_hessian_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/area_normalization/regge_local_hessian_check_2026_09_13.py
@@ -1,0 +1,122 @@
+"""Rational simplex geometry and a fixed all-phase Laurent identity.
+
+No input files are read except this module's own bytes for an integrity hash.
+"""
+from __future__ import annotations
+import itertools,json,time,hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic()
+    R=s.Rational
+    pairs=list(itertools.combinations(range(5),2))
+    q=s.symbols('q:10'); qdict=dict(zip(pairs,q))
+    def edge(a,b):
+        return s.S.Zero if a==b else qdict[tuple(sorted((a,b)))]
+    H=s.zeros(4)
+    for a in range(1,5):
+        H[a-1,a-1]=edge(a-1,a)
+        for b in range(a+1,5):
+            H[a-1,b-1]=H[b-1,a-1]=R(1,2)*(edge(a,b-1)+edge(a-1,b)-edge(a,b)-edge(a-1,b-1))
+    normals=[s.Matrix([-1,0,0,0]),s.Matrix([1,-1,0,0]),s.Matrix([0,1,-1,0]),s.Matrix([0,0,1,-1]),s.Matrix([0,0,0,1])]
+    assert sum(normals,s.zeros(4,1))==s.zeros(4,1)
+    local=s.S.Zero; schlaefli=s.S.Zero
+    for i,j in pairs:
+        ni,nj=normals[i],normals[j]
+        a,b,c=(ni.dot(ni),ni.dot(nj),nj.dot(nj))
+        N=ni.row_join(nj); P=s.eye(4)-N*(N.T*N).inv()*N.T
+        W=(ni.T*H*nj)[0]-b*R(1,2)*((ni.T*H*ni)[0]/a+(nj.T*H*nj)[0]/c)
+        schlaefli-=W/2
+        local+=s.trace(P*H)*W/8
+    assert s.expand(schlaefli)==0
+    local=s.expand(local)
+    Q0=s.hessian(local,q)/2
+    assert Q0==Q0.T
+    assert all(x.is_Rational for x in Q0)
+
+
+    w=s.symbols('w0:4',nonzero=True); z=[x*x for x in w]
+    sets=[frozenset(a for a,b in enumerate(v) if b) for v in itertools.product((0,1),repeat=4) if any(v)]
+    idx={A:i for i,A in enumerate(sets)}
+    def mon(anchor):
+        return s.prod(z[i] for i in anchor)
+    Q=s.zeros(15)
+    for perm in itertools.permutations(range(4)):
+        maps=[]
+        for a,b in pairs:
+            maps.append((idx[frozenset(perm[a:b])],frozenset(perm[:a])))
+        for i,(ci,ai) in enumerate(maps):
+            for j,(cj,aj) in enumerate(maps):
+                if Q0[i,j]:Q[ci,cj]+=Q0[i,j]*mon(aj)/mon(ai)
+    Q=Q.applyfunc(s.expand)
+
+
+    C=s.zeros(4,15)
+    for i,A in enumerate(itertools.combinations(range(4),3)):
+        C[i,idx[frozenset(A)]]=1
+        for a,b in itertools.combinations(A,2):
+            c=next(x for x in A if x not in (a,b))
+            C[i,idx[frozenset((a,b))]]-=(1+z[c])/2
+        for a in A:
+            b,c=[x for x in A if x!=a]
+            C[i,idx[frozenset((a,))]]+=(z[b]+z[c])/2
+
+    def minus(expr):return expr.xreplace({x:1/x for x in w})
+    Cm=C.applyfunc(minus)
+    E=[]
+    for A in sets:
+        h=s.zeros(4)
+        for a in range(4):h[a,a]=int(A==frozenset((a,)))
+        for a,b in itertools.combinations(range(4),2):
+            value=(int(A==frozenset((a,b)))-int(A==frozenset((a,)))-int(A==frozenset((b,))))/(2*w[a]*w[b])
+            h[a,b]=h[b,a]=value
+        E.append(h)
+    p=s.Matrix([(x-1/x)/s.I for x in w]); lap=s.expand(p.dot(p))
+    F=s.zeros(15)
+    for a,Ha in enumerate(E):
+        left=Ha.applyfunc(minus)
+        for b,Hb in enumerate(E):
+            F[a,b]=s.expand(-R(1,4)*(lap*s.trace(left*Hb)-2*(left*p).dot(Hb*p)+s.trace(left)*(p.T*Hb*p)[0]+s.trace(Hb)*(p.T*left*p)[0]-lap*s.trace(left)*s.trace(Hb)))
+    proposed=(F-Cm.T*C/2).applyfunc(s.expand)
+    res=(Q-proposed).applyfunc(s.expand)
+    fail=[(i,j,str(res[i,j])) for i in range(15) for j in range(15) if res[i,j]!=0]
+
+    assert not fail,fail[:3]
+
+    G=s.zeros(15,4)
+    for A in sets:
+        for a in A:G[idx[A],a]=2*(mon(A)-1)
+    assert (Q*G).applyfunc(s.expand)==s.zeros(15,4)
+    assert (C*G).applyfunc(s.expand)==s.zeros(4,4)
+    assert Q[:,idx[frozenset(range(4))]]==s.zeros(15,1)
+    body=[idx[frozenset(A)] for A in itertools.combinations(range(4),3)]
+    assert Q.extract(body,body)==-s.eye(4)/2
+    assert (Q.extract(body,list(range(15)))+C/2).applyfunc(s.expand)==s.zeros(4,15)
+    wrong_body=(Q-F).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_body)
+    wrong_sign=(Q+proposed).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_sign)
+    # An identity component phase is a distinct, wrong metric map.
+    # The full signed coefficient comparison is already independent of this construction.
+    wrong_E=[h.copy() for h in E]
+    for h in wrong_E:
+        for a,b in itertools.combinations(range(4),2):h[a,b]=h[b,a]=s.expand(h[a,b]*w[a]*w[b])
+    wrong_gauge=[]
+    for c in range(4):
+        T=sum((wrong_E[i]*G[i,c] for i in range(15)),s.zeros(4))
+        u=s.zeros(4,1);u[c]=w[c]
+        wrong_gauge.append((T-s.I*(p*u.T+u*p.T)).applyfunc(s.expand))
+    assert any(any(x!=0 for x in T) for T in wrong_gauge)
+
+    out={'status':'exact_coefficient_identity_passed','scope':'one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim',
+         'local_pairs':pairs,'local_hessian':[[str(Q0[i,j]) for j in range(10)] for i in range(10)],
+         'permutations':24,'matrix_entries':225,'nonzero_geometry_entries':sum(x!=0 for x in Q),
+         'residual_entries':len(fail),'max_laurent_terms':max(len(s.Add.make_args(x)) for x in Q),
+         'checks':['barycentric_normal_sum','local_schlaefli','rational_local_hessian','full_laurent_identity','exact_vertex_gauge','body_constraint_gauge','hyperdiagonal_zero','body_block','body_rows','missing_body_rejected','orientation_reversed_rejected','wrong_metric_phase_rejected'],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out, SimpleNamespace(Q=Q,w=w,z=z,p=p,sets=sets,E=E,C=C,G=G,idx=idx,minus=minus)

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/area_normalization/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/area_normalization/stderr.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_local_hessian_check_2026_09_13 import run; run()
+                                                          ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/area_normalization/regge_local_hessian_check_2026_09_13.py", line 87, in run
+    assert not fail,fail[:3]
+           ^^^^^^^^
+AssertionError: [(0, 0, '3/4'), (0, 1, 'w0**2*w3**2/8 + w1**2*w3**2/8 + 1/(8*w1**2*w2**2) + 1/(8*w0**2*w2**2)'), (0, 2, '-1/4 - 1/(4*w2**2)')]

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/body_sign/regge_local_hessian_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/body_sign/regge_local_hessian_check_2026_09_13.py
@@ -1,0 +1,122 @@
+"""Rational simplex geometry and a fixed all-phase Laurent identity.
+
+No input files are read except this module's own bytes for an integrity hash.
+"""
+from __future__ import annotations
+import itertools,json,time,hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic()
+    R=s.Rational
+    pairs=list(itertools.combinations(range(5),2))
+    q=s.symbols('q:10'); qdict=dict(zip(pairs,q))
+    def edge(a,b):
+        return s.S.Zero if a==b else qdict[tuple(sorted((a,b)))]
+    H=s.zeros(4)
+    for a in range(1,5):
+        H[a-1,a-1]=edge(a-1,a)
+        for b in range(a+1,5):
+            H[a-1,b-1]=H[b-1,a-1]=R(1,2)*(edge(a,b-1)+edge(a-1,b)-edge(a,b)-edge(a-1,b-1))
+    normals=[s.Matrix([-1,0,0,0]),s.Matrix([1,-1,0,0]),s.Matrix([0,1,-1,0]),s.Matrix([0,0,1,-1]),s.Matrix([0,0,0,1])]
+    assert sum(normals,s.zeros(4,1))==s.zeros(4,1)
+    local=s.S.Zero; schlaefli=s.S.Zero
+    for i,j in pairs:
+        ni,nj=normals[i],normals[j]
+        a,b,c=(ni.dot(ni),ni.dot(nj),nj.dot(nj))
+        N=ni.row_join(nj); P=s.eye(4)-N*(N.T*N).inv()*N.T
+        W=(ni.T*H*nj)[0]-b*R(1,2)*((ni.T*H*ni)[0]/a+(nj.T*H*nj)[0]/c)
+        schlaefli-=W/2
+        local+=s.trace(P*H)*W/4
+    assert s.expand(schlaefli)==0
+    local=s.expand(local)
+    Q0=s.hessian(local,q)/2
+    assert Q0==Q0.T
+    assert all(x.is_Rational for x in Q0)
+
+
+    w=s.symbols('w0:4',nonzero=True); z=[x*x for x in w]
+    sets=[frozenset(a for a,b in enumerate(v) if b) for v in itertools.product((0,1),repeat=4) if any(v)]
+    idx={A:i for i,A in enumerate(sets)}
+    def mon(anchor):
+        return s.prod(z[i] for i in anchor)
+    Q=s.zeros(15)
+    for perm in itertools.permutations(range(4)):
+        maps=[]
+        for a,b in pairs:
+            maps.append((idx[frozenset(perm[a:b])],frozenset(perm[:a])))
+        for i,(ci,ai) in enumerate(maps):
+            for j,(cj,aj) in enumerate(maps):
+                if Q0[i,j]:Q[ci,cj]+=Q0[i,j]*mon(aj)/mon(ai)
+    Q=Q.applyfunc(s.expand)
+
+
+    C=s.zeros(4,15)
+    for i,A in enumerate(itertools.combinations(range(4),3)):
+        C[i,idx[frozenset(A)]]=1
+        for a,b in itertools.combinations(A,2):
+            c=next(x for x in A if x not in (a,b))
+            C[i,idx[frozenset((a,b))]]+=(1+z[c])/2
+        for a in A:
+            b,c=[x for x in A if x!=a]
+            C[i,idx[frozenset((a,))]]+=(z[b]+z[c])/2
+
+    def minus(expr):return expr.xreplace({x:1/x for x in w})
+    Cm=C.applyfunc(minus)
+    E=[]
+    for A in sets:
+        h=s.zeros(4)
+        for a in range(4):h[a,a]=int(A==frozenset((a,)))
+        for a,b in itertools.combinations(range(4),2):
+            value=(int(A==frozenset((a,b)))-int(A==frozenset((a,)))-int(A==frozenset((b,))))/(2*w[a]*w[b])
+            h[a,b]=h[b,a]=value
+        E.append(h)
+    p=s.Matrix([(x-1/x)/s.I for x in w]); lap=s.expand(p.dot(p))
+    F=s.zeros(15)
+    for a,Ha in enumerate(E):
+        left=Ha.applyfunc(minus)
+        for b,Hb in enumerate(E):
+            F[a,b]=s.expand(-R(1,4)*(lap*s.trace(left*Hb)-2*(left*p).dot(Hb*p)+s.trace(left)*(p.T*Hb*p)[0]+s.trace(Hb)*(p.T*left*p)[0]-lap*s.trace(left)*s.trace(Hb)))
+    proposed=(F-Cm.T*C/2).applyfunc(s.expand)
+    res=(Q-proposed).applyfunc(s.expand)
+    fail=[(i,j,str(res[i,j])) for i in range(15) for j in range(15) if res[i,j]!=0]
+
+    assert not fail,fail[:3]
+
+    G=s.zeros(15,4)
+    for A in sets:
+        for a in A:G[idx[A],a]=2*(mon(A)-1)
+    assert (Q*G).applyfunc(s.expand)==s.zeros(15,4)
+    assert (C*G).applyfunc(s.expand)==s.zeros(4,4)
+    assert Q[:,idx[frozenset(range(4))]]==s.zeros(15,1)
+    body=[idx[frozenset(A)] for A in itertools.combinations(range(4),3)]
+    assert Q.extract(body,body)==-s.eye(4)/2
+    assert (Q.extract(body,list(range(15)))+C/2).applyfunc(s.expand)==s.zeros(4,15)
+    wrong_body=(Q-F).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_body)
+    wrong_sign=(Q+proposed).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_sign)
+    # An identity component phase is a distinct, wrong metric map.
+    # The full signed coefficient comparison is already independent of this construction.
+    wrong_E=[h.copy() for h in E]
+    for h in wrong_E:
+        for a,b in itertools.combinations(range(4),2):h[a,b]=h[b,a]=s.expand(h[a,b]*w[a]*w[b])
+    wrong_gauge=[]
+    for c in range(4):
+        T=sum((wrong_E[i]*G[i,c] for i in range(15)),s.zeros(4))
+        u=s.zeros(4,1);u[c]=w[c]
+        wrong_gauge.append((T-s.I*(p*u.T+u*p.T)).applyfunc(s.expand))
+    assert any(any(x!=0 for x in T) for T in wrong_gauge)
+
+    out={'status':'exact_coefficient_identity_passed','scope':'one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim',
+         'local_pairs':pairs,'local_hessian':[[str(Q0[i,j]) for j in range(10)] for i in range(10)],
+         'permutations':24,'matrix_entries':225,'nonzero_geometry_entries':sum(x!=0 for x in Q),
+         'residual_entries':len(fail),'max_laurent_terms':max(len(s.Add.make_args(x)) for x in Q),
+         'checks':['barycentric_normal_sum','local_schlaefli','rational_local_hessian','full_laurent_identity','exact_vertex_gauge','body_constraint_gauge','hyperdiagonal_zero','body_block','body_rows','missing_body_rejected','orientation_reversed_rejected','wrong_metric_phase_rejected'],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out, SimpleNamespace(Q=Q,w=w,z=z,p=p,sets=sets,E=E,C=C,G=G,idx=idx,minus=minus)

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/body_sign/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/body_sign/stderr.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_local_hessian_check_2026_09_13 import run; run()
+                                                          ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/body_sign/regge_local_hessian_check_2026_09_13.py", line 87, in run
+    assert not fail,fail[:3]
+           ^^^^^^^^
+AssertionError: [(0, 2, 'w0**2/(4*w2**2) + w1**2/(4*w2**2) + 1/2 + 1/(2*w2**2) + 1/(4*w1**2) + 1/(4*w0**2)'), (0, 4, 'w0**2/(4*w1**2) + 1/2 + 1/(4*w2**2) + w2**2/(4*w1**2) + 1/(2*w1**2) + 1/(4*w0**2)'), (0, 5, 'w3**2/(4*w2**2) + 1/(4*w2**2) + w3**2/(4*w1**2) + 1/(4*w1**2)')]

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/regge_local_hessian_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/regge_local_hessian_check_2026_09_13.py
@@ -1,0 +1,122 @@
+"""Rational simplex geometry and a fixed all-phase Laurent identity.
+
+No input files are read except this module's own bytes for an integrity hash.
+"""
+from __future__ import annotations
+import itertools,json,time,hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic()
+    R=s.Rational
+    pairs=list(itertools.combinations(range(5),2))
+    q=s.symbols('q:10'); qdict=dict(zip(pairs,q))
+    def edge(a,b):
+        return s.S.Zero if a==b else qdict[tuple(sorted((a,b)))]
+    H=s.zeros(4)
+    for a in range(1,5):
+        H[a-1,a-1]=edge(a-1,a)
+        for b in range(a+1,5):
+            H[a-1,b-1]=H[b-1,a-1]=R(1,2)*(edge(a,b-1)+edge(a-1,b)-edge(a,b)-edge(a-1,b-1))
+    normals=[s.Matrix([-1,0,0,0]),s.Matrix([1,-1,0,0]),s.Matrix([0,1,-1,0]),s.Matrix([0,0,1,-1]),s.Matrix([0,0,0,1])]
+    assert sum(normals,s.zeros(4,1))==s.zeros(4,1)
+    local=s.S.Zero; schlaefli=s.S.Zero
+    for i,j in pairs:
+        ni,nj=normals[i],normals[j]
+        a,b,c=(ni.dot(ni),ni.dot(nj),nj.dot(nj))
+        N=ni.row_join(nj); P=s.eye(4)-N*(N.T*N).inv()*N.T
+        W=(ni.T*H*nj)[0]-b*R(1,2)*((ni.T*H*ni)[0]/a+(nj.T*H*nj)[0]/c)
+        schlaefli-=W/2
+        local+=s.trace(P*H)*W/4
+    assert s.expand(schlaefli)==0
+    local=s.expand(local)
+    Q0=s.hessian(local,q)/2
+    assert Q0==Q0.T
+    assert all(x.is_Rational for x in Q0)
+
+
+    w=s.symbols('w0:4',nonzero=True); z=[x*x for x in w]
+    sets=[frozenset(a for a,b in enumerate(v) if b) for v in itertools.product((0,1),repeat=4) if any(v)]
+    idx={A:i for i,A in enumerate(sets)}
+    def mon(anchor):
+        return s.prod(z[i] for i in anchor)
+    Q=s.zeros(15)
+    for perm in itertools.permutations(range(4)):
+        maps=[]
+        for a,b in pairs:
+            maps.append((idx[frozenset(perm[a:b])],frozenset(perm[:a])))
+        for i,(ci,ai) in enumerate(maps):
+            for j,(cj,aj) in enumerate(maps):
+                if Q0[i,j]:Q[ci,cj]+=Q0[i,j]*mon(aj)/mon(ai)
+    Q=Q.applyfunc(s.expand)
+
+
+    C=s.zeros(4,15)
+    for i,A in enumerate(itertools.combinations(range(4),3)):
+        C[i,idx[frozenset(A)]]=1
+        for a,b in itertools.combinations(A,2):
+            c=next(x for x in A if x not in (a,b))
+            C[i,idx[frozenset((a,b))]]-=(1+z[c])/2
+        for a in A:
+            b,c=[x for x in A if x!=a]
+            C[i,idx[frozenset((a,))]]+=(z[b]+z[c])/2
+
+    def minus(expr):return expr.xreplace({x:1/x for x in w})
+    Cm=C.applyfunc(minus)
+    E=[]
+    for A in sets:
+        h=s.zeros(4)
+        for a in range(4):h[a,a]=int(A==frozenset((a,)))
+        for a,b in itertools.combinations(range(4),2):
+            value=(int(A==frozenset((a,b)))-int(A==frozenset((a,)))-int(A==frozenset((b,))))/s.Integer(2)
+            h[a,b]=h[b,a]=value
+        E.append(h)
+    p=s.Matrix([(x-1/x)/s.I for x in w]); lap=s.expand(p.dot(p))
+    F=s.zeros(15)
+    for a,Ha in enumerate(E):
+        left=Ha.applyfunc(minus)
+        for b,Hb in enumerate(E):
+            F[a,b]=s.expand(-R(1,4)*(lap*s.trace(left*Hb)-2*(left*p).dot(Hb*p)+s.trace(left)*(p.T*Hb*p)[0]+s.trace(Hb)*(p.T*left*p)[0]-lap*s.trace(left)*s.trace(Hb)))
+    proposed=(F-Cm.T*C/2).applyfunc(s.expand)
+    res=(Q-proposed).applyfunc(s.expand)
+    fail=[(i,j,str(res[i,j])) for i in range(15) for j in range(15) if res[i,j]!=0]
+
+    assert not fail,fail[:3]
+
+    G=s.zeros(15,4)
+    for A in sets:
+        for a in A:G[idx[A],a]=2*(mon(A)-1)
+    assert (Q*G).applyfunc(s.expand)==s.zeros(15,4)
+    assert (C*G).applyfunc(s.expand)==s.zeros(4,4)
+    assert Q[:,idx[frozenset(range(4))]]==s.zeros(15,1)
+    body=[idx[frozenset(A)] for A in itertools.combinations(range(4),3)]
+    assert Q.extract(body,body)==-s.eye(4)/2
+    assert (Q.extract(body,list(range(15)))+C/2).applyfunc(s.expand)==s.zeros(4,15)
+    wrong_body=(Q-F).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_body)
+    wrong_sign=(Q+proposed).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_sign)
+    # An identity component phase is a distinct, wrong metric map.
+    # The full signed coefficient comparison is already independent of this construction.
+    wrong_E=[h.copy() for h in E]
+    for h in wrong_E:
+        for a,b in itertools.combinations(range(4),2):h[a,b]=h[b,a]=s.expand(h[a,b]*w[a]*w[b])
+    wrong_gauge=[]
+    for c in range(4):
+        T=sum((wrong_E[i]*G[i,c] for i in range(15)),s.zeros(4))
+        u=s.zeros(4,1);u[c]=w[c]
+        wrong_gauge.append((T-s.I*(p*u.T+u*p.T)).applyfunc(s.expand))
+    assert any(any(x!=0 for x in T) for T in wrong_gauge)
+
+    out={'status':'exact_coefficient_identity_passed','scope':'one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim',
+         'local_pairs':pairs,'local_hessian':[[str(Q0[i,j]) for j in range(10)] for i in range(10)],
+         'permutations':24,'matrix_entries':225,'nonzero_geometry_entries':sum(x!=0 for x in Q),
+         'residual_entries':len(fail),'max_laurent_terms':max(len(s.Add.make_args(x)) for x in Q),
+         'checks':['barycentric_normal_sum','local_schlaefli','rational_local_hessian','full_laurent_identity','exact_vertex_gauge','body_constraint_gauge','hyperdiagonal_zero','body_block','body_rows','missing_body_rejected','orientation_reversed_rejected','wrong_metric_phase_rejected'],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out, SimpleNamespace(Q=Q,w=w,z=z,p=p,sets=sets,E=E,C=C,G=G,idx=idx,minus=minus)

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/stderr.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_local_hessian_check_2026_09_13 import run; run()
+                                                          ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/regge_local_hessian_check_2026_09_13.py", line 87, in run
+    assert not fail,fail[:3]
+           ^^^^^^^^
+AssertionError: [(0, 0, '-w0**2/4 + w0**2/(8*w2**2) + w0**2/(8*w1**2) + w0*w1/4 + w0*w2/4 - w0/(4*w2) - w0/(4*w1) - w1**2/4 + w1**2/(8*w2**2) + w1*w2/4 - w1/(4*w2) - w2**2/4 + 3/4 - 1/(4*w2**2) - w2/(4*w1) + 1/(4*w1*w2) + w2**2/(8*w1**2) - 1/(4*w1**2) - w1/(4*w0) - w2/(4*w0) + 1/(4*w0*w2) + 1/(4*w0*w1) + w1**2/(8*w0**2) + w2**2/(8*w0**2) - 1/(4*w0**2)'), (0, 1, '-w0**2*w3**2/4 + w0**2/8 + w0**2/(8*w2**2) + 3*w0*w2/8 + 3*w0*w3/8 - 3*w0/(8*w3) - 3*w0/(8*w2) - w1**2*w3**2/4 + w1**2/8 + w1**2/(8*w2**2) + 3*w1*w2/8 + 3*w1*w3/8 - 3*w1/(8*w3) - 3*w1/(8*w2) + w2*w3/4 - w2/(4*w3) - 1/4 - w3/(4*w2) + 1/(4*w2*w3) + w3**2/(4*w2**2) - 3*w2/(8*w1) - 3*w3/(8*w1) + 3/(8*w1*w3) + 3/(8*w1*w2) + w3**2/(8*w1**2) + 1/(8*w1**2) - 1/(4*w1**2*w2**2) - 3*w2/(8*w0) - 3*w3/(8*w0) + 3/(8*w0*w3) + 3/(8*w0*w2) + w3**2/(8*w0**2) + 1/(8*w0**2) - 1/(4*w0**2*w2**2)'), (0, 2, 'w0**2/8 - w0**2/(8*w2**2) - w0*w2/8 + w0/(8*w2) + w1**2/8 - w1**2/(8*w2**2) - w1*w2/8 + w1/(8*w2) - 1/4 + 1/(4*w2**2) + w2/(8*w1) - 1/(8*w1*w2) + w2/(8*w0) - 1/(8*w0*w2)')]

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed_first/regge_local_hessian_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed_first/regge_local_hessian_check_2026_09_13.py
@@ -1,0 +1,122 @@
+"""Rational simplex geometry and a fixed all-phase Laurent identity.
+
+No input files are read except this module's own bytes for an integrity hash.
+"""
+from __future__ import annotations
+import itertools,json,time,hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic()
+    R=s.Rational
+    pairs=list(itertools.combinations(range(5),2))
+    q=s.symbols('q:10'); qdict=dict(zip(pairs,q))
+    def edge(a,b):
+        return s.S.Zero if a==b else qdict[tuple(sorted((a,b)))]
+    H=s.zeros(4)
+    for a in range(1,5):
+        H[a-1,a-1]=edge(a-1,a)
+        for b in range(a+1,5):
+            H[a-1,b-1]=H[b-1,a-1]=R(1,2)*(edge(a,b-1)+edge(a-1,b)-edge(a,b)-edge(a-1,b-1))
+    normals=[s.Matrix([-1,0,0,0]),s.Matrix([1,-1,0,0]),s.Matrix([0,1,-1,0]),s.Matrix([0,0,1,-1]),s.Matrix([0,0,0,1])]
+    assert sum(normals,s.zeros(4,1))==s.zeros(4,1)
+    local=s.S.Zero; schlaefli=s.S.Zero
+    for i,j in pairs:
+        ni,nj=normals[i],normals[j]
+        a,b,c=(ni.dot(ni),ni.dot(nj),nj.dot(nj))
+        N=ni.row_join(nj); P=s.eye(4)-N*(N.T*N).inv()*N.T
+        W=(ni.T*H*nj)[0]-b*R(1,2)*((ni.T*H*ni)[0]/a+(nj.T*H*nj)[0]/c)
+        schlaefli-=W/2
+        local+=s.trace(P*H)*W/4
+    assert s.expand(schlaefli)==0
+    local=s.expand(local)
+    Q0=s.hessian(local,q)/2
+    assert Q0==Q0.T
+    assert all(x.is_Rational for x in Q0)
+
+
+    w=s.symbols('w0:4',nonzero=True); z=[x*x for x in w]
+    sets=[frozenset(a for a,b in enumerate(v) if b) for v in itertools.product((0,1),repeat=4) if any(v)]
+    idx={A:i for i,A in enumerate(sets)}
+    def mon(anchor):
+        return s.prod(z[i] for i in anchor)
+    Q=s.zeros(15)
+    for perm in itertools.permutations(range(4)):
+        maps=[]
+        for a,b in pairs:
+            maps.append((idx[frozenset(perm[a:b])],frozenset(perm[:a])))
+        for i,(ci,ai) in enumerate(maps):
+            for j,(cj,aj) in enumerate(maps):
+                if Q0[i,j]:Q[ci,cj]+=Q0[i,j]*mon(aj)/mon(ai)
+    Q=Q.applyfunc(s.expand)
+
+
+    C=s.zeros(4,15)
+    for i,A in enumerate(itertools.combinations(range(4),3)):
+        C[i,idx[frozenset(A)]]=1
+        for a,b in itertools.combinations(A,2):
+            c=next(x for x in A if x not in (a,b))
+            C[i,idx[frozenset((a,b))]]-=(1+z[c])/2
+        for a in A:
+            b,c=[x for x in A if x!=a]
+            C[i,idx[frozenset((a,))]]+=(z[b]+z[c])/2
+
+    def minus(expr):return expr.xreplace({x:1/x for x in w})
+    Cm=C.applyfunc(minus)
+    E=[]
+    for A in sets:
+        h=s.zeros(4)
+        for a in range(4):h[a,a]=int(A==frozenset((a,)))
+        for a,b in itertools.combinations(range(4),2):
+            value=(int(A==frozenset((a,b)))-int(A==frozenset((a,)))-int(A==frozenset((b,))))/2
+            h[a,b]=h[b,a]=value
+        E.append(h)
+    p=s.Matrix([(x-1/x)/s.I for x in w]); lap=s.expand(p.dot(p))
+    F=s.zeros(15)
+    for a,Ha in enumerate(E):
+        left=Ha.applyfunc(minus)
+        for b,Hb in enumerate(E):
+            F[a,b]=s.expand(-R(1,4)*(lap*s.trace(left*Hb)-2*(left*p).dot(Hb*p)+s.trace(left)*(p.T*Hb*p)[0]+s.trace(Hb)*(p.T*left*p)[0]-lap*s.trace(left)*s.trace(Hb)))
+    proposed=(F-Cm.T*C/2).applyfunc(s.expand)
+    res=(Q-proposed).applyfunc(s.expand)
+    fail=[(i,j,str(res[i,j])) for i in range(15) for j in range(15) if res[i,j]!=0]
+
+    assert not fail,fail[:3]
+
+    G=s.zeros(15,4)
+    for A in sets:
+        for a in A:G[idx[A],a]=2*(mon(A)-1)
+    assert (Q*G).applyfunc(s.expand)==s.zeros(15,4)
+    assert (C*G).applyfunc(s.expand)==s.zeros(4,4)
+    assert Q[:,idx[frozenset(range(4))]]==s.zeros(15,1)
+    body=[idx[frozenset(A)] for A in itertools.combinations(range(4),3)]
+    assert Q.extract(body,body)==-s.eye(4)/2
+    assert (Q.extract(body,list(range(15)))+C/2).applyfunc(s.expand)==s.zeros(4,15)
+    wrong_body=(Q-F).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_body)
+    wrong_sign=(Q+proposed).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_sign)
+    # An identity component phase is a distinct, wrong metric map.
+    # The full signed coefficient comparison is already independent of this construction.
+    wrong_E=[h.copy() for h in E]
+    for h in wrong_E:
+        for a,b in itertools.combinations(range(4),2):h[a,b]=h[b,a]=s.expand(h[a,b]*w[a]*w[b])
+    wrong_gauge=[]
+    for c in range(4):
+        T=sum((wrong_E[i]*G[i,c] for i in range(15)),s.zeros(4))
+        u=s.zeros(4,1);u[c]=w[c]
+        wrong_gauge.append((T-s.I*(p*u.T+u*p.T)).applyfunc(s.expand))
+    assert any(any(x!=0 for x in T) for T in wrong_gauge)
+
+    out={'status':'exact_coefficient_identity_passed','scope':'one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim',
+         'local_pairs':pairs,'local_hessian':[[str(Q0[i,j]) for j in range(10)] for i in range(10)],
+         'permutations':24,'matrix_entries':225,'nonzero_geometry_entries':sum(x!=0 for x in Q),
+         'residual_entries':len(fail),'max_laurent_terms':max(len(s.Add.make_args(x)) for x in Q),
+         'checks':['barycentric_normal_sum','local_schlaefli','rational_local_hessian','full_laurent_identity','exact_vertex_gauge','body_constraint_gauge','hyperdiagonal_zero','body_block','body_rows','missing_body_rejected','orientation_reversed_rejected','wrong_metric_phase_rejected'],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out, SimpleNamespace(Q=Q,w=w,z=z,p=p,sets=sets,E=E,C=C,G=G,idx=idx,minus=minus)

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed_first/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed_first/stderr.txt
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_local_hessian_check_2026_09_13 import run; run()
+                                                          ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/metric_phase_removed/regge_local_hessian_check_2026_09_13.py", line 87, in run
+    assert not fail,fail[:3]
+           ^^^^^^^^
+AssertionError: [(0, 0, '-0.25*w0**2 + w0**2/(8*w2**2) + w0**2/(8*w1**2) + 0.25*w0*w1 + 0.25*w0*w2 - 0.25*w0/w2 - 0.25*w0/w1 - 0.25*w1**2 + w1**2/(8*w2**2) + 0.25*w1*w2 - 0.25*w1/w2 - 0.25*w2**2 + 0.75 - 0.25/w2**2 - 0.25*w2/w1 + 0.25/(w1*w2) + w2**2/(8*w1**2) - 0.25/w1**2 - 0.25*w1/w0 - 0.25*w2/w0 + 0.25/(w0*w2) + 0.25/(w0*w1) + w1**2/(8*w0**2) + w2**2/(8*w0**2) - 0.25/w0**2'), (0, 1, '-w0**2*w3**2/4 + 0.125*w0**2 + w0**2/(8*w2**2) + 0.375*w0*w2 + 0.375*w0*w3 - 0.375*w0/w3 - 0.375*w0/w2 - w1**2*w3**2/4 + 0.125*w1**2 + w1**2/(8*w2**2) + 0.375*w1*w2 + 0.375*w1*w3 - 0.375*w1/w3 - 0.375*w1/w2 + 0.25*w2*w3 - 0.25*w2/w3 - 0.25 - 0.25*w3/w2 + 0.25/(w2*w3) + w3**2/(4*w2**2) - 0.375*w2/w1 - 0.375*w3/w1 + 0.375/(w1*w3) + 0.375/(w1*w2) + w3**2/(8*w1**2) + 0.125/w1**2 - 1/(4*w1**2*w2**2) - 0.375*w2/w0 - 0.375*w3/w0 + 0.375/(w0*w3) + 0.375/(w0*w2) + w3**2/(8*w0**2) + 0.125/w0**2 - 1/(4*w0**2*w2**2)'), (0, 2, '0.125*w0**2 - w0**2/(8*w2**2) - 0.125*w0*w2 + 0.125*w0/w2 + 0.125*w1**2 - w1**2/(8*w2**2) - 0.125*w1*w2 + 0.125*w1/w2 - 0.25 + 1/(4*w2**2) + 0.125*w2/w1 - 0.125/(w1*w2) + 0.125*w2/w0 - 0.125/(w0*w2)')]

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/regge_tensor_transfer_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/regge_tensor_transfer_check_2026_09_13.py
@@ -1,0 +1,97 @@
+"""Full mixed constraints, Gaussian transfer and exact polynomial fragments.
+
+Only this source is read for an integrity hash. The transfer calculation does
+not import the geometric checker or use its expected coefficient matrix.
+"""
+from __future__ import annotations
+import json,time,hashlib
+from pathlib import Path
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic();checks=[]
+    def check(name,condition):
+        if not condition:raise AssertionError(name)
+        checks.append(name)
+    r,t=s.symbols('r t',real=True);tau,sigma,a,b1,b2,b3,v1,v2,u,w=s.symbols('tau sigma a b1 b2 b3 v1 v2 u w',real=True)
+    H=s.Matrix([[tau/2+u,w,v1,b1],[w,tau/2-u,v2,b2],[v1,v2,sigma,b3],[b1,b2,b3,a]])
+    p=s.Matrix([0,0,r,t]);D=r*r+t*t
+    F=s.expand(D*s.trace(H*H)-2*(H*p).dot(H*p)+2*s.trace(H)*(p.T*H*p)[0]-D*s.trace(H)**2)
+    Ft=2*D*(u*u+w*w);Fv=2*((t*v1-r*b1)**2+(t*v2-r*b2)**2)
+    Fs=-D*tau*tau/2-2*tau*(r*r*a+t*t*sigma)
+    check('full_mixed_decomposition',s.expand(F-Ft-Fv-Fs)==0)
+    check('lapse_equation',s.diff(F,a)==-2*r*r*tau)
+    check('first_shift_equation',s.expand(s.diff(F,b1)-4*r*(r*b1-t*v1))==0)
+    check('second_shift_equation',s.expand(s.diff(F,b2)-4*r*(r*b2-t*v2))==0)
+    check('remaining_scalar_equation',s.expand(s.diff(F,tau).subs(tau,0)+2*(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    check('wrong_missing_scalar_cross_rejected',s.expand(F-Ft-Fv+D*tau*tau/2)!=0)
+    check('wrong_missing_vector_cross_rejected',s.expand(Fv-2*(t*t*(v1*v1+v2*v2)+r*r*(b1*b1+b2*b2)))!=0)
+    eta=s.Matrix(s.symbols('e0:4'))
+    HG=H+s.I*(p*eta.T+eta*p.T)
+    check('trace_constraint_gauge',s.expand(HG[0,0]+HG[1,1]-tau)==0)
+    check('tensor_gauge',HG[0,1]==w and s.expand((HG[0,0]-HG[1,1])/2-u)==0)
+    for j in (0,1):
+        check('vector_combination_gauge_'+str(j),s.expand(t*HG[j,2]-r*HG[j,3]-(t*H[j,2]-r*H[j,3]))==0)
+    check('scalar_combination_gauge',s.expand(r*r*HG[3,3]+t*t*HG[2,2]-2*r*t*HG[2,3]-(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    # On the constraint surface the explicit gauge choice kills every non-TT entry.
+    HS=H.subs({tau:0,b1:t*v1/r,b2:t*v2/r,a:(2*r*t*b3-t*t*sigma)/(r*r)})
+    g3=-sigma/(2*s.I*r)
+    g0=-(b3+s.I*t*g3)/(s.I*r)
+    g=s.Matrix([-v1/(s.I*r),-v2/(s.I*r),g3,g0])
+    fixed=(HS+s.I*(p*g.T+g*p.T)).applyfunc(s.simplify)
+    check('explicit_full_constraint_gauge_reduction',fixed==s.Matrix([[u,w,0,0],[w,-u,0,0],[0,0,0,0],[0,0,0,0]]))
+
+    z=s.Symbol('z',positive=True);x,beta=s.symbols('x beta',real=True)
+    A=(z+1/z)/2;alpha=(1/z-z)/2
+    check('transfer_width_equation',s.simplify(alpha**2-(A*A-1))==0)
+    check('transfer_generating_quadratic',s.simplify(2*alpha*z-1+z*z)==0)
+    check('transfer_generating_constant',s.simplify(A-z-alpha)==0)
+    # The domain is 0<z<1, hence r=(1-z)/sqrt(z)>0; keep that sign explicitly.
+    r_from_z=(1-z)/s.sqrt(z)
+    check('transfer_trace',s.simplify(s.sqrt(z)/(1-z)-1/r_from_z)==0)
+    # A separate Gaussian-moment recurrence checks seven Hermite eigenfunctions.
+    z0=s.Rational(1,2);alpha0=s.Rational(3,4);A0=s.Rational(5,4)
+    y=s.Symbol('y');mom=[s.S.One,z0*x]
+    for n in range(2,7):mom.append(s.expand(z0*x*mom[-1]+(n-1)*z0*mom[-2]))
+    for n in range(7):
+        poly=s.Poly(s.hermite(n,s.sqrt(alpha0)*y),y)
+        expectation=sum(coef*mom[power[0]] for power,coef in poly.terms())
+        check('hermite_transfer_eigenfunction_'+str(n),s.expand(expectation-z0**n*s.hermite(n,s.sqrt(alpha0)*x))==0)
+    check('continuum_width_substitution_rejected',s.Rational(1,2)!=A0*A0-1)
+
+    phase=s.Symbol('phase',nonzero=True)
+    Csum=(1-z*z)/((1-z*phase)*(1-z/phase))/(2*alpha)
+    check('covariance_fourier_all_phases',s.cancel(Csum-1/((1-z)**2/z+2-phase-1/phase))==0)
+
+    # Exact finite polynomial fragments in the full oscillator's invariant degree range.
+    N=8
+    T=s.diag(*[z0**n for n in range(N)])
+    X=s.zeros(N)
+    for n in range(N-1):X[n,n+1]=X[n+1,n]=s.sqrt(s.Rational(n+1)/(2*alpha0))
+    Omega=s.eye(N)[:,0]
+    vecs=[T*X*Omega,T**2*(X**2-s.eye(N)/(2*alpha0))*Omega,T*X*T*X**2*Omega]
+    V=s.Matrix.hstack(*vecs)
+    check('polynomial_fragments_no_cutoff_contact',V[7,:]==s.zeros(1,3))
+    site=(V.T*V).applyfunc(s.simplify);link=(V.T*T*V).applyfunc(s.simplify)
+    for name,gram in [('site',site),('link',link)]:
+        for order in range(1,4):
+            for inds in __import__('itertools').combinations(range(3),order):
+                check('reflection_'+name+'_'+str(inds),gram.extract(inds,inds).det()>=0)
+    wrong=T.copy();wrong[1,1]=-wrong[1,1]
+    check('negative_transfer_mode_rejected',((X*Omega).T*wrong*(X*Omega))[0]<0)
+    for n in (0,1,2,5):
+        check('exact_vacuum_covariance_'+str(n),(Omega.T*X*T**n*X*Omega)[0]==z0**n/(2*alpha0))
+
+    ps=s.symbols('p0:3',real=True);R2=sum(q*q for q in ps)
+    num=sum(q*q*(1-q*q/4) for q in ps)
+    check('group_velocity_identity',s.expand(num-(R2-sum(q**4 for q in ps)/4))==0)
+    check('group_velocity_axis_nyquist',num.subs({ps[0]:2,ps[1]:0,ps[2]:0})==0)
+
+    out={'status':'passed','scope':'exact constraints, Gaussian spectral algebra and finite polynomial fragments; reduced quantization only',
+         'checks':checks,'count':len(checks),'transfer_fixture':{'z':'1/2','width':'3/4','r_squared':'1/2','hermite_degrees':list(range(7))},
+         'reflection_gram_site':[[str(site[i,j]) for j in range(3)] for i in range(3)],
+         'reflection_gram_link':[[str(link[i,j]) for j in range(3)] for i in range(3)],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),'elapsed_sec':time.monotonic()-started}
+
+    return out

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/stderr.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_tensor_transfer_check_2026_09_13 import run; run()
+                                                            ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/regge_tensor_transfer_check_2026_09_13.py", line 23, in run
+    check('full_mixed_decomposition',s.expand(F-Ft-Fv-Fs)==0)
+    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/scalar_cross_removed/regge_tensor_transfer_check_2026_09_13.py", line 15, in check
+    if not condition:raise AssertionError(name)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+AssertionError: full_mixed_decomposition

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/regge_source_rank_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/regge_source_rank_check_2026_09_13.py
@@ -1,0 +1,101 @@
+"""Exact source identities and separate symmetric-tensor rank checks.
+
+The geometry bundle is passed by the primary runner. Only this source is read
+for an integrity hash; no mutable external scientific data is loaded.
+"""
+from __future__ import annotations
+import json,hashlib,time
+from pathlib import Path
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run(m):
+    started=time.monotonic()
+    Q,w,z,p,sets,E,C,G=m.Q,m.w,m.z,m.p,m.sets,m.E,m.C,m.G
+    zero=lambda A: all(s.cancel(s.expand(x))==0 for x in A)
+    checks=[]
+    def check(name,condition):
+        if not condition:raise AssertionError(name)
+        checks.append(name)
+    static={w[3]:1}; nu=s.Symbol('nu',real=True)
+    qnu=s.Matrix([(int(3 in A)-nu*len(A-{3}))*(1+s.prod(z[a] for a in A)) for A in sets])
+    qnu=qnu.subs(static); Qs=Q.subs(static); Cs=C.subs(static); ps=p.subs(static)
+    Es=[h.subs(static) for h in E]; lap=s.expand(ps.dot(ps))
+    Hnu=sum((Es[i]*qnu[i] for i in range(15)),s.zeros(4))
+    uvec=s.Matrix([-nu*w[0]/2,-nu*w[1]/2,-nu*w[2]/2,s.Rational(1,2)])
+    check('all_phase_exponent_body',zero(Cs*qnu))
+    check('all_phase_exponent_gauge',zero(Hnu-s.diag(-2*nu,-2*nu,-2*nu,2)-s.I*(ps*uvec.T+uvec*ps.T)))
+    T=s.zeros(4); T[3,3]=-nu*lap
+    for a in range(3):
+        for b in range(3):T[a,b]=(1-nu)*(lap*int(a==b)-ps[a]*ps[b])/2
+    T=s.Matrix(4,4,lambda i,j:T[i,j] if i==j else T[i,j]/2)
+    J=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in Es])
+    check('geometric_all_phase_exponent_source',zero(Qs*qnu-J))
+    e_tau=s.zeros(15,1);e_tau[m.idx[frozenset((3,))]]=1
+    check('geometric_all_phase_static_poisson',zero(Qs*qnu.subs(nu,1)+lap*e_tau))
+    check('wrong_poisson_sign_rejected',not zero(Qs*qnu.subs(nu,1)-lap*e_tau))
+    check('constant_mode_any_exponent',zero(Qs.subs({x:1 for x in w[:3]})*qnu.subs({x:1 for x in w[:3]})))
+
+    phi=s.Matrix(1,15,lambda a,i:Es[i][3,3]/2)
+    Psp=s.eye(3)-ps[:3,0]*ps[:3,0].T/lap
+    psi=s.Matrix(1,15,lambda a,i:-s.trace(Psp*Es[i][:3,:3])/4)
+    Gs=G.subs(static)
+    check('phi_gauge_annihilation_all_phases',zero(phi*Gs))
+    check('psi_gauge_annihilation_all_phases',zero(psi*Gs))
+    check('phi_endpoint_mean',zero(phi*qnu.subs(nu,1)-s.ones(1)))
+    check('psi_endpoint_mean',zero(psi*qnu.subs(nu,1)-s.ones(1)))
+    check('hyperdiagonal_readout_zero',phi[0,14]==0 and psi[0,14]==0)
+    for a in range(3):
+        check('scalar_seam_periodicity_'+str(a),zero(psi.subs(w[a],-w[a])-psi))
+
+    fixtures=[('origin',[1,1,1,1],4),
+              ('static_axis_nyquist',[s.I,1,1,1],10),
+              ('static_two_components',[s.I,s.Rational(3,5)+s.I*s.Rational(4,5),1,1],10),
+              ('complex_axis_shell',[s.I,1,1,s.sqrt(2)-1],8),
+              ('complex_axis_off_shell',[s.I,1,1,s.Rational(1,2)],10)]
+    ranks=[]
+    for name,values,expected in fixtures:
+        sub=dict(zip(w,values))
+        matrix=Q.subs(sub).applyfunc(s.simplify)
+        rank=matrix.rank()
+        check('exact_rank_'+name,rank==expected)
+        ranks.append({'fixture':name,'rank':rank,'expected':expected})
+
+    # Direct symmetric-matrix operator: no edge map or geometric Hessian used here.
+    def F(v,H):
+        d=(v.T*v)[0];u=H*v;t=s.trace(H)
+        return d*H-v*u.T-u*v.T+(v*v.T)*t+s.eye(4)*((v.T*H*v)[0]-d*t)
+    components=[(a,a) for a in range(4)]+list(__import__('itertools').combinations(range(4),2))
+    basis=[]
+    for a,b in components:
+        h=s.zeros(4);h[a,b]=h[b,a]=1;basis.append(h)
+    for name,v,rank in [('nonnull',s.Matrix([1,2,0,0]),6),('null',s.Matrix([1,0,0,s.I]),4)]:
+        mat=s.Matrix(10,10,lambda i,j:F(v,basis[j])[components[i]])
+        check('direct_fierz_operator_rank_'+name,mat.rank()==rank)
+        for a in range(4):
+            u=s.eye(4)[:,a]
+            check('direct_fierz_gauge_'+name+'_'+str(a),F(v,v*u.T+u*v.T)==s.zeros(4))
+
+    v=s.Matrix([2,0,0,0]);d=4;Pi=s.eye(4)-v*v.T/d
+    T=s.Matrix([[0,0,0,0],[0,1,2,3],[0,2,-1,4],[0,3,4,5]])
+    U=s.Matrix([[0,0,0,0],[0,2,1,-2],[0,1,3,1],[0,-2,1,4]])
+    def sol(A):return -4*(A-Pi*s.trace(A)/2)/d
+    HT,HU=sol(T),sol(U)
+    check('source_inverse_normalization',-F(v,HT)/4==T)
+    check('source_reciprocity',s.trace(U*HT)==s.trace(T*HU))
+    # Verify tensor off-diagonal factor on the actual q-source lift.
+    sub={w[0]:s.I,w[1]:1,w[2]:1,w[3]:1}
+    edgeJ=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in E]).subs(sub)
+    wrongT=T.copy()
+    for a in range(4):
+        for b in range(4):
+            if a!=b:wrongT[a,b]/=2
+    wrongJ=s.Matrix([s.trace(h.applyfunc(m.minus)*wrongT) for h in E]).subs(sub)
+    check('missing_offdiagonal_source_factor_rejected',edgeJ!=wrongJ)
+
+    out={'status':'passed','scope':'exact Laurent static identities and finite algebraic rank fixtures; same author, no physical graviton conclusion',
+         'checks':checks,'count':len(checks),'rank_fixtures':ranks,
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/stderr.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_local_hessian_check_2026_09_13 import run as geo; from regge_source_rank_check_2026_09_13 import run; run(geo()[1])
+                                                                                                                     ~~~^^^^^^^^^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/regge_source_rank_check_2026_09_13.py", line 33, in run
+    check('geometric_all_phase_exponent_source',zero(Qs*qnu-J))
+    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/source_offdiagonal_halved/regge_source_rank_check_2026_09_13.py", line 18, in check
+    if not condition:raise AssertionError(name)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+AssertionError: geometric_all_phase_exponent_source

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/regge_tensor_transfer_check_2026_09_13.py
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/regge_tensor_transfer_check_2026_09_13.py
@@ -1,0 +1,97 @@
+"""Full mixed constraints, Gaussian transfer and exact polynomial fragments.
+
+Only this source is read for an integrity hash. The transfer calculation does
+not import the geometric checker or use its expected coefficient matrix.
+"""
+from __future__ import annotations
+import json,time,hashlib
+from pathlib import Path
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic();checks=[]
+    def check(name,condition):
+        if not condition:raise AssertionError(name)
+        checks.append(name)
+    r,t=s.symbols('r t',real=True);tau,sigma,a,b1,b2,b3,v1,v2,u,w=s.symbols('tau sigma a b1 b2 b3 v1 v2 u w',real=True)
+    H=s.Matrix([[tau/2+u,w,v1,b1],[w,tau/2-u,v2,b2],[v1,v2,sigma,b3],[b1,b2,b3,a]])
+    p=s.Matrix([0,0,r,t]);D=r*r+t*t
+    F=s.expand(D*s.trace(H*H)-2*(H*p).dot(H*p)+2*s.trace(H)*(p.T*H*p)[0]-D*s.trace(H)**2)
+    Ft=2*D*(u*u+w*w);Fv=2*((t*v1-r*b1)**2+(t*v2-r*b2)**2)
+    Fs=-D*tau*tau/2-2*tau*(r*r*a+t*t*sigma-2*r*t*b3)
+    check('full_mixed_decomposition',s.expand(F-Ft-Fv-Fs)==0)
+    check('lapse_equation',s.diff(F,a)==-2*r*r*tau)
+    check('first_shift_equation',s.expand(s.diff(F,b1)-4*r*(r*b1-t*v1))==0)
+    check('second_shift_equation',s.expand(s.diff(F,b2)-4*r*(r*b2-t*v2))==0)
+    check('remaining_scalar_equation',s.expand(s.diff(F,tau).subs(tau,0)+2*(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    check('wrong_missing_scalar_cross_rejected',s.expand(F-Ft-Fv+D*tau*tau/2)!=0)
+    check('wrong_missing_vector_cross_rejected',s.expand(Fv-2*(t*t*(v1*v1+v2*v2)+r*r*(b1*b1+b2*b2)))!=0)
+    eta=s.Matrix(s.symbols('e0:4'))
+    HG=H+s.I*(p*eta.T+eta*p.T)
+    check('trace_constraint_gauge',s.expand(HG[0,0]+HG[1,1]-tau)==0)
+    check('tensor_gauge',HG[0,1]==w and s.expand((HG[0,0]-HG[1,1])/2-u)==0)
+    for j in (0,1):
+        check('vector_combination_gauge_'+str(j),s.expand(t*HG[j,2]-r*HG[j,3]-(t*H[j,2]-r*H[j,3]))==0)
+    check('scalar_combination_gauge',s.expand(r*r*HG[3,3]+t*t*HG[2,2]-2*r*t*HG[2,3]-(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    # On the constraint surface the explicit gauge choice kills every non-TT entry.
+    HS=H.subs({tau:0,b1:t*v1/r,b2:t*v2/r,a:(2*r*t*b3-t*t*sigma)/(r*r)})
+    g3=-sigma/(2*s.I*r)
+    g0=-(b3+s.I*t*g3)/(s.I*r)
+    g=s.Matrix([-v1/(s.I*r),-v2/(s.I*r),g3,g0])
+    fixed=(HS+s.I*(p*g.T+g*p.T)).applyfunc(s.simplify)
+    check('explicit_full_constraint_gauge_reduction',fixed==s.Matrix([[u,w,0,0],[w,-u,0,0],[0,0,0,0],[0,0,0,0]]))
+
+    z=s.Symbol('z',positive=True);x,beta=s.symbols('x beta',real=True)
+    A=(z+1/z)/2;alpha=(1/z-z)/4
+    check('transfer_width_equation',s.simplify(alpha**2-(A*A-1))==0)
+    check('transfer_generating_quadratic',s.simplify(2*alpha*z-1+z*z)==0)
+    check('transfer_generating_constant',s.simplify(A-z-alpha)==0)
+    # The domain is 0<z<1, hence r=(1-z)/sqrt(z)>0; keep that sign explicitly.
+    r_from_z=(1-z)/s.sqrt(z)
+    check('transfer_trace',s.simplify(s.sqrt(z)/(1-z)-1/r_from_z)==0)
+    # A separate Gaussian-moment recurrence checks seven Hermite eigenfunctions.
+    z0=s.Rational(1,2);alpha0=s.Rational(3,4);A0=s.Rational(5,4)
+    y=s.Symbol('y');mom=[s.S.One,z0*x]
+    for n in range(2,7):mom.append(s.expand(z0*x*mom[-1]+(n-1)*z0*mom[-2]))
+    for n in range(7):
+        poly=s.Poly(s.hermite(n,s.sqrt(alpha0)*y),y)
+        expectation=sum(coef*mom[power[0]] for power,coef in poly.terms())
+        check('hermite_transfer_eigenfunction_'+str(n),s.expand(expectation-z0**n*s.hermite(n,s.sqrt(alpha0)*x))==0)
+    check('continuum_width_substitution_rejected',s.Rational(1,2)!=A0*A0-1)
+
+    phase=s.Symbol('phase',nonzero=True)
+    Csum=(1-z*z)/((1-z*phase)*(1-z/phase))/(2*alpha)
+    check('covariance_fourier_all_phases',s.cancel(Csum-1/((1-z)**2/z+2-phase-1/phase))==0)
+
+    # Exact finite polynomial fragments in the full oscillator's invariant degree range.
+    N=8
+    T=s.diag(*[z0**n for n in range(N)])
+    X=s.zeros(N)
+    for n in range(N-1):X[n,n+1]=X[n+1,n]=s.sqrt(s.Rational(n+1)/(2*alpha0))
+    Omega=s.eye(N)[:,0]
+    vecs=[T*X*Omega,T**2*(X**2-s.eye(N)/(2*alpha0))*Omega,T*X*T*X**2*Omega]
+    V=s.Matrix.hstack(*vecs)
+    check('polynomial_fragments_no_cutoff_contact',V[7,:]==s.zeros(1,3))
+    site=(V.T*V).applyfunc(s.simplify);link=(V.T*T*V).applyfunc(s.simplify)
+    for name,gram in [('site',site),('link',link)]:
+        for order in range(1,4):
+            for inds in __import__('itertools').combinations(range(3),order):
+                check('reflection_'+name+'_'+str(inds),gram.extract(inds,inds).det()>=0)
+    wrong=T.copy();wrong[1,1]=-wrong[1,1]
+    check('negative_transfer_mode_rejected',((X*Omega).T*wrong*(X*Omega))[0]<0)
+    for n in (0,1,2,5):
+        check('exact_vacuum_covariance_'+str(n),(Omega.T*X*T**n*X*Omega)[0]==z0**n/(2*alpha0))
+
+    ps=s.symbols('p0:3',real=True);R2=sum(q*q for q in ps)
+    num=sum(q*q*(1-q*q/4) for q in ps)
+    check('group_velocity_identity',s.expand(num-(R2-sum(q**4 for q in ps)/4))==0)
+    check('group_velocity_axis_nyquist',num.subs({ps[0]:2,ps[1]:0,ps[2]:0})==0)
+
+    out={'status':'passed','scope':'exact constraints, Gaussian spectral algebra and finite polynomial fragments; reduced quantization only',
+         'checks':checks,'count':len(checks),'transfer_fixture':{'z':'1/2','width':'3/4','r_squared':'1/2','hermite_degrees':list(range(7))},
+         'reflection_gram_site':[[str(site[i,j]) for j in range(3)] for i in range(3)],
+         'reflection_gram_link':[[str(link[i,j]) for j in range(3)] for i in range(3)],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),'elapsed_sec':time.monotonic()-started}
+
+    return out

--- a/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/stderr.txt
+++ b/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/stderr.txt
@@ -1,0 +1,11 @@
+Traceback (most recent call last):
+  File "<string>", line 2, in <module>
+    from regge_tensor_transfer_check_2026_09_13 import run; run()
+                                                            ~~~^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/regge_tensor_transfer_check_2026_09_13.py", line 47, in run
+    check('transfer_width_equation',s.simplify(alpha**2-(A*A-1))==0)
+    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/jonreilly/Projects/Physics-worktrees/regge-exact-reduction-positive-transfer-20260913/.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/transfer_width_halved/regge_tensor_transfer_check_2026_09_13.py", line 15, in check
+    if not condition:raise AssertionError(name)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+AssertionError: transfer_width_equation

--- a/docs/REGGE_EXACT_REDUCTION_POSITIVE_TENSOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-09-13.md
+++ b/docs/REGGE_EXACT_REDUCTION_POSITIVE_TENSOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-09-13.md
@@ -1,0 +1,561 @@
+---
+claim_id: regge_exact_reduction_positive_tensor_transfer_bounded_theorem_note_2026-09-13
+claim_type: bounded_theorem
+claim_scope: "Supplied unit 4D path complex and length Regge action: exact Hessian reduction, conserved-source lift, static kernel-invariant readouts, full scalar/vector constraints and a positive reduced tensor transfer on finite odd spatial tori with zero spatial mode removed."
+upstream_dependencies:
+  - the_regge_second_variation_on_the_4d_cubic_coxeter_complex_carries_a_native_linearised_graviton_bounded_theorem_note_2026-09-03
+  - the_formation_rate_defines_the_static_regge_edge_lengths_exactly_regge_is_the_lattice_poisson_equation_and_forces_nu_r_equal_one_bounded_theorem_note_2026-09-03
+runner: scripts/regge_exact_reduction_positive_transfer_2026_09_13.py
+---
+
+# Exact Regge reduction and a positive reduced tensor transfer
+
+**Date:** 2026-09-13
+**Type:** bounded_theorem
+**Status:** proposed_retained
+
+Actual current-surface status is conditional-support. This is an author
+proposal; independent source review and formal audit remain pending.
+
+The corrected main [spectrum note](THE_REGGE_SECOND_VARIATION_ON_THE_4D_CUBIC_COXETER_COMPLEX_CARRIES_A_NATIVE_LINEARISED_GRAVITON_BOUNDED_THEOREM_NOTE_2026-09-03.md) and
+[static-source note](THE_FORMATION_RATE_DEFINES_THE_STATIC_REGGE_EDGE_LENGTHS_EXACTLY_REGGE_IS_THE_LATTICE_POISSON_EQUATION_AND_FORCES_NU_R_EQUAL_ONE_BOUNDED_THEOREM_NOTE_2026-09-03.md) retain finite diagnostics after
+withdrawing broader metric-projection and invariant-readout conclusions.
+This note derives the full coefficient identity and a different metric map,
+then constructs exact scalar readouts and a positive reduced tensor transfer.
+The earlier corrections remain valid. No physical graviton, matter source,
+clock, nonlinear closure or axiom selection is inferred from this result.
+
+~~~yaml
+actual_current_surface_status: conditional-support
+conditional_surface_status: conditional-support
+target_claim_type: bounded_theorem
+claim_type_reason: "Exact local geometry and coefficient identities followed by analytical constraint reduction and a Gaussian transfer proof."
+trace_class: upstream_support
+target_claim_id: the_regge_second_variation_on_the_4d_cubic_coxeter_complex_carries_a_native_linearised_graviton_bounded_theorem_note_2026-09-03
+target_blocker_text: "Supply an all-momentum tensor reduction and a positive reduced state construction, with source and clock assumptions explicit."
+source_of_blocker_text: handoff
+reachability_to_target: partially_closes
+artifact_role: theorem
+next_trace_action: "Independently review this linear source unit; derive common physical matter coupling and nonlinear compatibility separately."
+hypothetical_axiom_status: null
+admitted_observation_status: null
+audit_required_before_effective_retained: true
+bare_retained_allowed: false
+~~~
+
+The two named main notes are context and comparison targets. Their geometric
+object is supplied and reconstructed below; no old sampled conclusion is used
+as a premise in the proof. Literature priority is stated in Part A. The full
+new argument is contained in this source unit and its directly imported checks.
+
+## A1. Object and prior art
+
+The complex consists of all 24 ordered coordinate paths in each unit 4-cube.
+Its action is S_R=sum_t A_t delta_t, with positive Euclidean simplex lengths.
+At the flat background each nonempty coordinate subset A labels an edge of
+length sqrt(|A|). Write q_A=delta(length_A squared); then
+q_A=2sqrt(|A|)delta l_A at first order. All Hessians below are with respect to
+q, and q(-k)^T Q(k)q(k) is the second variation, not the quadratic Taylor term
+(which has an additional factor 1/2). No continuum limit is used in this identity.
+
+The length-Regge reduction to ten metric coordinates, four body variables and
+a decoupled hyperdiagonal is established prior art. The relevant primary
+sections read are Bahr–Dittrich–He, [arXiv:1011.3667v2](https://arxiv.org/html/1011.3667v2),
+section 6.1 and appendix A, and Dittrich,
+[arXiv:2105.10808](https://arxiv.org/pdf/2105.10808), section IV.B.5.
+The present derivation reconstructs the exact coefficients in this repository's
+normalization and uses the resulting map to settle its static source/readout
+questions. It does not claim discovery of linearized lattice gravity.
+
+## A2. A rational local Hessian from geometry
+
+In the reference simplex let X_j=e_1+...+e_j for j=0,...,4. The barycentric
+normal vectors are
+
+n_0=-e_1, n_1=e_1-e_2, n_2=e_2-e_3, n_3=e_3-e_4, n_4=e_4.
+
+They sum to zero. Let h be its infinitesimal metric in this orthonormal
+coordinate frame. For the hinge opposite vertices i,j set
+
+a=n_i.n_i, b=n_i.n_j, c=n_j.n_j,
+N=(n_i,n_j), P=I-N(N^T N)^(-1)N^T.
+
+P projects onto the two-dimensional hinge plane. The flat simplex volume is
+1/24, and its hinge area is A=sqrt(ac-b^2)/2. The interior angle obeys
+cos(theta)=-b/sqrt(ac). Differentiating the inverse metric in this formula gives
+
+A delta theta = -1/2 [n_i^T h n_j
+             - b/2 (n_i^T h n_i/a+n_j^T h n_j/c)].                 (2.1)
+
+Also delta A/A=tr(P h)/2. These are ordinary first derivatives at a nondegenerate
+Euclidean simplex; no numerical angle derivative is used. Summing (2.1) over
+all missing pairs gives zero: sum_(j != i)n_i.n_j=-a and sum_i n_i=0 cancel
+the two terms. This is the needed Schlaefli identity directly in these variables.
+It removes area-times-second-angle terms from the global flat second variation.
+Consequently each simplex contributes
+
+1/4 sum_(i<j) tr(P_ij h)
+  [n_i^T h n_j - (b_ij/2)(n_i^T h n_i/a_i+n_j^T h n_j/a_j)].      (2.2)
+
+For the ten squared-edge variations q_ij, with q_ii=0,
+
+h_aa=q_(a-1,a),
+h_ab=(q_(a,b-1)+q_(a-1,b)-q_(a,b)-q_(a-1,b-1))/2, a<b.         (2.3)
+
+The local quadratic matrix in edge order
+01,02,03,04,12,13,14,23,24,34 is exactly 1/48 times
+
+```text
+ 0  0  0  0  0  3  0 -6  0  0
+ 0 -3  3  0  6 -6  0  3  0  0
+ 0  3 -2  0 -6  3  0  0  0  0
+ 0  0  0  0  0  0  0  0  0  0
+ 0  6 -6  0 -6  6  0  0  3 -6
+ 3 -6  3  0  6 -6  3  6 -6  3
+ 0  0  0  0  0  3 -2 -6  3  0
+-6  3  0  0  0  6 -6 -6  6  0
+ 0  0  0  0  3 -6  3  6 -3  0
+ 0  0  0  0 -6  3  0  0  0  0
+```
+
+This table is obtained by substitution into (2.2), not by fitting the old
+Hessian. Its zero 04 row also explains the hyperdiagonal zero before Fourier
+transformation. For a permutation sigma, local edge ij maps to class
+A={sigma_(i+1),...,sigma_j} at anchor {sigma_1,...,sigma_i}. Its Fourier
+multiplier is z_anchor. Thus the global Q is the sum of 24 translated copies
+of this displayed rational table. This is an explicit finite Laurent formula.
+
+## A3. Exact body elimination and the correct metric coordinates
+
+Put z_a=exp(i k_a), w_a=exp(i k_a/2), p_a=2sin(k_a/2), Delta=sum_a p_a^2.
+For each triple A={a,b,c}, define
+
+r_A=q_A - 1/2 sum_(ij subset A)(1+z_(A minus ij))q_ij
+          + 1/2 sum_(i in A)(z_j+z_k)q_i.                       (3.1)
+
+Let C be this four-row map. Define ten symmetric metric coordinates by
+
+h_aa=q_a, h_ab=(q_ab-q_a-q_b)/2,
+H_aa=h_aa, H_ab=h_ab/(w_a w_b), a!=b.                          (3.2)
+
+The change from (q_axis,q_face,q_body,q_hyper) to (H,r,q_hyper) is invertible
+for every finite complex k: the nonzero phases and the diagonal body coefficients
+never require a Laplacian inverse. H is a discrete metric coordinate, not the
+old line-integrated continuum metric field. The latter map is unchanged.
+
+Collecting the 24 local tables gives
+
+q(-k)^T Q(k)q(k) = -1/4 F_p(H(-k),H(k))
+                         -1/2 sum_A r_A(-k)r_A(k),             (3.3)
+
+where, for symmetric matrices U,V,
+
+F_p(U,V)=Delta tr(U V)-2(Up).(Vp)
+        +tr(U) p^T V p+tr(V) p^T U p-Delta tr(U)tr(V).          (3.4)
+
+The p here belongs to k on both sides of (3.4); p(-k)=-p(k), while H(-k)
+is the corresponding reversed-phase coordinate. For real k the minus-k field
+is the complex conjugate field. For complex k use the bilinear analytic
+continuation, not a Hermitian conjugate.
+
+One compact coefficient verification of (3.3) is as follows. The body rows of
+the table sum to -C/2, their four-by-four block is -I/2, and the hyperdiagonal
+row is zero. After their Schur elimination and the phase change (3.2), the
+remaining symmetric-component entries have these seven types. Distinct letters
+below are distinct coordinate directions; the off-diagonal component has both
+symmetric matrix entries equal to one, without a sqrt(2) normalization.
+
+| Entries | Reduced coefficient |
+|---|---|
+| aa,aa | 0 |
+| aa,bb | (Delta-p_a^2-p_b^2)/4 |
+| aa,ab | 0 |
+| aa,bc | -p_b p_c/2 |
+| ab,ab | -(Delta-p_a^2-p_b^2)/2 |
+| ab,ac | p_b p_c/2 |
+| ab,cd | 0 |
+
+Coordinate permutations and bilinear symmetry exhaust the ten-component matrix.
+These are exactly the entries of -(3.4)/4. The local rational table and the
+explicit anchor rule make each cancellation inspectable. The separate exact
+checker expands all 225 Laurent entries and rejects any nonzero coefficient;
+this verifies the stated algebra rather than extrapolating from sample momenta.
+
+## A4. Gauge, rank and the continued dispersion
+
+A vertex displacement xi changes q_A by
+
+G_A xi=2(z_A-1)sum_(a in A)xi_a.
+
+Substitution into (3.1) gives r_A=0. For each xi_a coefficient the two face
+terms leave (1-z_a)(z_b+z_c), cancelled by the axis term. With u_a=w_a xi_a,
+(3.2) gives H=i(p u^T+u p^T). Formula (3.4) annihilates this family directly.
+The hyperdiagonal gives a fifth independent null direction at nonzero real k.
+
+For Delta!=0, project transverse to p. Every symmetric H is a sum of a gauge
+field and a transverse symmetric tensor. On the latter, the operator of F is
+Delta(H-Pi tr H), Pi=I-pp^T/Delta. In four dimensions its five-dimensional
+transverse traceless subspace has eigenvalue Delta and its transverse trace
+has eigenvalue -2Delta. The remaining four modes are gauge. Hence the reduced
+rank is six, the full rank is ten and the full nullity is five. For real k
+this holds at every nonzero torus momentum, including Nyquist momenta.
+At p=0 the reduced matrix vanishes, leaving full rank four and nullity eleven.
+
+At a nonzero complex null vector p with Delta=0, the equation F(H)=0 is
+
+H p=(tr H/2)p.                                                (4.1)
+
+To derive it, the trace first gives p^T H p=0; the remaining dyadic equation
+then forces (4.1). The map H -> H p-(tr H/2)p has rank four: choose a null q
+with p.q=1 and two independent transverse vectors; q q^T, q e^T+e q^T, and I
+produce four independent images. Its kernel is therefore six-dimensional.
+It consists of the four gauge directions and two transverse traceless classes
+in the two-dimensional transverse quotient. The full Q has rank eight and
+nullity seven. This is an algebraic quotient count, not yet a reconstructed
+physical Hilbert space or a positive graviton-residue theorem.
+
+With real spatial k and k_t=i omega, omega real positive,
+
+Delta=sum_i 4sin^2(k_i/2)-4sinh^2(omega/2).
+
+Its derivative in omega is -2sinh(omega)<0. Therefore for every nonzero spatial
+momentum modulo 2pi there is exactly one positive zero,
+
+4sinh^2(omega/2)=sum_i 4sin^2(k_i/2).                          (4.2)
+
+All other finite positive frequencies have nullity five, and that zero has
+nullity seven. The invertible coordinate change and constant body block rule
+out additional finite-frequency rank drops in this declared continuation.
+At zero spatial momentum the zero is omega=0 and belongs to the different
+rank-four origin. No claim is made about a nonlinear spectrum, transfer matrix,
+OS reconstruction, physical time, or other actions/triangulations.
+
+## A5. Transport a source through the same action
+
+In the variables (H,r,q_hyper), choose a source which couples only to H, through
+the same bilinear pairing. Its q-covector J is defined by
+q(-k)^T J(k)=tr(H(-k)T(k)). In ten independent symmetric components,
+J=E(-k)^T t, where E is (3.2), t_aa=T_aa and t_ab=2T_ab for a<b.
+The off-diagonal factor is part of the Frobenius pairing. This is an explicit source lift; it is not selected by the axioms. At real
+nonzero k, p^T T=0 is the gauge compatibility condition. The body equations give
+r=0. The metric equation is the reduced equation from (3.4), and the source
+has no hyperdiagonal component. Thus every such conserved source lies in the
+range of the full Hessian. Its solution is unique modulo the complete kernel.
+
+For transverse T a convenient representative is
+
+H = -4/Delta [T-(1/2)Pi tr T].                               (5.1)
+
+Adding a gauge tensor or an arbitrary hyperdiagonal leaves the sourced equation
+unchanged. The inverse response of two compatible sources follows by contraction
+with the same (5.1), so it is reciprocal with common normalization. A physical
+matter action must still derive T and its conservation; a label called energy
+or a supplied external potential alone does not do so.
+
+## A6. Exact static endpoint-mean solution and genuine scalar readouts
+
+Now k_t=0 and spatial Delta>0. Let the optional endpoint-mean ansatz of the
+corrected main static note be expressed in squared edges:
+
+q_A=(n_t(A)-n_s(A))(1+z_A)Phi.                               (6.1)
+
+Substituting into every triple (3.1) gives r=0. For a purely spatial triple,
+the single and pair monomials cancel separately, as do the constant and triple
+monomials. For a triple with t, use z_t=1; the residual is
+(1+z_i z_j)-(1+z_i)(1+z_j)+(z_i+z_j)=0.
+
+Its H differs from diag(-2Phi,-2Phi,-2Phi,+2Phi) by the exact gauge tensor
+i(pu^T+up^T), with u_i=-w_i Phi/2 and u_t=Phi/2. For example the off-diagonal
+spatial entry is Phi(w_i/w_j+w_j/w_i-2w_i w_j)/2, precisely the corresponding
+gauge entry; H_it=i p_i Phi/2. Therefore (3.4) gives the identity
+
+Q_q q = -Delta Phi e_t,
+Q_l delta l = -2Delta Phi e_t = 2 Delta_lat Phi e_t.          (6.2)
+
+This proves the current main note's sampled source identity for every static
+momentum, hence every finite periodic lattice where this path complex is well
+defined. One may periodize the local stencil; usual simple-box geometry uses
+periods at least three. At k=0 the equation is zero for every constant Phi.
+A periodic source must have its constant mode removed, or an explicitly
+specified compensating background; the proof does not bypass that requirement.
+
+For Q_l delta l=8pi G P0 rho e_t, (6.2) gives
+Phi=-4pi G (-Delta_lat)^(-1)P0 rho. The sign agrees with the corrected bridge.
+No Newton constant or physical mass identification is derived.
+
+Define readouts directly from the reduced coordinates,
+
+Phi_inv=H_tt/2,
+Psi_inv=-1/4 sum_(ij spatial)(delta_ij-p_i p_j/Delta)H_ij.     (6.3)
+
+At static momentum every gauge tensor has zero tt component and zero projected
+spatial trace. These readouts also ignore the independent hyperdiagonal, so
+they are invariant under the COMPLETE kernel of Q. On (6.1) both equal Phi;
+they therefore equal Phi on every solution of the same sourced equation,
+including its pseudoinverse representative. They use (3.2), not pinv(M_AM),
+and do not restore the old noninvariant readout routine.
+
+Although half-phase coordinates change signs across a Brillouin-zone seam,
+the scalar readouts are periodic: each p_i p_j H_ij is a Laurent expression
+in z_i,z_j times q-components, and diagonal p_i^2 is periodic. Their inverse
+Laplacian makes the scalar readout spatially nonlocal. No local Record readout
+or physical metric/formation-rate interpretation follows automatically.
+
+## A7. Exact exponent condition within the supplied scalar family
+
+For the broader ansatz q_A=(n_t-nu n_s)(1+z_A)Phi, the body variables still
+vanish. Its H is gauge-equivalent to diag(-2nu Phi,-2nu Phi,-2nu Phi,2Phi):
+use u_i=-nu w_i Phi/2 and u_t=Phi/2. Applying (3.4) gives
+
+T_tt=-nu Delta Phi,
+T_ij=(1-nu)Phi(Delta delta_ij-p_i p_j)/2,
+T_it=0.                                                       (7.1)
+
+Since the spatial projector has rank two for every real static nonzero
+momentum, absence of spatial stress at any mode with Phi nonzero forces nu=1.
+Conversely nu=1 supplies zero spatial stress and (6.2). This holds on the
+whole nonzero static domain, not just the four original tested momenta.
+A constant field, a zero field or a supplied balancing spatial stress does not
+select nu. The conditional theorem does not select a physical ruler law or
+justify treating generic moving matter as a pressure-free source.
+
+## A8. Checks and status
+
+The analytical route and candidate formulas were recorded before the new
+comparison at campaign commit `4889a58373`; the working history is preserved
+on branch `physics-loop/toe-local-formation-20260912`. The exact checker reconstructs the rational local
+normal/area identity and all 24 anchored simplices. Every one of 225 Laurent
+entry differences vanishes identically. It also checks Schlaefli, gauge,
+constant body block, full body rows and the zero hyperdiagonal, and rejects
+removed body terms, reversed action orientation and a missing metric phase.
+The maximal global entry has four Laurent terms; this is a small fixed
+coefficient identity, not a numerical search over momentum or lattice size.
+
+A separate four-point floating comparison uses the existing area/angle
+implementation, with maximum full residual below 7e-16. Its first separate
+body-row comparison used a reversed row order and reported 1/2; the correctly
+indexed full matrices already agreed. The first source/JSON are preserved;
+aligning the body-row order gives residual below 3e-16 without changing the
+mathematical candidate. This is a checker correction, not a discarded physical
+counterexample.
+
+The consequence checker passed 32 named exact checks in 23.98 seconds.
+These include full Laurent exponent/source identities, scalar gauge and seam
+invariance, five finite exact rank fixtures, a separately built symmetric-tensor
+operator, inverse-source normalization and off-diagonal source multiplicity.
+Its finite full ranks are 4 at the origin, 10 at two real static fixtures,
+8 at an exact complex shell and 10 off shell. The complete symbolic static
+identities have no momentum sampling. The first fixed run passed.
+
+The complete proof and checkers received a cold same-author pass. Independent
+review remains pending. Part B adds a reduced positive tensor model under
+additional supplied conventions. Physical source selection, Record formation,
+a clock and nonlinear constraint closure remain open. No axiom or primitive
+has been changed, and formal retention is not claimed.
+
+## B1. Full scalar and vector constraints
+
+At any nonzero real spatial momentum set r=|p_spatial|>0. An orthogonal
+spatial frame takes p=(0,0,r,t), t=2sin(k_t/2). The component order is
+(1,2,3,0): the time index 0 is the fourth component. Use the same frame on
+both sides of the bilinear form. Split the symmetric H as follows:
+
+- H_ab=TT_ab+(tau/2)delta_ab for transverse indices a,b=1,2;
+- H_a3=v_a, H_a0=b_a, H_33=sigma, H_30=b_3, H_00=a.
+
+The TT tensor is traceless in its two-dimensional plane, hence has two
+independent components. Direct expansion of the Part A F_p gives
+
+F_TT=(r^2+t^2)tr(TT^2),
+F_vector=2 sum_(a=1,2)(t v_a-r b_a)^2,
+F_scalar=-(r^2+t^2)tau^2/2
+         -2tau(r^2 a+t^2 sigma-2rt b_3).                       (B1.1)
+
+The displayed squares stand for the bilinear products of the opposite Fourier
+fields, or their absolute squares for real Euclidean momentum. Equation (B1.1)
+is a full mixed-form identity, not a statement about selected diagonal entries.
+
+The lapse equation is r^2 tau=0, so tau=0. The transverse shift equations give
+t v_a-r b_a=0. The remaining scalar equation imposes
+r^2 a+t^2 sigma-2rt b_3=0. The longitudinal shift and sigma equations are
+then redundant. These conclusions need r>0 but no inverse of t.
+
+Under H -> H+i(pu^T+up^T), the transverse transformations are
+v_a -> v_a+i r u_a and b_a -> b_a+i t u_a. Set v_a=0; its shift then vanishes.
+Use u_3 to set sigma=0, and then u_0 to set b_3=0. The scalar equation sets
+a=0. The combinations in (B1.1) are gauge invariant, as direct substitution
+checks. Thus every source-free scalar/vector solution is gauge, for every
+real frequency and its finite complex continuation at r>0. Exactly two tensor
+coordinates remain. This supplies the multiplier/constraint argument missing
+from a test of zero lapse/shift diagonal entries.
+
+The four body coordinates are algebraic with constant nonzero block and vanish
+in the source-free problem. The hyperdiagonal is an additional zero-action
+coordinate at quadratic order, not a vertex gauge transformation. This reduced
+model fixes a section for it and considers only the tensor observables.
+The chosen linear section is not claimed to solve any nonlinear constraint,
+and no nonlinear continuation of these tensor data is established here.
+
+## B2. Finite tensor coordinates and orientation
+
+Choose a finite three-torus with odd side periods at least three and remove
+spatial momentum zero. Every remaining momentum has a distinct conjugate
+partner, so real cosine/sine coordinates can be chosen without a self-inverse
+Nyquist-mode convention. The projector onto spatial transverse traceless tensors is
+
+P_TT,ij,kl = (Pi_ik Pi_jl+Pi_il Pi_jk)/2-Pi_ij Pi_kl/2,
+Pi_ij=delta_ij-p_i p_j/r^2.                                   (B2.1)
+
+It is an orthogonal rank-two projector. Choose an orthonormal tensor basis
+in each conjugate pair, respecting the opposite-phase reality convention of
+Part A. No globally smooth polarization basis is required. This gives
+2(V-1) real tensor coordinates on a V-site spatial torus.
+
+Choose the action orientation -S_R and a positive overall coefficient, fixed
+here to one. The quadratic action is F_TT/8. For each orthonormal amplitude
+h=2X and Parseval-normalized spatial Fourier coordinate, it becomes
+
+I_r[X]=1/2 sum_n[(X_(n+1)-X_n)^2+r^2 X_n^2].                 (B2.2)
+
+Both the orientation and time normalization are supplied. The opposite action
+orientation gives a negative tensor Gaussian and is not selected by this
+calculation. Equation (B2.2) defines the reduced tensor measure; it is not an
+integration over the full unconstrained conformal Regge field.
+
+## B3. Positive transfer, obtained explicitly
+
+On L^2(R,dx) define
+
+K_r(x,y)=(2pi)^(-1/2)
+ exp[-(x-y)^2/2-r^2(x^2+y^2)/4].                            (B3.1)
+
+Products of these kernels produce precisely (B2.2), with its endpoints weighted
+by half the local potential. Let M be multiplication by exp(-r^2x^2/4).
+Then K=M exp(partial_x^2/2)M. The heat operator is positive self-adjoint
+(its Fourier multiplier is exp(-p^2/2)), so K is positive self-adjoint.
+Its Gaussian kernel is Hilbert-Schmidt for r>0. The explicit spectrum below
+also gives trace class. Positivity here is operator positivity, stronger than
+pointwise positivity of the kernel.
+
+Set
+
+A=1+r^2/2=cosh E, a=sqrt(A^2-1)=sinh E,
+E=2asinh(r/2)>0, z=exp(-E).                                 (B3.2)
+
+The normalized Gaussian psi_0(x)=(a/pi)^(1/4)exp(-a x^2/2)
+has eigenvalue exp(-E/2). Gaussian integration of the Hermite generating
+function gives
+
+K{exp(-a y^2/2)exp(2sqrt(a)y s-s^2)}(x)
+ =exp(-E/2)exp(-a x^2/2)exp(2sqrt(a)x z s-z^2 s^2).           (B3.3)
+
+Indeed (A+a)^(-1)=z, A-z=a and 2az-1=-z^2. Comparing powers of s shows
+that the complete Hermite basis of width a has eigenvalues
+
+lambda_m=exp[-E(m+1/2)], m=0,1,... .                          (B3.4)
+
+Their sum is 1/[2sinh(E/2)]=1/r, equal to the integral of K(x,x).
+The normalized transfer T=K/lambda_0 is a positive contraction with a simple
+vacuum eigenvalue one. Its self-adjoint generator is
+
+H_r=-log T=E N_a,
+N_a=(P^2+a^2X^2)/(2a)-1/2.                                  (B3.5)
+
+It defines unitary real-parameter evolution exp(-is H_r). This reconstructs
+a mathematical time evolution for the supplied reduced model; it does not
+identify that parameter with a physical Record clock.
+
+## B4. Reflection positivity and the exact covariance
+
+For finitely many spatial modes use the tensor product of these transfers.
+It is positive trace class before vacuum normalization and has the tensor
+product Gaussian vacuum. Products of bounded functions of X at ordered
+nonnegative integer times define vectors by inserting the appropriate powers
+of T between the functions. Reflection of an ordered product reverses its
+order and takes adjoints. The site-reflected expectation is the Gram pairing
+of those vectors; the link-reflected expectation inserts one positive T.
+Both are nonnegative. Finite linear combinations preserve this property.
+Gaussian moment bounds extend it to polynomial fields. This is reflection
+positivity for the reduced tensor histories, proved by the positive transfer.
+
+Since X psi_0=psi_1/sqrt(2a), the ground-state covariance is
+
+C_r(n)=exp(-E|n|)/(2sinh E).                                 (B4.1)
+
+Summing its geometric series gives
+
+sum_(n in Z) C_r(n) exp(-ik_t n)
+ =1/[2(cosh E-cos k_t)]
+ =1/[r^2+4sin^2(k_t/2)].                                    (B4.2)
+
+Consequently the tensor covariance is 4 P_TT times (B4.2), in the H=2X
+normalization. The two positive spectral weights are 1/(2sinh E) for X.
+This gives an actual positive reduced tensor-state construction with the same
+dispersion as the algebraic Regge rank drop. It does not turn a small singular
+value or an approximate old metric projection into a physical state theorem.
+
+Within the chosen lattice and tick units,
+
+partial E/partial k_i=sin(k_i)/sinh E,
+|grad E|^2=[r^2-(1/4)sum_i p_i^4]/[r^2+r^4/4] <=1.            (B4.3)
+
+The low-momentum speed tends to one. This is a group-velocity statement;
+it does not establish a microscopic causal cone or match the clock/speed of
+the separate native matter model. That comparison still needs one physical
+coordinate and time map.
+
+## B5. Scope and remaining obligations
+
+The Part B theorem is finite-volume, quadratic, source-free and reduced. It uses odd
+spatial periods, nonzero spatial modes, a chosen action orientation and a chosen
+hyperdiagonal section. It proves full scalar/vector elimination and a positive
+tensor transfer in that domain. It supplies neither an unconstrained conformal
+measure nor a nonlinear physical graviton theory.
+
+The strongest remaining connection is a common physical matter/source and time
+map, with a conserved source obtained by varying that same matter action.
+A finite physical qubit realization, a thermodynamic/continuum limit and nonlinear
+constraint propagation remain separate. No axiom, primitive, G or empirical
+constant is derived or amended here. This is proposed conditional-support;
+same-author checks are complete and independent review remains pending.
+
+## B6. Author verification
+
+The exact checker passes 48 checks. It expands the entire mixed scalar/vector/
+tensor form, verifies the gauge transformation that removes constrained entries,
+and rejects missing scalar and vector cross terms. The transfer generating
+identity is checked symbolically, then a separate Gaussian-moment recurrence
+checks the first seven Hermite eigenfunctions at a rational fixture. The
+Fourier covariance is checked as a rational identity for arbitrary phase.
+Exact site and link Gram matrices for finite polynomial fragments are positive;
+an intentionally negative transfer eigenvalue produces a negative link norm.
+These finite checks challenge the analytical proof, rather than replacing its
+all-mode statements. They provide no independent source review.
+
+The first fixed checker run passed. During author cleanup, a redundant squared
+trace predicate was replaced with the signed trace identity using the stated
+domain 0<z<1 and r=(1-z)/sqrt(z). The formulas and claim did not change.
+
+
+## Source, evidence and reproduction
+
+The [primary runner](../scripts/regge_exact_reduction_positive_transfer_2026_09_13.py)
+imports the [local geometry checker](../scripts/regge_local_hessian_check_2026_09_13.py),
+[source and rank checker](../scripts/regge_source_rank_check_2026_09_13.py), and
+[constraint and transfer checker](../scripts/regge_tensor_transfer_check_2026_09_13.py).
+The first derives the rational simplex table and every Laurent coefficient;
+the second consumes that matrix and separately constructs the tensor operator;
+the third constructs the mixed quadratic form and the Gaussian spectral checks
+without importing the edge calculation. The general statements are proved in
+the note. The fixed rank fixtures and polynomial fragments are discriminators,
+not a numerical substitute for the proofs. All evidence is same-author.
+
+The [author review record](../.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/REVIEW_HISTORY.md)
+records source scope and final validation. The
+[scope checklist](../.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/NO_GO_DISCIPLINE_CHECKLIST.md)
+keeps this positive conditional construction distinct from a global no-go.
+
+Six actual scratch source mutations were rejected: wrong local area normalization,
+reversed body sign, omitted metric phase, halved off-diagonal source, omitted
+scalar cross term and halved transfer width. Their exact changes and failures
+are preserved in the [mutation record](../.claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/RESULTS.json).

--- a/docs/audit/data/citation_graph_manifest.json
+++ b/docs/audit/data/citation_graph_manifest.json
@@ -1,6 +1,6 @@
 {
- "edge_count": 12519,
- "node_count": 5041,
+ "edge_count": 12521,
+ "node_count": 5042,
  "nodes": {
   "3d_correction_master_note": {
    "deps_hash": "e3b0c44298fc",
@@ -15721,6 +15721,10 @@
   "regge_curved_prism_tick_dispersion_narrow_theorem_note_2026-06-17": {
    "deps_hash": "7e5bfd516c31",
    "out_degree": 4
+  },
+  "regge_exact_reduction_positive_tensor_transfer_bounded_theorem_note_2026-09-13": {
+   "deps_hash": "1a1675156687",
+   "out_degree": 2
   },
   "regge_ok4_frame_section_narrow_theorem_note_2026-06-17": {
    "deps_hash": "aa05cfece5d8",

--- a/logs/runner-cache/regge_exact_reduction_positive_transfer_2026_09_13.txt
+++ b/logs/runner-cache/regge_exact_reduction_positive_transfer_2026_09_13.txt
@@ -1,0 +1,382 @@
+===== runner cache v1 =====
+runner: scripts/regge_exact_reduction_positive_transfer_2026_09_13.py
+runner_sha256: 1a76056c5fcaa58bcc9c2d5d3c6a340919c446376616d4aa3685c55ad28750cb
+input_fingerprint_sha256: b23ad787278efbdd7acbbc128f2ed515248cbe8fed69043b810944b29f7c5c12
+timeout_sec: 180
+exit_code: 0
+elapsed_sec: 26.42
+status: ok
+----- stdout -----
+{
+  "geometry": {
+    "status": "exact_coefficient_identity_passed",
+    "scope": "one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim",
+    "local_pairs": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        2
+      ],
+      [
+        0,
+        3
+      ],
+      [
+        0,
+        4
+      ],
+      [
+        1,
+        2
+      ],
+      [
+        1,
+        3
+      ],
+      [
+        1,
+        4
+      ],
+      [
+        2,
+        3
+      ],
+      [
+        2,
+        4
+      ],
+      [
+        3,
+        4
+      ]
+    ],
+    "local_hessian": [
+      [
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "1/16",
+        "0",
+        "-1/8",
+        "0",
+        "0"
+      ],
+      [
+        "0",
+        "-1/16",
+        "1/16",
+        "0",
+        "1/8",
+        "-1/8",
+        "0",
+        "1/16",
+        "0",
+        "0"
+      ],
+      [
+        "0",
+        "1/16",
+        "-1/24",
+        "0",
+        "-1/8",
+        "1/16",
+        "0",
+        "0",
+        "0",
+        "0"
+      ],
+      [
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0"
+      ],
+      [
+        "0",
+        "1/8",
+        "-1/8",
+        "0",
+        "-1/8",
+        "1/8",
+        "0",
+        "0",
+        "1/16",
+        "-1/8"
+      ],
+      [
+        "1/16",
+        "-1/8",
+        "1/16",
+        "0",
+        "1/8",
+        "-1/8",
+        "1/16",
+        "1/8",
+        "-1/8",
+        "1/16"
+      ],
+      [
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "1/16",
+        "-1/24",
+        "-1/8",
+        "1/16",
+        "0"
+      ],
+      [
+        "-1/8",
+        "1/16",
+        "0",
+        "0",
+        "0",
+        "1/8",
+        "-1/8",
+        "-1/8",
+        "1/8",
+        "0"
+      ],
+      [
+        "0",
+        "0",
+        "0",
+        "0",
+        "1/16",
+        "-1/8",
+        "1/16",
+        "1/8",
+        "-1/16",
+        "0"
+      ],
+      [
+        "0",
+        "0",
+        "0",
+        "0",
+        "-1/8",
+        "1/16",
+        "0",
+        "0",
+        "0",
+        "0"
+      ]
+    ],
+    "permutations": 24,
+    "matrix_entries": 225,
+    "nonzero_geometry_entries": 146,
+    "residual_entries": 0,
+    "max_laurent_terms": 4,
+    "checks": [
+      "barycentric_normal_sum",
+      "local_schlaefli",
+      "rational_local_hessian",
+      "full_laurent_identity",
+      "exact_vertex_gauge",
+      "body_constraint_gauge",
+      "hyperdiagonal_zero",
+      "body_block",
+      "body_rows",
+      "missing_body_rejected",
+      "orientation_reversed_rejected",
+      "wrong_metric_phase_rejected"
+    ],
+    "source_sha256": "1e172437fca41640f4dc0e90ef4cbee8ce3ca57219327fdedecbe4f588f91188",
+    "elapsed_sec": 0.5331320000113919
+  },
+  "source": {
+    "status": "passed",
+    "scope": "exact Laurent static identities and finite algebraic rank fixtures; same author, no physical graviton conclusion",
+    "checks": [
+      "all_phase_exponent_body",
+      "all_phase_exponent_gauge",
+      "geometric_all_phase_exponent_source",
+      "geometric_all_phase_static_poisson",
+      "wrong_poisson_sign_rejected",
+      "constant_mode_any_exponent",
+      "phi_gauge_annihilation_all_phases",
+      "psi_gauge_annihilation_all_phases",
+      "phi_endpoint_mean",
+      "psi_endpoint_mean",
+      "hyperdiagonal_readout_zero",
+      "scalar_seam_periodicity_0",
+      "scalar_seam_periodicity_1",
+      "scalar_seam_periodicity_2",
+      "exact_rank_origin",
+      "exact_rank_static_axis_nyquist",
+      "exact_rank_static_two_components",
+      "exact_rank_complex_axis_shell",
+      "exact_rank_complex_axis_off_shell",
+      "direct_fierz_operator_rank_nonnull",
+      "direct_fierz_gauge_nonnull_0",
+      "direct_fierz_gauge_nonnull_1",
+      "direct_fierz_gauge_nonnull_2",
+      "direct_fierz_gauge_nonnull_3",
+      "direct_fierz_operator_rank_null",
+      "direct_fierz_gauge_null_0",
+      "direct_fierz_gauge_null_1",
+      "direct_fierz_gauge_null_2",
+      "direct_fierz_gauge_null_3",
+      "source_inverse_normalization",
+      "source_reciprocity",
+      "missing_offdiagonal_source_factor_rejected"
+    ],
+    "count": 32,
+    "rank_fixtures": [
+      {
+        "fixture": "origin",
+        "rank": 4,
+        "expected": 4
+      },
+      {
+        "fixture": "static_axis_nyquist",
+        "rank": 10,
+        "expected": 10
+      },
+      {
+        "fixture": "static_two_components",
+        "rank": 10,
+        "expected": 10
+      },
+      {
+        "fixture": "complex_axis_shell",
+        "rank": 8,
+        "expected": 8
+      },
+      {
+        "fixture": "complex_axis_off_shell",
+        "rank": 10,
+        "expected": 10
+      }
+    ],
+    "source_sha256": "ab08cd53644936b9d5169e3db4da170d02b03a1f7df222c7ec3776129071d51f",
+    "elapsed_sec": 25.422252500022296
+  },
+  "transfer": {
+    "status": "passed",
+    "scope": "exact constraints, Gaussian spectral algebra and finite polynomial fragments; reduced quantization only",
+    "checks": [
+      "full_mixed_decomposition",
+      "lapse_equation",
+      "first_shift_equation",
+      "second_shift_equation",
+      "remaining_scalar_equation",
+      "wrong_missing_scalar_cross_rejected",
+      "wrong_missing_vector_cross_rejected",
+      "trace_constraint_gauge",
+      "tensor_gauge",
+      "vector_combination_gauge_0",
+      "vector_combination_gauge_1",
+      "scalar_combination_gauge",
+      "explicit_full_constraint_gauge_reduction",
+      "transfer_width_equation",
+      "transfer_generating_quadratic",
+      "transfer_generating_constant",
+      "transfer_trace",
+      "hermite_transfer_eigenfunction_0",
+      "hermite_transfer_eigenfunction_1",
+      "hermite_transfer_eigenfunction_2",
+      "hermite_transfer_eigenfunction_3",
+      "hermite_transfer_eigenfunction_4",
+      "hermite_transfer_eigenfunction_5",
+      "hermite_transfer_eigenfunction_6",
+      "continuum_width_substitution_rejected",
+      "covariance_fourier_all_phases",
+      "polynomial_fragments_no_cutoff_contact",
+      "reflection_site_(0,)",
+      "reflection_site_(1,)",
+      "reflection_site_(2,)",
+      "reflection_site_(0, 1)",
+      "reflection_site_(0, 2)",
+      "reflection_site_(1, 2)",
+      "reflection_site_(0, 1, 2)",
+      "reflection_link_(0,)",
+      "reflection_link_(1,)",
+      "reflection_link_(2,)",
+      "reflection_link_(0, 1)",
+      "reflection_link_(0, 2)",
+      "reflection_link_(1, 2)",
+      "reflection_link_(0, 1, 2)",
+      "negative_transfer_mode_rejected",
+      "exact_vacuum_covariance_0",
+      "exact_vacuum_covariance_1",
+      "exact_vacuum_covariance_2",
+      "exact_vacuum_covariance_5",
+      "group_velocity_identity",
+      "group_velocity_axis_nyquist"
+    ],
+    "count": 48,
+    "transfer_fixture": {
+      "z": "1/2",
+      "width": "3/4",
+      "r_squared": "1/2",
+      "hermite_degrees": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    "reflection_gram_site": [
+      [
+        "1/6",
+        "0",
+        "1/6"
+      ],
+      [
+        "0",
+        "1/288",
+        "0"
+      ],
+      [
+        "1/6",
+        "0",
+        "97/576"
+      ]
+    ],
+    "reflection_gram_link": [
+      [
+        "1/12",
+        "0",
+        "1/12"
+      ],
+      [
+        "0",
+        "1/1152",
+        "0"
+      ],
+      [
+        "1/12",
+        "0",
+        "385/4608"
+      ]
+    ],
+    "source_sha256": "7a94cd98ea09453a5f9fe3b43cd05e8b935284e33b353391f83529f30e9ff278",
+    "elapsed_sec": 0.10164320800686255
+  }
+}
+per_element: Every rational simplex entry follows from normal and area variations.
+per_site: Literal simplex anchors are included in the assembled cell.
+per_mode: All 225 Laurent coefficients and all-phase static source identities are exact.
+per_block: Full scalar/vector cross terms and the positive tensor transfer are checked.
+lattice_wide: checked and not executed — all-volume statements are analytical consequences of the local identity; no full-lattice simulation.
+TOTAL: PASS=92 FAIL=0
+
+----- stderr -----
+

--- a/scripts/regge_exact_reduction_positive_transfer_2026_09_13.py
+++ b/scripts/regge_exact_reduction_positive_transfer_2026_09_13.py
@@ -1,0 +1,32 @@
+"""Exact discriminating checks for the accompanying analytical derivation."""
+AUDIT_TIMEOUT_SEC = 180
+AUDIT_INPUT_PATHS = (
+    "docs/REGGE_EXACT_REDUCTION_POSITIVE_TENSOR_TRANSFER_BOUNDED_THEOREM_NOTE_2026-09-13.md",
+    "scripts/regge_local_hessian_check_2026_09_13.py",
+    "scripts/regge_source_rank_check_2026_09_13.py",
+    "scripts/regge_tensor_transfer_check_2026_09_13.py",
+    ".claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/NO_GO_DISCIPLINE_CHECKLIST.md",
+    ".claude/science/physics-loops/regge-exact-reduction-positive-transfer-20260913/mutations/RESULTS.json",
+)
+import json,signal
+from regge_local_hessian_check_2026_09_13 import run as geometry_check
+from regge_source_rank_check_2026_09_13 import run as source_check
+from regge_tensor_transfer_check_2026_09_13 import run as transfer_check
+
+def main():
+    signal.alarm(AUDIT_TIMEOUT_SEC)
+    geometry,bundle=geometry_check()
+    source=source_check(bundle)
+    transfer=transfer_check()
+    total=len(geometry['checks'])+source['count']+transfer['count']
+    print(json.dumps({'geometry':geometry,'source':source,'transfer':transfer},indent=2))
+    print('per_element: Every rational simplex entry follows from normal and area variations.')
+    print('per_site: Literal simplex anchors are included in the assembled cell.')
+    print('per_mode: All 225 Laurent coefficients and all-phase static source identities are exact.')
+    print('per_block: Full scalar/vector cross terms and the positive tensor transfer are checked.')
+    print('lattice_wide: checked and not executed — all-volume statements are analytical consequences of the local identity; no full-lattice simulation.')
+    print(f'TOTAL: PASS={total} FAIL=0')
+    signal.alarm(0)
+
+if __name__=='__main__':
+    main()

--- a/scripts/regge_local_hessian_check_2026_09_13.py
+++ b/scripts/regge_local_hessian_check_2026_09_13.py
@@ -1,0 +1,122 @@
+"""Rational simplex geometry and a fixed all-phase Laurent identity.
+
+No input files are read except this module's own bytes for an integrity hash.
+"""
+from __future__ import annotations
+import itertools,json,time,hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic()
+    R=s.Rational
+    pairs=list(itertools.combinations(range(5),2))
+    q=s.symbols('q:10'); qdict=dict(zip(pairs,q))
+    def edge(a,b):
+        return s.S.Zero if a==b else qdict[tuple(sorted((a,b)))]
+    H=s.zeros(4)
+    for a in range(1,5):
+        H[a-1,a-1]=edge(a-1,a)
+        for b in range(a+1,5):
+            H[a-1,b-1]=H[b-1,a-1]=R(1,2)*(edge(a,b-1)+edge(a-1,b)-edge(a,b)-edge(a-1,b-1))
+    normals=[s.Matrix([-1,0,0,0]),s.Matrix([1,-1,0,0]),s.Matrix([0,1,-1,0]),s.Matrix([0,0,1,-1]),s.Matrix([0,0,0,1])]
+    assert sum(normals,s.zeros(4,1))==s.zeros(4,1)
+    local=s.S.Zero; schlaefli=s.S.Zero
+    for i,j in pairs:
+        ni,nj=normals[i],normals[j]
+        a,b,c=(ni.dot(ni),ni.dot(nj),nj.dot(nj))
+        N=ni.row_join(nj); P=s.eye(4)-N*(N.T*N).inv()*N.T
+        W=(ni.T*H*nj)[0]-b*R(1,2)*((ni.T*H*ni)[0]/a+(nj.T*H*nj)[0]/c)
+        schlaefli-=W/2
+        local+=s.trace(P*H)*W/4
+    assert s.expand(schlaefli)==0
+    local=s.expand(local)
+    Q0=s.hessian(local,q)/2
+    assert Q0==Q0.T
+    assert all(x.is_Rational for x in Q0)
+
+
+    w=s.symbols('w0:4',nonzero=True); z=[x*x for x in w]
+    sets=[frozenset(a for a,b in enumerate(v) if b) for v in itertools.product((0,1),repeat=4) if any(v)]
+    idx={A:i for i,A in enumerate(sets)}
+    def mon(anchor):
+        return s.prod(z[i] for i in anchor)
+    Q=s.zeros(15)
+    for perm in itertools.permutations(range(4)):
+        maps=[]
+        for a,b in pairs:
+            maps.append((idx[frozenset(perm[a:b])],frozenset(perm[:a])))
+        for i,(ci,ai) in enumerate(maps):
+            for j,(cj,aj) in enumerate(maps):
+                if Q0[i,j]:Q[ci,cj]+=Q0[i,j]*mon(aj)/mon(ai)
+    Q=Q.applyfunc(s.expand)
+
+
+    C=s.zeros(4,15)
+    for i,A in enumerate(itertools.combinations(range(4),3)):
+        C[i,idx[frozenset(A)]]=1
+        for a,b in itertools.combinations(A,2):
+            c=next(x for x in A if x not in (a,b))
+            C[i,idx[frozenset((a,b))]]-=(1+z[c])/2
+        for a in A:
+            b,c=[x for x in A if x!=a]
+            C[i,idx[frozenset((a,))]]+=(z[b]+z[c])/2
+
+    def minus(expr):return expr.xreplace({x:1/x for x in w})
+    Cm=C.applyfunc(minus)
+    E=[]
+    for A in sets:
+        h=s.zeros(4)
+        for a in range(4):h[a,a]=int(A==frozenset((a,)))
+        for a,b in itertools.combinations(range(4),2):
+            value=(int(A==frozenset((a,b)))-int(A==frozenset((a,)))-int(A==frozenset((b,))))/(2*w[a]*w[b])
+            h[a,b]=h[b,a]=value
+        E.append(h)
+    p=s.Matrix([(x-1/x)/s.I for x in w]); lap=s.expand(p.dot(p))
+    F=s.zeros(15)
+    for a,Ha in enumerate(E):
+        left=Ha.applyfunc(minus)
+        for b,Hb in enumerate(E):
+            F[a,b]=s.expand(-R(1,4)*(lap*s.trace(left*Hb)-2*(left*p).dot(Hb*p)+s.trace(left)*(p.T*Hb*p)[0]+s.trace(Hb)*(p.T*left*p)[0]-lap*s.trace(left)*s.trace(Hb)))
+    proposed=(F-Cm.T*C/2).applyfunc(s.expand)
+    res=(Q-proposed).applyfunc(s.expand)
+    fail=[(i,j,str(res[i,j])) for i in range(15) for j in range(15) if res[i,j]!=0]
+
+    assert not fail,fail[:3]
+
+    G=s.zeros(15,4)
+    for A in sets:
+        for a in A:G[idx[A],a]=2*(mon(A)-1)
+    assert (Q*G).applyfunc(s.expand)==s.zeros(15,4)
+    assert (C*G).applyfunc(s.expand)==s.zeros(4,4)
+    assert Q[:,idx[frozenset(range(4))]]==s.zeros(15,1)
+    body=[idx[frozenset(A)] for A in itertools.combinations(range(4),3)]
+    assert Q.extract(body,body)==-s.eye(4)/2
+    assert (Q.extract(body,list(range(15)))+C/2).applyfunc(s.expand)==s.zeros(4,15)
+    wrong_body=(Q-F).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_body)
+    wrong_sign=(Q+proposed).applyfunc(s.expand)
+    assert any(x!=0 for x in wrong_sign)
+    # An identity component phase is a distinct, wrong metric map.
+    # The full signed coefficient comparison is already independent of this construction.
+    wrong_E=[h.copy() for h in E]
+    for h in wrong_E:
+        for a,b in itertools.combinations(range(4),2):h[a,b]=h[b,a]=s.expand(h[a,b]*w[a]*w[b])
+    wrong_gauge=[]
+    for c in range(4):
+        T=sum((wrong_E[i]*G[i,c] for i in range(15)),s.zeros(4))
+        u=s.zeros(4,1);u[c]=w[c]
+        wrong_gauge.append((T-s.I*(p*u.T+u*p.T)).applyfunc(s.expand))
+    assert any(any(x!=0 for x in T) for T in wrong_gauge)
+
+    out={'status':'exact_coefficient_identity_passed','scope':'one fixed 4D unit path triangulation, all nonzero Laurent phases; no physical gravity claim',
+         'local_pairs':pairs,'local_hessian':[[str(Q0[i,j]) for j in range(10)] for i in range(10)],
+         'permutations':24,'matrix_entries':225,'nonzero_geometry_entries':sum(x!=0 for x in Q),
+         'residual_entries':len(fail),'max_laurent_terms':max(len(s.Add.make_args(x)) for x in Q),
+         'checks':['barycentric_normal_sum','local_schlaefli','rational_local_hessian','full_laurent_identity','exact_vertex_gauge','body_constraint_gauge','hyperdiagonal_zero','body_block','body_rows','missing_body_rejected','orientation_reversed_rejected','wrong_metric_phase_rejected'],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out, SimpleNamespace(Q=Q,w=w,z=z,p=p,sets=sets,E=E,C=C,G=G,idx=idx,minus=minus)

--- a/scripts/regge_source_rank_check_2026_09_13.py
+++ b/scripts/regge_source_rank_check_2026_09_13.py
@@ -1,0 +1,100 @@
+"""Exact source identities and separate symmetric-tensor rank checks.
+
+The geometry bundle is passed by the primary runner. Only this source is read
+for an integrity hash; no mutable external scientific data is loaded.
+"""
+from __future__ import annotations
+import json,hashlib,time
+from pathlib import Path
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run(m):
+    started=time.monotonic()
+    Q,w,z,p,sets,E,C,G=m.Q,m.w,m.z,m.p,m.sets,m.E,m.C,m.G
+    zero=lambda A: all(s.cancel(s.expand(x))==0 for x in A)
+    checks=[]
+    def check(name,condition):
+        if not condition:raise AssertionError(name)
+        checks.append(name)
+    static={w[3]:1}; nu=s.Symbol('nu',real=True)
+    qnu=s.Matrix([(int(3 in A)-nu*len(A-{3}))*(1+s.prod(z[a] for a in A)) for A in sets])
+    qnu=qnu.subs(static); Qs=Q.subs(static); Cs=C.subs(static); ps=p.subs(static)
+    Es=[h.subs(static) for h in E]; lap=s.expand(ps.dot(ps))
+    Hnu=sum((Es[i]*qnu[i] for i in range(15)),s.zeros(4))
+    uvec=s.Matrix([-nu*w[0]/2,-nu*w[1]/2,-nu*w[2]/2,s.Rational(1,2)])
+    check('all_phase_exponent_body',zero(Cs*qnu))
+    check('all_phase_exponent_gauge',zero(Hnu-s.diag(-2*nu,-2*nu,-2*nu,2)-s.I*(ps*uvec.T+uvec*ps.T)))
+    T=s.zeros(4); T[3,3]=-nu*lap
+    for a in range(3):
+        for b in range(3):T[a,b]=(1-nu)*(lap*int(a==b)-ps[a]*ps[b])/2
+    J=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in Es])
+    check('geometric_all_phase_exponent_source',zero(Qs*qnu-J))
+    e_tau=s.zeros(15,1);e_tau[m.idx[frozenset((3,))]]=1
+    check('geometric_all_phase_static_poisson',zero(Qs*qnu.subs(nu,1)+lap*e_tau))
+    check('wrong_poisson_sign_rejected',not zero(Qs*qnu.subs(nu,1)-lap*e_tau))
+    check('constant_mode_any_exponent',zero(Qs.subs({x:1 for x in w[:3]})*qnu.subs({x:1 for x in w[:3]})))
+
+    phi=s.Matrix(1,15,lambda a,i:Es[i][3,3]/2)
+    Psp=s.eye(3)-ps[:3,0]*ps[:3,0].T/lap
+    psi=s.Matrix(1,15,lambda a,i:-s.trace(Psp*Es[i][:3,:3])/4)
+    Gs=G.subs(static)
+    check('phi_gauge_annihilation_all_phases',zero(phi*Gs))
+    check('psi_gauge_annihilation_all_phases',zero(psi*Gs))
+    check('phi_endpoint_mean',zero(phi*qnu.subs(nu,1)-s.ones(1)))
+    check('psi_endpoint_mean',zero(psi*qnu.subs(nu,1)-s.ones(1)))
+    check('hyperdiagonal_readout_zero',phi[0,14]==0 and psi[0,14]==0)
+    for a in range(3):
+        check('scalar_seam_periodicity_'+str(a),zero(psi.subs(w[a],-w[a])-psi))
+
+    fixtures=[('origin',[1,1,1,1],4),
+              ('static_axis_nyquist',[s.I,1,1,1],10),
+              ('static_two_components',[s.I,s.Rational(3,5)+s.I*s.Rational(4,5),1,1],10),
+              ('complex_axis_shell',[s.I,1,1,s.sqrt(2)-1],8),
+              ('complex_axis_off_shell',[s.I,1,1,s.Rational(1,2)],10)]
+    ranks=[]
+    for name,values,expected in fixtures:
+        sub=dict(zip(w,values))
+        matrix=Q.subs(sub).applyfunc(s.simplify)
+        rank=matrix.rank()
+        check('exact_rank_'+name,rank==expected)
+        ranks.append({'fixture':name,'rank':rank,'expected':expected})
+
+    # Direct symmetric-matrix operator: no edge map or geometric Hessian used here.
+    def F(v,H):
+        d=(v.T*v)[0];u=H*v;t=s.trace(H)
+        return d*H-v*u.T-u*v.T+(v*v.T)*t+s.eye(4)*((v.T*H*v)[0]-d*t)
+    components=[(a,a) for a in range(4)]+list(__import__('itertools').combinations(range(4),2))
+    basis=[]
+    for a,b in components:
+        h=s.zeros(4);h[a,b]=h[b,a]=1;basis.append(h)
+    for name,v,rank in [('nonnull',s.Matrix([1,2,0,0]),6),('null',s.Matrix([1,0,0,s.I]),4)]:
+        mat=s.Matrix(10,10,lambda i,j:F(v,basis[j])[components[i]])
+        check('direct_fierz_operator_rank_'+name,mat.rank()==rank)
+        for a in range(4):
+            u=s.eye(4)[:,a]
+            check('direct_fierz_gauge_'+name+'_'+str(a),F(v,v*u.T+u*v.T)==s.zeros(4))
+
+    v=s.Matrix([2,0,0,0]);d=4;Pi=s.eye(4)-v*v.T/d
+    T=s.Matrix([[0,0,0,0],[0,1,2,3],[0,2,-1,4],[0,3,4,5]])
+    U=s.Matrix([[0,0,0,0],[0,2,1,-2],[0,1,3,1],[0,-2,1,4]])
+    def sol(A):return -4*(A-Pi*s.trace(A)/2)/d
+    HT,HU=sol(T),sol(U)
+    check('source_inverse_normalization',-F(v,HT)/4==T)
+    check('source_reciprocity',s.trace(U*HT)==s.trace(T*HU))
+    # Verify tensor off-diagonal factor on the actual q-source lift.
+    sub={w[0]:s.I,w[1]:1,w[2]:1,w[3]:1}
+    edgeJ=s.Matrix([s.trace(h.applyfunc(m.minus)*T) for h in E]).subs(sub)
+    wrongT=T.copy()
+    for a in range(4):
+        for b in range(4):
+            if a!=b:wrongT[a,b]/=2
+    wrongJ=s.Matrix([s.trace(h.applyfunc(m.minus)*wrongT) for h in E]).subs(sub)
+    check('missing_offdiagonal_source_factor_rejected',edgeJ!=wrongJ)
+
+    out={'status':'passed','scope':'exact Laurent static identities and finite algebraic rank fixtures; same author, no physical graviton conclusion',
+         'checks':checks,'count':len(checks),'rank_fixtures':ranks,
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+         'elapsed_sec':time.monotonic()-started}
+
+    return out

--- a/scripts/regge_tensor_transfer_check_2026_09_13.py
+++ b/scripts/regge_tensor_transfer_check_2026_09_13.py
@@ -1,0 +1,97 @@
+"""Full mixed constraints, Gaussian transfer and exact polynomial fragments.
+
+Only this source is read for an integrity hash. The transfer calculation does
+not import the geometric checker or use its expected coefficient matrix.
+"""
+from __future__ import annotations
+import json,time,hashlib
+from pathlib import Path
+import sympy as s
+AUDIT_TIMEOUT_SEC = 180
+
+def run():
+    started=time.monotonic();checks=[]
+    def check(name,condition):
+        if not condition:raise AssertionError(name)
+        checks.append(name)
+    r,t=s.symbols('r t',real=True);tau,sigma,a,b1,b2,b3,v1,v2,u,w=s.symbols('tau sigma a b1 b2 b3 v1 v2 u w',real=True)
+    H=s.Matrix([[tau/2+u,w,v1,b1],[w,tau/2-u,v2,b2],[v1,v2,sigma,b3],[b1,b2,b3,a]])
+    p=s.Matrix([0,0,r,t]);D=r*r+t*t
+    F=s.expand(D*s.trace(H*H)-2*(H*p).dot(H*p)+2*s.trace(H)*(p.T*H*p)[0]-D*s.trace(H)**2)
+    Ft=2*D*(u*u+w*w);Fv=2*((t*v1-r*b1)**2+(t*v2-r*b2)**2)
+    Fs=-D*tau*tau/2-2*tau*(r*r*a+t*t*sigma-2*r*t*b3)
+    check('full_mixed_decomposition',s.expand(F-Ft-Fv-Fs)==0)
+    check('lapse_equation',s.diff(F,a)==-2*r*r*tau)
+    check('first_shift_equation',s.expand(s.diff(F,b1)-4*r*(r*b1-t*v1))==0)
+    check('second_shift_equation',s.expand(s.diff(F,b2)-4*r*(r*b2-t*v2))==0)
+    check('remaining_scalar_equation',s.expand(s.diff(F,tau).subs(tau,0)+2*(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    check('wrong_missing_scalar_cross_rejected',s.expand(F-Ft-Fv+D*tau*tau/2)!=0)
+    check('wrong_missing_vector_cross_rejected',s.expand(Fv-2*(t*t*(v1*v1+v2*v2)+r*r*(b1*b1+b2*b2)))!=0)
+    eta=s.Matrix(s.symbols('e0:4'))
+    HG=H+s.I*(p*eta.T+eta*p.T)
+    check('trace_constraint_gauge',s.expand(HG[0,0]+HG[1,1]-tau)==0)
+    check('tensor_gauge',HG[0,1]==w and s.expand((HG[0,0]-HG[1,1])/2-u)==0)
+    for j in (0,1):
+        check('vector_combination_gauge_'+str(j),s.expand(t*HG[j,2]-r*HG[j,3]-(t*H[j,2]-r*H[j,3]))==0)
+    check('scalar_combination_gauge',s.expand(r*r*HG[3,3]+t*t*HG[2,2]-2*r*t*HG[2,3]-(r*r*a+t*t*sigma-2*r*t*b3))==0)
+    # On the constraint surface the explicit gauge choice kills every non-TT entry.
+    HS=H.subs({tau:0,b1:t*v1/r,b2:t*v2/r,a:(2*r*t*b3-t*t*sigma)/(r*r)})
+    g3=-sigma/(2*s.I*r)
+    g0=-(b3+s.I*t*g3)/(s.I*r)
+    g=s.Matrix([-v1/(s.I*r),-v2/(s.I*r),g3,g0])
+    fixed=(HS+s.I*(p*g.T+g*p.T)).applyfunc(s.simplify)
+    check('explicit_full_constraint_gauge_reduction',fixed==s.Matrix([[u,w,0,0],[w,-u,0,0],[0,0,0,0],[0,0,0,0]]))
+
+    z=s.Symbol('z',positive=True);x,beta=s.symbols('x beta',real=True)
+    A=(z+1/z)/2;alpha=(1/z-z)/2
+    check('transfer_width_equation',s.simplify(alpha**2-(A*A-1))==0)
+    check('transfer_generating_quadratic',s.simplify(2*alpha*z-1+z*z)==0)
+    check('transfer_generating_constant',s.simplify(A-z-alpha)==0)
+    # The domain is 0<z<1, hence r=(1-z)/sqrt(z)>0; keep that sign explicitly.
+    r_from_z=(1-z)/s.sqrt(z)
+    check('transfer_trace',s.simplify(s.sqrt(z)/(1-z)-1/r_from_z)==0)
+    # A separate Gaussian-moment recurrence checks seven Hermite eigenfunctions.
+    z0=s.Rational(1,2);alpha0=s.Rational(3,4);A0=s.Rational(5,4)
+    y=s.Symbol('y');mom=[s.S.One,z0*x]
+    for n in range(2,7):mom.append(s.expand(z0*x*mom[-1]+(n-1)*z0*mom[-2]))
+    for n in range(7):
+        poly=s.Poly(s.hermite(n,s.sqrt(alpha0)*y),y)
+        expectation=sum(coef*mom[power[0]] for power,coef in poly.terms())
+        check('hermite_transfer_eigenfunction_'+str(n),s.expand(expectation-z0**n*s.hermite(n,s.sqrt(alpha0)*x))==0)
+    check('continuum_width_substitution_rejected',s.Rational(1,2)!=A0*A0-1)
+
+    phase=s.Symbol('phase',nonzero=True)
+    Csum=(1-z*z)/((1-z*phase)*(1-z/phase))/(2*alpha)
+    check('covariance_fourier_all_phases',s.cancel(Csum-1/((1-z)**2/z+2-phase-1/phase))==0)
+
+    # Exact finite polynomial fragments in the full oscillator's invariant degree range.
+    N=8
+    T=s.diag(*[z0**n for n in range(N)])
+    X=s.zeros(N)
+    for n in range(N-1):X[n,n+1]=X[n+1,n]=s.sqrt(s.Rational(n+1)/(2*alpha0))
+    Omega=s.eye(N)[:,0]
+    vecs=[T*X*Omega,T**2*(X**2-s.eye(N)/(2*alpha0))*Omega,T*X*T*X**2*Omega]
+    V=s.Matrix.hstack(*vecs)
+    check('polynomial_fragments_no_cutoff_contact',V[7,:]==s.zeros(1,3))
+    site=(V.T*V).applyfunc(s.simplify);link=(V.T*T*V).applyfunc(s.simplify)
+    for name,gram in [('site',site),('link',link)]:
+        for order in range(1,4):
+            for inds in __import__('itertools').combinations(range(3),order):
+                check('reflection_'+name+'_'+str(inds),gram.extract(inds,inds).det()>=0)
+    wrong=T.copy();wrong[1,1]=-wrong[1,1]
+    check('negative_transfer_mode_rejected',((X*Omega).T*wrong*(X*Omega))[0]<0)
+    for n in (0,1,2,5):
+        check('exact_vacuum_covariance_'+str(n),(Omega.T*X*T**n*X*Omega)[0]==z0**n/(2*alpha0))
+
+    ps=s.symbols('p0:3',real=True);R2=sum(q*q for q in ps)
+    num=sum(q*q*(1-q*q/4) for q in ps)
+    check('group_velocity_identity',s.expand(num-(R2-sum(q**4 for q in ps)/4))==0)
+    check('group_velocity_axis_nyquist',num.subs({ps[0]:2,ps[1]:0,ps[2]:0})==0)
+
+    out={'status':'passed','scope':'exact constraints, Gaussian spectral algebra and finite polynomial fragments; reduced quantization only',
+         'checks':checks,'count':len(checks),'transfer_fixture':{'z':'1/2','width':'3/4','r_squared':'1/2','hermite_degrees':list(range(7))},
+         'reflection_gram_site':[[str(site[i,j]) for j in range(3)] for i in range(3)],
+         'reflection_gram_link':[[str(link[i,j]) for j in range(3)] for i in range(3)],
+         'source_sha256':hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),'elapsed_sec':time.monotonic()-started}
+
+    return out


### PR DESCRIPTION
The corrected main Regge notes leave the tensor reduction and static source/readout identities supported by finite diagnostics. This source unit derives an exact rational simplex Hessian and its all-momentum reduction, then supplies the conserved-source lift, kernel-invariant static scalar readouts and the complete scalar/vector constraint argument. A directly constructed positive Gaussian transfer gives the two reduced tensor coordinates the same exact dispersion.

The result is bounded conditional-support for the supplied unit 4D path complex and length Regge action. Reduced quantization additionally chooses the action orientation, integer time coordinate, finite odd spatial torus, removed zero spatial mode and a hyperdiagonal section. It does not derive a physical clock or matter source, establish nonlinear gravity, restore the old disproved metric/readout map, or claim priority for linearized Regge gravity. The complete argument is self-contained; the two current-main parents are context and comparison targets.

Author validation: 92 named checks with all 225 Laurent coefficient residuals zero; six actual source mutants rejected; final source/input-bound cache fresh; Python compilation, nine tracked relative links, vocabulary and staged whitespace checks passed. The fresh citation graph adds exactly one node and two intended main-context edges, with all three static helpers attached. The manifest delta and graph-row readiness were checked. Different calculation paths remain same-author evidence.

Independent source review is pending. Full pipeline, strict audit lint and ledger changed-evidence checks remain shared integration gates under SCIENCE_WORKFLOW and conformance section 12. No author merge or scientific audit verdict. Source recovery is campaign commit 4889a58373 on physics-loop/toe-local-formation-20260912; the separate nonlinear campaign is not a dependency of this PR.
